### PR TITLE
feat: default connections from c1 holes to medium size

### DIFF
--- a/lib/wanderer_app/api/map_connection.ex
+++ b/lib/wanderer_app/api/map_connection.ex
@@ -38,7 +38,8 @@ defmodule WandererApp.Api.MapConnection do
       :map_id,
       :solar_system_source,
       :solar_system_target,
-      :type
+      :type,
+      :ship_size_type
     ]
 
     defaults [:create, :read, :update, :destroy]

--- a/lib/wanderer_app/map/server/map_server_connections_impl.ex
+++ b/lib/wanderer_app/map/server/map_server_connections_impl.ex
@@ -69,6 +69,7 @@ defmodule WandererApp.Map.Server.ConnectionsImpl do
   @connection_time_status_eol 1
   @connection_type_wormhole 0
   @connection_type_stargate 1
+  @medium_ship_size 1
 
   def get_connection_auto_expire_hours(), do: WandererApp.Env.map_connection_auto_expire_hours()
 
@@ -351,12 +352,24 @@ defmodule WandererApp.Map.Server.ConnectionsImpl do
               @connection_type_wormhole
           end
 
+        # Check if either system is C1 before creating the connection
+        {:ok, source_system_info} = get_system_static_info(old_location.solar_system_id)
+        {:ok, target_system_info} = get_system_static_info(location.solar_system_id)
+
+        # Set ship size type to medium if either system is C1
+        ship_size_type = if source_system_info.system_class == @c1 or target_system_info.system_class == @c1 do
+          @medium_ship_size
+        else
+          2  # Default to large
+        end
+
         {:ok, connection} =
           WandererApp.MapConnectionRepo.create(%{
             map_id: map_id,
             solar_system_source: old_location.solar_system_id,
             solar_system_target: location.solar_system_id,
-            type: connection_type
+            type: connection_type,
+            ship_size_type: ship_size_type
           })
 
         if connection_type == @connection_type_wormhole do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Wormhole connections involving C1 class systems now automatically assign a medium ship size type.
	- The ship size type attribute is now supported and managed across connection creation, reading, updating, and deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->