### PR TITLE
fix: ensure pub/sub occurs after acl api change

### DIFF
--- a/lib/wanderer_app_web/controllers/access_list_member_api_controller.ex
+++ b/lib/wanderer_app_web/controllers/access_list_member_api_controller.ex
@@ -395,12 +395,7 @@ defmodule WandererAppWeb.AccessListMemberAPIController do
                    :acl_member_removed
                  ) do
               :ok ->
-                # Also broadcast internal PubSub message for map servers
-                Phoenix.PubSub.broadcast(
-                  WandererApp.PubSub,
-                  "acls:#{acl_id}",
-                  {:acl_updated, %{acl_id: acl_id}}
-                )
+                broadcast_acl_updated(acl_id)
 
                 json(conn, %{ok: true})
 
@@ -410,11 +405,7 @@ defmodule WandererAppWeb.AccessListMemberAPIController do
                 )
 
                 # Still broadcast internal message even if external broadcast fails
-                Phoenix.PubSub.broadcast(
-                  WandererApp.PubSub,
-                  "acls:#{acl_id}",
-                  {:acl_updated, %{acl_id: acl_id}}
-                )
+                broadcast_acl_updated(acl_id)
 
                 json(conn, %{ok: true})
             end

--- a/lib/wanderer_app_web/controllers/access_list_member_api_controller.ex
+++ b/lib/wanderer_app_web/controllers/access_list_member_api_controller.ex
@@ -192,11 +192,25 @@ defmodule WandererAppWeb.AccessListMemberAPIController do
                      :acl_member_added
                    ) do
                 :ok ->
+                  # Also broadcast internal PubSub message for map servers
+                  Phoenix.PubSub.broadcast(
+                    WandererApp.PubSub,
+                    "acls:#{acl_id}",
+                    {:acl_updated, %{acl_id: acl_id}}
+                  )
+
                   json(conn, %{data: member_to_json(new_member)})
 
                 {:error, broadcast_error} ->
                   Logger.warning(
                     "Failed to broadcast ACL member added event: #{inspect(broadcast_error)}"
+                  )
+
+                  # Still broadcast internal message even if external broadcast fails
+                  Phoenix.PubSub.broadcast(
+                    WandererApp.PubSub,
+                    "acls:#{acl_id}",
+                    {:acl_updated, %{acl_id: acl_id}}
                   )
 
                   json(conn, %{data: member_to_json(new_member)})
@@ -300,11 +314,25 @@ defmodule WandererAppWeb.AccessListMemberAPIController do
                      :acl_member_updated
                    ) do
                 :ok ->
+                  # Also broadcast internal PubSub message for map servers
+                  Phoenix.PubSub.broadcast(
+                    WandererApp.PubSub,
+                    "acls:#{acl_id}",
+                    {:acl_updated, %{acl_id: acl_id}}
+                  )
+
                   json(conn, %{data: member_to_json(updated_membership)})
 
                 {:error, broadcast_error} ->
                   Logger.warning(
                     "Failed to broadcast ACL member updated event: #{inspect(broadcast_error)}"
+                  )
+
+                  # Still broadcast internal message even if external broadcast fails
+                  Phoenix.PubSub.broadcast(
+                    WandererApp.PubSub,
+                    "acls:#{acl_id}",
+                    {:acl_updated, %{acl_id: acl_id}}
                   )
 
                   json(conn, %{data: member_to_json(updated_membership)})
@@ -385,11 +413,25 @@ defmodule WandererAppWeb.AccessListMemberAPIController do
                    :acl_member_removed
                  ) do
               :ok ->
+                # Also broadcast internal PubSub message for map servers
+                Phoenix.PubSub.broadcast(
+                  WandererApp.PubSub,
+                  "acls:#{acl_id}",
+                  {:acl_updated, %{acl_id: acl_id}}
+                )
+
                 json(conn, %{ok: true})
 
               {:error, broadcast_error} ->
                 Logger.warning(
                   "Failed to broadcast ACL member removed event: #{inspect(broadcast_error)}"
+                )
+
+                # Still broadcast internal message even if external broadcast fails
+                Phoenix.PubSub.broadcast(
+                  WandererApp.PubSub,
+                  "acls:#{acl_id}",
+                  {:acl_updated, %{acl_id: acl_id}}
                 )
 
                 json(conn, %{ok: true})

--- a/lib/wanderer_app_web/controllers/access_list_member_api_controller.ex
+++ b/lib/wanderer_app_web/controllers/access_list_member_api_controller.ex
@@ -192,12 +192,7 @@ defmodule WandererAppWeb.AccessListMemberAPIController do
                      :acl_member_added
                    ) do
                 :ok ->
-                  # Also broadcast internal PubSub message for map servers
-                  Phoenix.PubSub.broadcast(
-                    WandererApp.PubSub,
-                    "acls:#{acl_id}",
-                    {:acl_updated, %{acl_id: acl_id}}
-                  )
+                  broadcast_acl_updated(acl_id)
 
                   json(conn, %{data: member_to_json(new_member)})
 
@@ -207,11 +202,7 @@ defmodule WandererAppWeb.AccessListMemberAPIController do
                   )
 
                   # Still broadcast internal message even if external broadcast fails
-                  Phoenix.PubSub.broadcast(
-                    WandererApp.PubSub,
-                    "acls:#{acl_id}",
-                    {:acl_updated, %{acl_id: acl_id}}
-                  )
+                  broadcast_acl_updated(acl_id)
 
                   json(conn, %{data: member_to_json(new_member)})
               end
@@ -314,12 +305,7 @@ defmodule WandererAppWeb.AccessListMemberAPIController do
                      :acl_member_updated
                    ) do
                 :ok ->
-                  # Also broadcast internal PubSub message for map servers
-                  Phoenix.PubSub.broadcast(
-                    WandererApp.PubSub,
-                    "acls:#{acl_id}",
-                    {:acl_updated, %{acl_id: acl_id}}
-                  )
+                  broadcast_acl_updated(acl_id)
 
                   json(conn, %{data: member_to_json(updated_membership)})
 
@@ -329,11 +315,7 @@ defmodule WandererAppWeb.AccessListMemberAPIController do
                   )
 
                   # Still broadcast internal message even if external broadcast fails
-                  Phoenix.PubSub.broadcast(
-                    WandererApp.PubSub,
-                    "acls:#{acl_id}",
-                    {:acl_updated, %{acl_id: acl_id}}
-                  )
+                  broadcast_acl_updated(acl_id)
 
                   json(conn, %{data: member_to_json(updated_membership)})
               end
@@ -458,6 +440,14 @@ defmodule WandererAppWeb.AccessListMemberAPIController do
   # ---------------------------------------------------------------------------
   # Private Helpers
   # ---------------------------------------------------------------------------
+
+  defp broadcast_acl_updated(acl_id) do
+    Phoenix.PubSub.broadcast(
+      WandererApp.PubSub,
+      "acls:#{acl_id}",
+      {:acl_updated, %{acl_id: acl_id}}
+    )
+  end
 
   @doc false
   defp member_to_json(member) do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Internal real-time notifications for access-list member changes (create, role update, delete) to improve propagation.

* **Bug Fixes / Improvements**
  * Prevents duplicate access entries by deduplicating ACL additions.
  * Map-update broadcasts are now sent only when a new ACL is actually added, reducing redundant notifications.
* **Chores**
  * No public API or external responses changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->