### PR TITLE
fix: removed wormhole only logic error

### DIFF
--- a/assets/js/hooks/Mapper/components/mapInterface/widgets/WSystemKills/WSystemKills.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/widgets/WSystemKills/WSystemKills.tsx
@@ -44,10 +44,7 @@ const SystemKillsContent = () => {
 
   const filteredKills = useMemo(() => {
     if (!settingsKills.whOnly) return kills;
-
-    const wormholeKills = kills.filter(kill => isWormholeSystem(Number(kill.solar_system_id)));
-
-    return wormholeKills;
+    return kills.filter(kill => isWormholeSystem(Number(kill.solar_system_id)));
   }, [kills, settingsKills.whOnly, isWormholeSystem]);
 
   if (!isSubscriptionActive) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Wormhole-only filter now evaluates each kill on demand, ensuring only wormhole-space kills are shown.
  - “Show all” no longer bypasses wormhole-only filtering, preventing unintended results.
  - Kills with missing system info are quietly excluded (no noisy warnings).

- Refactor
  - Per-system wormhole classification is memoized and cached for faster, more responsive filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->