### PR TITLE
feat: add support for 1 hour eol

### DIFF
--- a/assets/js/hooks/Mapper/components/map/components/ContextMenuConnection/ContextMenuConnection.module.scss
+++ b/assets/js/hooks/Mapper/components/map/components/ContextMenuConnection/ContextMenuConnection.module.scss
@@ -1,7 +1,7 @@
 @use '@/hooks/Mapper/components/map/styles/eve-common-variables';
 
 .ConnectionTimeEOL {
-  background-image: linear-gradient(207deg, transparent, var(--conn-time-eol));
+  background-image: linear-gradient(207deg, transparent, var(--conn-time-eol-4hr));
 }
 
 .ConnectionFrigate {

--- a/assets/js/hooks/Mapper/components/map/components/ContextMenuConnection/ContextMenuConnection.tsx
+++ b/assets/js/hooks/Mapper/components/map/components/ContextMenuConnection/ContextMenuConnection.tsx
@@ -18,7 +18,7 @@ import { Edge } from 'reactflow';
 export interface ContextMenuConnectionProps {
   contextMenuRef: RefObject<ContextMenu>;
   onDeleteConnection(): void;
-  onChangeTimeState(): void;
+  onChangeTimeState(status?: TimeStatus): void;
   onChangeMassState(state: MassState): void;
   onChangeShipSizeStatus(state: ShipSizeStatus): void;
   onToggleMassSave(isLocked: boolean): void;
@@ -50,10 +50,32 @@ export const ContextMenuConnection: React.FC<ContextMenuConnectionProps> = ({
             {
               label: `EOL`,
               className: clsx({
-                [classes.ConnectionTimeEOL]: edge.data?.time_status === TimeStatus.eol,
+                [classes.ConnectionTimeEOL]:
+                  edge.data?.time_status === TimeStatus.eol_4hr || edge.data?.time_status === TimeStatus.eol_1hr,
               }),
               icon: PrimeIcons.CLOCK,
-              command: onChangeTimeState,
+              items: [
+                {
+                  label: '< 4 hours',
+                  className: clsx({
+                    [classes.SelectedItem]: edge.data?.time_status === TimeStatus.eol_4hr,
+                  }),
+                  command: () =>
+                    onChangeTimeState(
+                      edge.data?.time_status === TimeStatus.eol_4hr ? TimeStatus.default : TimeStatus.eol_4hr,
+                    ),
+                },
+                {
+                  label: '< 1 hour',
+                  className: clsx({
+                    [classes.SelectedItem]: edge.data?.time_status === TimeStatus.eol_1hr,
+                  }),
+                  command: () =>
+                    onChangeTimeState(
+                      edge.data?.time_status === TimeStatus.eol_1hr ? TimeStatus.default : TimeStatus.eol_1hr,
+                    ),
+                },
+              ],
             },
             {
               label: `Frigate`,

--- a/assets/js/hooks/Mapper/components/map/components/ContextMenuConnection/useContextMenuConnectionHandlers.ts
+++ b/assets/js/hooks/Mapper/components/map/components/ContextMenuConnection/useContextMenuConnectionHandlers.ts
@@ -30,9 +30,15 @@ export const useContextMenuConnectionHandlers = () => {
     setEdge(undefined);
   };
 
-  const onChangeTimeState = () => {
+  const onChangeTimeState = (status?: TimeStatus) => {
     if (!edge || !edge.data) {
       return;
+    }
+
+    // Use provided status, or toggle between default and eol_4hr for backwards compatibility
+    let newStatus = status;
+    if (newStatus === undefined) {
+      newStatus = edge.data.time_status === TimeStatus.default ? TimeStatus.eol_4hr : TimeStatus.default;
     }
 
     outCommand({
@@ -40,7 +46,7 @@ export const useContextMenuConnectionHandlers = () => {
       data: {
         source: edge.source,
         target: edge.target,
-        value: edge.data.time_status === TimeStatus.default ? TimeStatus.eol : TimeStatus.default,
+        value: newStatus,
       },
     });
     setEdge(undefined);

--- a/assets/js/hooks/Mapper/components/map/components/SolarSystemEdge/SolarSystemEdge.module.scss
+++ b/assets/js/hooks/Mapper/components/map/components/SolarSystemEdge/SolarSystemEdge.module.scss
@@ -5,24 +5,37 @@
   stroke: #80a5c5;
   stroke-width: 3px;
 
-  &.TimeCrit {
-    stroke: #f11ab2;
+  &.TimeEol4hr {
+    stroke: var(--conn-time-eol-4hr);
     stroke-width: 4px;
+  }
+
+  &.TimeEol1hr {
+    stroke: var(--conn-time-eol-1hr);
+    stroke-width: 5px;
   }
 
   &.Hovered {
     stroke: #b5c8d9;
 
-    &.TimeCrit {
-      stroke: #ef7dce;
+    &.TimeEol4hr {
+      stroke: #9d7ce3;
+    }
+
+    &.TimeEol1hr {
+      stroke: #ff7777;
     }
   }
 
   &.Tick {
     stroke-width: 5px;
 
-    &.TimeCrit {
+    &.TimeEol4hr {
       stroke-width: 6px;
+    }
+
+    &.TimeEol1hr {
+      stroke-width: 7px;
     }
   }
 

--- a/assets/js/hooks/Mapper/components/map/components/SolarSystemEdge/SolarSystemEdge.tsx
+++ b/assets/js/hooks/Mapper/components/map/components/SolarSystemEdge/SolarSystemEdge.tsx
@@ -79,7 +79,8 @@ export const SolarSystemEdge = ({ id, source, target, markerEnd, style, data }: 
         id={`back_${id}`}
         className={clsx(classes.EdgePathBack, {
           [classes.Tick]: isThickConnections,
-          [classes.TimeCrit]: isWormhole && data.time_status === TimeStatus.eol,
+          [classes.TimeEol4hr]: isWormhole && data.time_status === TimeStatus.eol_4hr,
+          [classes.TimeEol1hr]: isWormhole && data.time_status === TimeStatus.eol_1hr,
           [classes.Hovered]: hovered,
           [classes.Gate]: !isWormhole,
         })}

--- a/assets/js/hooks/Mapper/components/map/styles/eve-common-variables.scss
+++ b/assets/js/hooks/Mapper/components/map/styles/eve-common-variables.scss
@@ -116,7 +116,8 @@ $homeDark30: color.adjust($homeBase, $lightness: -30%);
   --eve-solar-system-status-dangerous: #d54040;
   --eve-solar-system-status-color-dangerous: #d54040;
 
-  --conn-time-eol: #7452c3e3;
+  --conn-time-eol-4hr: #7452c3e3;
+  --conn-time-eol-1hr: #ff4444e3;
   --conn-frigate: #325d88;
   --conn-save: rgba(155, 102, 45, 0.85);
   --selected-item-bg: rgba(98, 98, 98, 0.33);

--- a/assets/js/hooks/Mapper/types/connection.ts
+++ b/assets/js/hooks/Mapper/types/connection.ts
@@ -10,8 +10,9 @@ export enum MassState {
 }
 
 export enum TimeStatus {
-  default,
-  eol,
+  default = 0,
+  eol_4hr = 1,
+  eol_1hr = 2,
 }
 
 export enum ShipSizeStatus {

--- a/lib/wanderer_app_web/live/access_lists/access_lists_live.html.heex
+++ b/lib/wanderer_app_web/live/access_lists/access_lists_live.html.heex
@@ -34,7 +34,11 @@
           </button>
         </:action>
       </.table>
-      <.link :if={@allow_acl_creation} class="btn mt-2 w-full btn-neutral rounded-none" patch={~p"/access-lists/new"}>
+      <.link
+        :if={@allow_acl_creation}
+        class="btn mt-2 w-full btn-neutral rounded-none"
+        patch={~p"/access-lists/new"}
+      >
         <.icon name="hero-plus-solid" class="w-6 h-6" />
         <h3 class="card-title text-center text-md">New Access List</h3>
       </.link>
@@ -142,10 +146,10 @@
       placeholder="Select an owner"
       options={Enum.map(@characters, fn character -> {character.label, character.id} end)}
     />
-
+    
 <!-- Divider between above inputs and the API key section -->
     <hr class="my-4 border-gray-600" />
-
+    
 <!-- API Key Section with grid layout -->
     <div class="mt-2">
       <label class="block text-sm font-medium text-gray-200 mb-1">ACL API key</label>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Connection context menu now offers EOL options: “< 4 hours” and “< 1 hour.”
  - Map edges and expiration behavior now distinguish 4‑hour vs 1‑hour EOL states for clearer status and timed expiry.

- Style
  - Updated EOL colors, gradient, and stroke widths with distinct hover/pulse visuals for 4‑hour and 1‑hour states.

- Chores
  - Minor layout/whitespace cleanup in Access Lists UI (no functional changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->