### PR TITLE
feat: share intel between maps

### DIFF
--- a/assets/js/hooks/Mapper/components/contexts/ContextMenuSystem/useContextMenuSystemItems.tsx
+++ b/assets/js/hooks/Mapper/components/contexts/ContextMenuSystem/useContextMenuSystemItems.tsx
@@ -49,8 +49,10 @@ export const useContextMenuSystemItems = ({
   const getUserRoutes = useUserRoute({ userHubs, systemId, onUserHubToggle });
 
   const {
-    data: { pings, isSubscriptionActive },
+    data: { pings, isSubscriptionActive, options: mapOptions },
   } = useMapRootState();
+
+  const hasIntelSource = !!mapOptions?.intel_source_map_id;
 
   const ping = useMemo(() => (pings.length === 1 ? pings[0] : undefined), [pings]);
   const isShowPingBtn = useMemo(() => {
@@ -92,9 +94,9 @@ export const useContextMenuSystemItems = ({
         },
       },
       { separator: true },
-      getTags(),
-      getStatus(),
-      ...getLabels(),
+      { ...getTags(), disabled: hasIntelSource },
+      { ...getStatus(), disabled: hasIntelSource },
+      ...getLabels().map(item => ({ ...item, disabled: hasIntelSource || item.disabled })),
       ...getWaypointMenu(systemId, systemStaticInfo.system_class),
       {
         label: !hubs.includes(systemId) ? 'Add Route' : 'Remove Route',
@@ -200,5 +202,6 @@ export const useContextMenuSystemItems = ({
     onTogglePing,
     ping,
     isShowPingBtn,
+    hasIntelSource,
   ]);
 };

--- a/assets/js/hooks/Mapper/components/map/components/SolarSystemNode/SolarSystemNodeDefault.tsx
+++ b/assets/js/hooks/Mapper/components/map/components/SolarSystemNode/SolarSystemNodeDefault.tsx
@@ -18,6 +18,7 @@ import { Tag } from 'primereact/tag';
 import { LocalCounter } from '@/hooks/Mapper/components/map/components/LocalCounter';
 import { KillsCounter } from '@/hooks/Mapper/components/map/components/KillsCounter';
 import { useLocalCounter } from '@/hooks/Mapper/components/hooks/useLocalCounter.ts';
+import { SyncIntelAction } from '@/hooks/Mapper/components/map/components/SyncIntelAction';
 
 // let render = 0;
 export const SolarSystemNodeDefault = memo((props: NodeProps<MapSolarSystemType>) => {
@@ -160,6 +161,9 @@ export const SolarSystemNodeDefault = memo((props: NodeProps<MapSolarSystemType>
                         )}
                       />
                     </WdTooltipWrapper>
+                  )}
+                  {nodeVars.hasIntelSource && (
+                    <SyncIntelAction solarSystemId={nodeVars.solarSystemId} />
                   )}
                 </div>
 

--- a/assets/js/hooks/Mapper/components/map/components/SolarSystemNode/SolarSystemNodeTheme.tsx
+++ b/assets/js/hooks/Mapper/components/map/components/SolarSystemNode/SolarSystemNodeTheme.tsx
@@ -17,6 +17,7 @@ import { TooltipSize } from '@/hooks/Mapper/components/ui-kit/WdTooltipWrapper/u
 import { LocalCounter } from '@/hooks/Mapper/components/map/components/LocalCounter';
 import { KillsCounter } from '@/hooks/Mapper/components/map/components/KillsCounter';
 import { useLocalCounter } from '@/hooks/Mapper/components/hooks/useLocalCounter.ts';
+import { SyncIntelAction } from '@/hooks/Mapper/components/map/components/SyncIntelAction';
 
 // let render = 0;
 export const SolarSystemNodeTheme = memo((props: NodeProps<MapSolarSystemType>) => {
@@ -140,6 +141,9 @@ export const SolarSystemNodeTheme = memo((props: NodeProps<MapSolarSystemType>) 
                   {nodeVars.locked && <i className={clsx(PrimeIcons.LOCK, classes.lockIcon)} />}
                   {nodeVars.hubs.includes(nodeVars.solarSystemId) && (
                     <i className={clsx(PrimeIcons.MAP_MARKER, classes.mapMarker)} />
+                  )}
+                  {nodeVars.hasIntelSource && (
+                    <SyncIntelAction solarSystemId={nodeVars.solarSystemId} />
                   )}
                 </div>
 

--- a/assets/js/hooks/Mapper/components/map/components/SyncIntelAction.tsx
+++ b/assets/js/hooks/Mapper/components/map/components/SyncIntelAction.tsx
@@ -1,0 +1,36 @@
+import clsx from 'clsx';
+import { TooltipPosition, WdTooltipWrapper } from '@/hooks/Mapper/components/ui-kit';
+import { OutCommand } from '@/hooks/Mapper/types';
+import { useMapState } from '@/hooks/Mapper/components/map/MapProvider';
+
+interface SyncIntelActionProps {
+  solarSystemId: string;
+}
+
+export const SyncIntelAction = ({ solarSystemId }: SyncIntelActionProps) => {
+  const { outCommand } = useMapState();
+
+  return (
+    <WdTooltipWrapper
+      className="h-[15px] transform -translate-y-[6%]"
+      position={TooltipPosition.top}
+      content="Sync intel from source"
+    >
+      <button
+        type="button"
+        aria-label="Sync intel from source"
+        className={clsx(
+          'pi pi-sync',
+          'text-[8px] cursor-pointer text-blue-400 hover:text-blue-200',
+        )}
+        onClick={(e) => {
+          e.stopPropagation();
+          outCommand({
+            type: OutCommand.syncIntel,
+            data: { solar_system_id: solarSystemId },
+          });
+        }}
+      />
+    </WdTooltipWrapper>
+  );
+};

--- a/assets/js/hooks/Mapper/components/map/hooks/useSolarSystemNode.ts
+++ b/assets/js/hooks/Mapper/components/map/hooks/useSolarSystemNode.ts
@@ -53,6 +53,7 @@ export interface SolarSystemNodeVars {
   description: string | null;
   comments_count: number | null;
   systemHighlighted: string | undefined;
+  hasIntelSource: boolean;
 }
 
 export const useSolarSystemNode = (props: NodeProps<MapSolarSystemType>): SolarSystemNodeVars => {
@@ -72,7 +73,7 @@ export const useSolarSystemNode = (props: NodeProps<MapSolarSystemType>): SolarS
 
   const {
     storedSettings: { interfaceSettings },
-    data: { systemSignatures: mapSystemSignatures, pings },
+    data: { systemSignatures: mapSystemSignatures, pings, options: mapOptions },
   } = useMapRootState();
 
   const systemStaticInfo = useMemo(() => {
@@ -219,6 +220,7 @@ export const useSolarSystemNode = (props: NodeProps<MapSolarSystemType>): SolarS
     description,
     comments_count,
     systemHighlighted,
+    hasIntelSource: !!mapOptions?.intel_source_map_id,
   };
 
   return nodeVars;

--- a/assets/js/hooks/Mapper/components/mapInterface/components/Comments/Comments.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/components/Comments/Comments.tsx
@@ -39,15 +39,15 @@ export const Comments = ({}: CommentsProps) => {
   if (commentsList.length === 0) {
     return (
       <div className="w-full h-full flex justify-center items-center select-none text-stone-400/80 text-sm">
-        Not comments found here
+        No comments found here
       </div>
     );
   }
 
   return (
     <div className="flex flex-col gap-1 whitespace-nowrap overflow-auto text-ellipsis custom-scrollbar">
-      {commentsList.map(({ id, text, updated_at, characterEveId }) => (
-        <MarkdownComment key={id} text={text} time={updated_at} characterEveId={characterEveId} id={id} />
+      {commentsList.map(({ id, text, updated_at, characterEveId, inherited_from_map_id }) => (
+        <MarkdownComment key={id} text={text} time={updated_at} characterEveId={characterEveId} id={id} inherited={!!inherited_from_map_id} />
       ))}
     </div>
   );

--- a/assets/js/hooks/Mapper/components/mapInterface/components/Comments/components/MarkdownComment/MarkdownComment.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/components/Comments/components/MarkdownComment/MarkdownComment.tsx
@@ -22,9 +22,10 @@ export interface MarkdownCommentProps {
   time: string;
   characterEveId: string;
   id: string;
+  inherited?: boolean;
 }
 
-export const MarkdownComment = ({ text, time, characterEveId, id }: MarkdownCommentProps) => {
+export const MarkdownComment = ({ text, time, characterEveId, id, inherited }: MarkdownCommentProps) => {
   const char = useGetCacheCharacter(characterEveId);
   const [hovered, setHovered] = useState(false);
 
@@ -57,16 +58,18 @@ export const MarkdownComment = ({ text, time, characterEveId, id }: MarkdownComm
         onMouseLeave={handleMouseLeave}
         title={
           <div className="flex items-center justify-between">
-            <div>
+            <div className="flex items-center gap-1">
               <span className="text-stone-500">
                 by <span className="text-orange-300/70">{char?.data?.name ?? ''}</span>
               </span>
+              {inherited && (
+                <span className="text-[9px] text-blue-400/70 bg-blue-900/30 px-1 rounded">inherited</span>
+              )}
             </div>
 
             <WdTransition active={hovered} timeout={100}>
               <div className="text-stone-500 max-h-[12px]">
-                {!hovered && <TimeAgo timestamp={time} />}
-                {hovered && (
+                {hovered && !inherited ? (
                   // @ts-ignore
                   <div ref={cfRef}>
                     <WdImgButton
@@ -75,6 +78,8 @@ export const MarkdownComment = ({ text, time, characterEveId, id }: MarkdownComm
                       onClick={cfShow}
                     />
                   </div>
+                ) : (
+                  <TimeAgo timestamp={time} />
                 )}
               </div>
             </WdTransition>
@@ -84,14 +89,16 @@ export const MarkdownComment = ({ text, time, characterEveId, id }: MarkdownComm
         <MarkdownTextViewer>{text}</MarkdownTextViewer>
       </InfoDrawer>
 
-      <ConfirmPopup
-        target={cfRef.current}
-        visible={cfVisible}
-        onHide={cfHide}
-        message="Are you sure you want to delete?"
-        icon="pi pi-exclamation-triangle"
-        accept={handleDelete}
-      />
+      {!inherited && (
+        <ConfirmPopup
+          target={cfRef.current}
+          visible={cfVisible}
+          onHide={cfHide}
+          message="Are you sure you want to delete?"
+          icon="pi pi-exclamation-triangle"
+          accept={handleDelete}
+        />
+      )}
     </>
   );
 };

--- a/assets/js/hooks/Mapper/components/mapInterface/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/components/MarkdownEditor/MarkdownEditor.tsx
@@ -46,6 +46,7 @@ export interface MarkdownEditorProps {
   onChange: (value: string) => void;
   height?: string;
   className?: string;
+  readOnly?: boolean;
 }
 
 export const MarkdownEditor = ({
@@ -54,6 +55,7 @@ export const MarkdownEditor = ({
   overlayContent,
   height = '70px',
   className,
+  readOnly = false,
 }: MarkdownEditorProps) => {
   const [hasShift, setHasShift] = useState(false);
 
@@ -71,7 +73,7 @@ export const MarkdownEditor = ({
   }, []);
 
   return (
-    <div className={clsx(classes.MarkdownEditor, 'relative')}>
+    <div className={clsx(classes.MarkdownEditor, 'relative', { 'opacity-50': readOnly })}>
       <CodeMirror
         value={value}
         height={height}
@@ -80,6 +82,8 @@ export const MarkdownEditor = ({
         theme={oneDark}
         onChange={handleOnChange}
         placeholder="Start typing..."
+        readOnly={readOnly}
+        editable={!readOnly}
       />
       <div
         className={clsx('absolute top-0 left-0 h-full pointer-events-none', {

--- a/assets/js/hooks/Mapper/components/mapInterface/components/SystemSettingsDialog/SystemSettingsDialog.tsx
+++ b/assets/js/hooks/Mapper/components/mapInterface/components/SystemSettingsDialog/SystemSettingsDialog.tsx
@@ -19,11 +19,12 @@ interface SystemSettingsDialog {
 
 export const SystemSettingsDialog = ({ systemId, visible, setVisible }: SystemSettingsDialog) => {
   const {
-    data: { systems },
+    data: { systems, options: mapOptions },
     outCommand,
   } = useMapRootState();
 
   const isTempSystemNameEnabled = useMapGetOption('show_temp_system_name') === 'true';
+  const hasIntelSource = !!mapOptions?.intel_source_map_id;
 
   const system = getSystemById(systems, systemId);
   const systemStaticInfo = getSystemStaticInfo(systemId);
@@ -37,7 +38,8 @@ export const SystemSettingsDialog = ({ systemId, visible, setVisible }: SystemSe
   const ref = useRef({ name, description, temporaryName, label, outCommand, systemId, system, systemStaticInfo });
   ref.current = { name, description, label, temporaryName, outCommand, systemId, system, systemStaticInfo };
 
-  const handleSave = useCallback(() => {
+  const handleSave = useCallback((e?: React.FormEvent) => {
+    if (e) e.preventDefault();
     const { name, description, label, temporaryName, outCommand, systemId, system, systemStaticInfo } = ref.current;
 
     const outLabel = new LabelsManager(system?.labels ?? '');
@@ -124,14 +126,20 @@ export const SystemSettingsDialog = ({ systemId, visible, setVisible }: SystemSe
         setVisible(false);
       }}
     >
-      <form onSubmit={handleSave}>
+      <form onSubmit={handleSave} action="#">
         <div className="flex flex-col gap-3 px-2">
+          {hasIntelSource && (
+            <div className="text-stone-400 text-[11px] bg-blue-900/20 border border-blue-500/30 rounded px-2 py-1">
+              <i className="pi pi-info-circle mr-1" />
+              These fields are managed by the intel source map and cannot be edited here.
+            </div>
+          )}
           <div className="flex flex-col gap-2">
             <div className="flex flex-col gap-1">
               <label htmlFor="username">Custom name</label>
 
               <IconField>
-                {name !== systemStaticInfo?.solar_system_name && (
+                {!hasIntelSource && name !== systemStaticInfo?.solar_system_name && (
                   <WdImgButton
                     className="pi pi-undo"
                     textSize={WdImageSize.large}
@@ -148,6 +156,7 @@ export const SystemSettingsDialog = ({ systemId, visible, setVisible }: SystemSe
                   aria-describedby="name"
                   autoComplete="off"
                   value={name}
+                  disabled={hasIntelSource}
                   // @ts-expect-error
                   ref={inputRef}
                   onChange={e => setName(e.target.value)}
@@ -159,7 +168,7 @@ export const SystemSettingsDialog = ({ systemId, visible, setVisible }: SystemSe
               <label htmlFor="label">Custom label</label>
 
               <IconField>
-                {label !== '' && (
+                {!hasIntelSource && label !== '' && (
                   <WdImgButton
                     className="pi pi-trash text-red-400"
                     textSize={WdImageSize.large}
@@ -177,6 +186,7 @@ export const SystemSettingsDialog = ({ systemId, visible, setVisible }: SystemSe
                   autoComplete="off"
                   value={label}
                   maxLength={5}
+                  disabled={hasIntelSource}
                   onChange={e => setLabel(e.target.value)}
                   onInput={handleInput}
                 />
@@ -188,7 +198,7 @@ export const SystemSettingsDialog = ({ systemId, visible, setVisible }: SystemSe
                 <label htmlFor="username">Temporary Name</label>
 
                 <IconField>
-                  {temporaryName !== '' && (
+                  {!hasIntelSource && temporaryName !== '' && (
                     <WdImgButton
                       className="pi pi-trash text-red-400"
                       textSize={WdImageSize.large}
@@ -206,6 +216,7 @@ export const SystemSettingsDialog = ({ systemId, visible, setVisible }: SystemSe
                     autoComplete="off"
                     value={temporaryName}
                     maxLength={12}
+                    disabled={hasIntelSource}
                     onChange={e => setTemporaryName(e.target.value)}
                   />
                 </IconField>
@@ -215,13 +226,13 @@ export const SystemSettingsDialog = ({ systemId, visible, setVisible }: SystemSe
             <div className="flex flex-col gap-1">
               <label htmlFor="username">Description</label>
               <div className="h-[200px]">
-                <MarkdownEditor value={description} onChange={e => setDescription(e)} height="180px" />
+                <MarkdownEditor value={description} onChange={e => setDescription(e)} height="180px" readOnly={hasIntelSource} />
               </div>
             </div>
           </div>
 
           <div className="flex gap-2 justify-end">
-            <WdButton onClick={handleSave} outlined size="small" label="Save" type="submit" />
+            <WdButton onClick={handleSave} outlined size="small" label="Save" type="submit" disabled={hasIntelSource} />
           </div>
         </div>
       </form>

--- a/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemStructures/helpers/structureTypes.ts
+++ b/assets/js/hooks/Mapper/components/mapInterface/widgets/SystemStructures/helpers/structureTypes.ts
@@ -12,6 +12,7 @@ export interface StructureItem {
   notes?: string;
   status: StructureStatus;
   endTime?: string;
+  inherited_from_map_id?: string | null;
 }
 
 export const STRUCTURE_TYPE_MAP: Record<string, string> = {

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/MapSettings.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/MapSettings.tsx
@@ -15,6 +15,7 @@ import { SettingsListItem } from './types.ts';
 import { ImportExport } from './components/ImportExport.tsx';
 import { ServerSettings } from './components/ServerSettings.tsx';
 import { AdminSettings } from './components/AdminSettings.tsx';
+import { IntelSettings } from './components/IntelSettings.tsx';
 import { useMapCheckPermissions } from '@/hooks/Mapper/mapRootProvider/hooks/api';
 
 export interface MapSettingsProps {
@@ -24,10 +25,16 @@ export interface MapSettingsProps {
 
 export const MapSettingsComp = ({ visible, onHide }: MapSettingsProps) => {
   const [activeIndex, setActiveIndex] = useState(0);
-  const { outCommand } = useMapRootState();
+  const {
+    outCommand,
+    data: { clientEnv },
+  } = useMapRootState();
 
   const { renderSettingItem, setUserRemoteSettings } = useMapSettings();
   const isAdmin = useMapCheckPermissions([UserPermission.ADMIN_MAP]);
+  const isManager = useMapCheckPermissions([UserPermission.MANAGE_MAP]);
+
+  const intelSharingEnabled = clientEnv?.intelSharingEnabled ?? false;
 
   const refVars = useRef({ outCommand, onHide, visible });
   refVars.current = { outCommand, onHide, visible };
@@ -100,6 +107,12 @@ export const MapSettingsComp = ({ visible, onHide }: MapSettingsProps) => {
             <TabPanel header="Server Settings" className="h-full" headerClassName="color-warn">
               <ServerSettings />
             </TabPanel>
+
+            {(isManager || isAdmin) && intelSharingEnabled && (
+              <TabPanel header="Intel Source" className="h-full" headerClassName="color-warn">
+                <IntelSettings />
+              </TabPanel>
+            )}
 
             {isAdmin && (
               <TabPanel header="Admin Settings" className="h-full" headerClassName="color-warn">

--- a/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/IntelSettings.tsx
+++ b/assets/js/hooks/Mapper/components/mapRootContent/components/MapSettings/components/IntelSettings.tsx
@@ -1,0 +1,130 @@
+import { useMapRootState } from '@/hooks/Mapper/mapRootProvider';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { OutCommand, UserPermission } from '@/hooks/Mapper/types';
+import { useMapCheckPermissions } from '@/hooks/Mapper/mapRootProvider/hooks/api';
+import { Dropdown } from 'primereact/dropdown';
+import { WdButton } from '@/hooks/Mapper/components/ui-kit';
+
+interface IntelSourceMap {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+export const IntelSettings = () => {
+  const {
+    outCommand,
+    data: { options },
+  } = useMapRootState();
+
+  const isManager = useMapCheckPermissions([UserPermission.MANAGE_MAP]);
+  const isAdmin = useMapCheckPermissions([UserPermission.ADMIN_MAP]);
+  const hasPermission = isManager || isAdmin;
+
+  const [availableMaps, setAvailableMaps] = useState<IntelSourceMap[]>([]);
+  const [selectedMapId, setSelectedMapId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const refVars = useRef({ outCommand });
+  refVars.current = { outCommand };
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      try {
+        const result = (await refVars.current.outCommand({
+          type: OutCommand.getIntelSourceMaps,
+          data: null,
+        })) as { maps?: IntelSourceMap[] } | undefined;
+
+        if (!cancelled && result?.maps) {
+          setAvailableMaps(result.maps);
+        }
+      } catch (error) {
+        console.error('Failed to load intel source maps:', error);
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    if (hasPermission) {
+      load();
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasPermission]);
+
+  useEffect(() => {
+    setSelectedMapId(options?.intel_source_map_id ?? null);
+  }, [options?.intel_source_map_id]);
+
+  const handleChange = useCallback(
+    async (mapId: string | null) => {
+      setSelectedMapId(mapId);
+      try {
+        await outCommand({
+          type: OutCommand.setIntelSourceMap,
+          data: { intel_source_map_id: mapId },
+        });
+      } catch (error) {
+        console.error('Failed to update intel source map:', error);
+        setSelectedMapId(options?.intel_source_map_id ?? null);
+      }
+    },
+    [outCommand, options?.intel_source_map_id],
+  );
+
+  const handleClear = useCallback(() => {
+    handleChange(null);
+  }, [handleChange]);
+
+  if (!hasPermission) {
+    return null;
+  }
+
+  return (
+    <div className="w-full h-full flex flex-col gap-5">
+      <div className="flex flex-col gap-3">
+        <span className="text-stone-500 text-[12px]">
+          Select a map to use as the intel source. System intel (custom names, labels, descriptions, status, comments,
+          structures) will be copied from the source map when systems appear on this map.
+        </span>
+
+        <div className="flex items-center gap-2">
+          <Dropdown
+            value={selectedMapId}
+            options={availableMaps.map(m => ({ label: m.name, value: m.id }))}
+            onChange={e => handleChange(e.value)}
+            placeholder="Select intel source map"
+            className="w-full"
+            loading={loading}
+            showClear={false}
+          />
+
+          {selectedMapId && (
+            <WdButton
+              onClick={handleClear}
+              icon="pi pi-times"
+              size="small"
+              severity="danger"
+              label="Clear"
+              className="py-[4px]"
+            />
+          )}
+        </div>
+
+        {selectedMapId && (
+          <span className="text-stone-400 text-[12px]">
+            Currently linked to: {availableMaps.find(m => m.id === selectedMapId)?.name ?? options?.intel_source_map_name ?? 'Unknown map'}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/assets/js/hooks/Mapper/mapRootProvider/MapRootProvider.tsx
+++ b/assets/js/hooks/Mapper/mapRootProvider/MapRootProvider.tsx
@@ -99,6 +99,7 @@ const INITIAL_DATA: MapRootData = {
   pings: [],
   loadingPublicRoutes: false,
   map_slug: null,
+  clientEnv: { intelSharingEnabled: false, detailedKillsDisabled: false },
 };
 
 export enum InterfaceStoredSettingsProps {

--- a/assets/js/hooks/Mapper/mapRootProvider/hooks/api/useMapInit.ts
+++ b/assets/js/hooks/Mapper/mapRootProvider/hooks/api/useMapInit.ts
@@ -28,6 +28,7 @@ export const useMapInit = () => {
         following_character_eve_id,
         user_hubs,
         map_slug,
+        client_env,
       } = props;
 
       const updateData: Partial<MapRootData> = {};
@@ -101,6 +102,10 @@ export const useMapInit = () => {
 
       if ('map_slug' in props) {
         updateData.map_slug = map_slug;
+      }
+
+      if ('client_env' in props) {
+        updateData.clientEnv = client_env;
       }
 
       update(updateData);

--- a/assets/js/hooks/Mapper/types/comment.ts
+++ b/assets/js/hooks/Mapper/types/comment.ts
@@ -4,6 +4,7 @@ export type CommentType = {
   solarSystemId: number;
   text: string;
   updated_at: string;
+  inherited_from_map_id?: string | null;
 };
 
 export type CommentSystem = {

--- a/assets/js/hooks/Mapper/types/mapHandlers.ts
+++ b/assets/js/hooks/Mapper/types/mapHandlers.ts
@@ -81,6 +81,11 @@ export type Command =
   | Commands.pingCancelled
   | Commands.pingBlocked;
 
+export type ClientEnv = {
+  intelSharingEnabled: boolean;
+  detailedKillsDisabled: boolean;
+};
+
 export type CommandInit = {
   systems: SolarSystemRawType[];
   system_signatures: Record<string, SystemSignature[]>;
@@ -104,6 +109,7 @@ export type CommandInit = {
   main_character_eve_id?: string | null;
   following_character_eve_id?: string | null;
   map_slug?: string;
+  client_env?: ClientEnv;
 };
 
 export type CommandAddSystems = SolarSystemRawType[];
@@ -281,6 +287,10 @@ export enum OutCommand {
   addPing = 'add_ping',
   cancelPing = 'cancel_ping',
   startTracking = 'startTracking',
+
+  getIntelSourceMaps = 'get_intel_source_maps',
+  setIntelSourceMap = 'set_intel_source_map',
+  syncIntel = 'sync_intel',
 
   // Only UI commands
   openSettings = 'open_settings',

--- a/assets/js/hooks/Mapper/types/mapUnionTypes.ts
+++ b/assets/js/hooks/Mapper/types/mapUnionTypes.ts
@@ -4,7 +4,7 @@ import { CharacterTypeRaw } from '@/hooks/Mapper/types/character.ts';
 import { SolarSystemRawType } from '@/hooks/Mapper/types/system.ts';
 import { RoutesList } from '@/hooks/Mapper/types/routes.ts';
 import { SolarSystemConnection } from '@/hooks/Mapper/types/connection.ts';
-import { MapOptions, PingData, UserPermissions } from '@/hooks/Mapper/types';
+import { ClientEnv, MapOptions, PingData, UserPermissions } from '@/hooks/Mapper/types';
 import { SystemSignature } from '@/hooks/Mapper/types/signatures';
 
 export type MapUnionTypes = {
@@ -29,4 +29,5 @@ export type MapUnionTypes = {
   mainCharacterEveId: string | null;
   followingCharacterEveId: string | null;
   pings: PingData[];
+  clientEnv: ClientEnv;
 };

--- a/assets/js/hooks/Mapper/types/options.ts
+++ b/assets/js/hooks/Mapper/types/options.ts
@@ -11,4 +11,6 @@ export type MapOptions = {
   show_linked_signature_id_temp_name: StringBoolean;
   show_temp_system_name: StringBoolean;
   store_custom_labels: StringBoolean;
+  intel_source_map_id?: string | null;
+  intel_source_map_name?: string | null;
 };

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -72,6 +72,11 @@ map_subscriptions_enabled =
   |> get_var_from_path_or_env("WANDERER_MAP_SUBSCRIPTIONS_ENABLED", "false")
   |> String.to_existing_atom()
 
+intel_sharing_enabled =
+  config_dir
+  |> get_var_from_path_or_env("WANDERER_INTEL_SHARING_ENABLED", "false")
+  |> String.to_existing_atom()
+
 map_subscription_characters_limit =
   config_dir
   |> get_int_from_path_or_env("WANDERER_MAP_SUBSCRIPTION_CHARACTERS_LIMIT", 10_000)
@@ -179,6 +184,7 @@ config :wanderer_app,
   map_connection_auto_eol_hours: map_connection_auto_eol_hours,
   map_connection_eol_expire_timeout_mins: map_connection_eol_expire_timeout_mins,
   wallet_tracking_enabled: wallet_tracking_enabled,
+  intel_sharing_enabled: intel_sharing_enabled,
   restrict_maps_creation: restrict_maps_creation,
   restrict_acls_creation: restrict_acls_creation,
   subscription_settings: %{

--- a/lib/wanderer_app/api/map.ex
+++ b/lib/wanderer_app/api/map.ex
@@ -69,6 +69,7 @@ defmodule WandererApp.Api.Map do
     define(:duplicate, action: :duplicate)
     define(:admin_all, action: :admin_all)
     define(:restore, action: :restore)
+    define(:set_intel_source_map, action: :set_intel_source_map)
   end
 
   calculations do
@@ -193,6 +194,22 @@ defmodule WandererApp.Api.Map do
     update :update_options do
       accept [:options]
       require_atomic? false
+    end
+
+    update :set_intel_source_map do
+      accept [:intel_source_map_id]
+      require_atomic? false
+
+      validate fn changeset, _context ->
+        source_id = Ash.Changeset.get_attribute(changeset, :intel_source_map_id)
+        map_id = changeset.data.id
+
+        if source_id != nil and source_id == map_id do
+          {:error, field: :intel_source_map_id, message: "a map cannot be its own intel source"}
+        else
+          :ok
+        end
+      end
     end
 
     update :mark_as_deleted do
@@ -432,6 +449,17 @@ defmodule WandererApp.Api.Map do
     end
 
     has_many :transactions, WandererApp.Api.MapTransaction do
+      public? false
+    end
+
+    belongs_to :intel_source_map, WandererApp.Api.Map do
+      attribute_writable? true
+      public? true
+      allow_nil? true
+    end
+
+    has_many :intel_subscriber_maps, WandererApp.Api.Map do
+      destination_attribute :intel_source_map_id
       public? false
     end
   end

--- a/lib/wanderer_app/api/map_system.ex
+++ b/lib/wanderer_app/api/map_system.ex
@@ -101,6 +101,7 @@ defmodule WandererApp.Api.MapSystem do
     define(:update_linked_sig_eve_id, action: :update_linked_sig_eve_id)
     define(:update_position, action: :update_position)
     define(:update_visible, action: :update_visible)
+    define(:update_intel, action: :update_intel)
   end
 
   actions do
@@ -289,6 +290,11 @@ defmodule WandererApp.Api.MapSystem do
 
     update :update_visible do
       accept [:visible]
+      require_atomic? false
+    end
+
+    update :update_intel do
+      accept [:custom_name, :description, :tag, :temporary_name, :labels, :status]
       require_atomic? false
     end
   end

--- a/lib/wanderer_app/api/map_system_comment.ex
+++ b/lib/wanderer_app/api/map_system_comment.ex
@@ -37,6 +37,7 @@ defmodule WandererApp.Api.MapSystemComment do
   code_interface do
     define(:create, action: :create)
     define(:destroy, action: :destroy)
+    define(:inherited_by_system, action: :inherited_by_system, args: [:system_id, :source_map_id])
 
     define(:by_id,
       get_by: [:id],
@@ -61,7 +62,8 @@ defmodule WandererApp.Api.MapSystemComment do
       accept [
         :system_id,
         :character_id,
-        :text
+        :text,
+        :inherited_from_map_id
       ]
     end
 
@@ -69,6 +71,15 @@ defmodule WandererApp.Api.MapSystemComment do
       argument(:system_id, :string, allow_nil?: false)
 
       filter(expr(system_id == ^arg(:system_id)))
+    end
+
+    read :inherited_by_system do
+      argument(:system_id, :string, allow_nil?: false)
+      argument(:source_map_id, :uuid, allow_nil?: false)
+
+      filter(
+        expr(system_id == ^arg(:system_id) and inherited_from_map_id == ^arg(:source_map_id))
+      )
     end
   end
 
@@ -93,6 +104,12 @@ defmodule WandererApp.Api.MapSystemComment do
     belongs_to :character, WandererApp.Api.Character do
       attribute_writable? true
       public? true
+    end
+
+    belongs_to :inherited_from_map, WandererApp.Api.Map do
+      attribute_writable? true
+      public? true
+      allow_nil? true
     end
   end
 end

--- a/lib/wanderer_app/api/map_system_structure.ex
+++ b/lib/wanderer_app/api/map_system_structure.ex
@@ -20,6 +20,7 @@ defmodule WandererApp.Api.MapSystemStructure do
              :owner_id,
              :status,
              :end_time,
+             :inherited_from_map_id,
              :inserted_at,
              :updated_at
            ]}
@@ -79,6 +80,7 @@ defmodule WandererApp.Api.MapSystemStructure do
     define(:all_active, action: :all_active)
     define(:create, action: :create)
     define(:update, action: :update)
+    define(:inherited_by_system, action: :inherited_by_system, args: [:system_id, :source_map_id])
 
     define(:by_id,
       get_by: [:id],
@@ -89,6 +91,8 @@ defmodule WandererApp.Api.MapSystemStructure do
       action: :by_system_id,
       args: [:system_id]
     )
+
+    define(:destroy, action: :destroy)
   end
 
   actions do
@@ -135,8 +139,18 @@ defmodule WandererApp.Api.MapSystemStructure do
         :owner_ticker,
         :owner_id,
         :status,
-        :end_time
+        :end_time,
+        :inherited_from_map_id
       ]
+    end
+
+    read :inherited_by_system do
+      argument(:system_id, :string, allow_nil?: false)
+      argument(:source_map_id, :uuid, allow_nil?: false)
+
+      filter(
+        expr(system_id == ^arg(:system_id) and inherited_from_map_id == ^arg(:source_map_id))
+      )
     end
 
     update :update do
@@ -232,6 +246,12 @@ defmodule WandererApp.Api.MapSystemStructure do
     belongs_to :system, WandererApp.Api.MapSystem do
       attribute_writable? true
       public? true
+    end
+
+    belongs_to :inherited_from_map, WandererApp.Api.Map do
+      attribute_writable? true
+      public? true
+      allow_nil? true
     end
   end
 end

--- a/lib/wanderer_app/application.ex
+++ b/lib/wanderer_app/application.ex
@@ -91,6 +91,7 @@ defmodule WandererApp.Application do
        child_spec: DynamicSupervisor, name: WandererApp.Character.DynamicSupervisors},
       WandererAppWeb.PresenceGracePeriodManager,
       WandererAppWeb.Presence,
+      {Task.Supervisor, name: WandererApp.TaskSupervisor},
       WandererAppWeb.Endpoint
     ]
 

--- a/lib/wanderer_app/env.ex
+++ b/lib/wanderer_app/env.ex
@@ -17,6 +17,7 @@ defmodule WandererApp.Env do
   def invites(), do: get_key(:invites, false)
 
   def map_subscriptions_enabled?(), do: get_key(:map_subscriptions_enabled, false)
+  def intel_sharing_enabled?(), do: get_key(:intel_sharing_enabled, false)
   def public_api_disabled?(), do: get_key(:public_api_disabled, false)
 
   @decorate cacheable(
@@ -119,6 +120,9 @@ defmodule WandererApp.Env do
   made available to react
   """
   def to_client_env() do
-    %{detailedKillsDisabled: not wanderer_kills_service_enabled?()}
+    %{
+      detailedKillsDisabled: not wanderer_kills_service_enabled?(),
+      intelSharingEnabled: intel_sharing_enabled?()
+    }
   end
 end

--- a/lib/wanderer_app/map/intel_sync.ex
+++ b/lib/wanderer_app/map/intel_sync.ex
@@ -1,0 +1,273 @@
+defmodule WandererApp.Map.IntelSync do
+  @moduledoc """
+  Copies intel from a source map to a subscriber map for a given solar system.
+
+  Called when a system becomes visible on a subscriber map (sync-on-visibility),
+  or when a user manually triggers a re-sync via the sync icon.
+
+  Intel fields: custom_name, description, tag, temporary_name, labels, status.
+  Also syncs comments and structures (marked with inherited_from_map_id).
+  """
+
+  require Logger
+
+  alias WandererApp.MapSystemRepo
+
+  @intel_fields [:custom_name, :description, :tag, :temporary_name, :labels, :status]
+
+  @doc "Returns the list of system fields considered intel for syncing."
+  def intel_fields, do: @intel_fields
+
+  @doc """
+  Syncs intel for a single system from source map to subscriber map.
+  Copies system metadata fields, comments, and structures.
+
+  Returns:
+    - {:ok, updated_system} on successful sync
+    - {:ok, :disabled} if intel sharing is disabled
+    - {:ok, :no_source_data} if source map has no data for this system
+    - {:ok, :subscriber_not_found} if subscriber map has no matching system
+    - {:error, reason} on failure
+  """
+  def sync_system(subscriber_map_id, source_map_id, solar_system_id) do
+    if WandererApp.Env.intel_sharing_enabled?() do
+      do_sync_system(subscriber_map_id, source_map_id, solar_system_id)
+    else
+      {:ok, :disabled}
+    end
+  end
+
+  @doc """
+  Syncs intel for all visible systems on a subscriber map from its source.
+  Used when intel_source_map_id is first configured (backfill).
+
+  Returns:
+    - `{:ok, synced_count}` when all systems synced successfully (or were skipped).
+      `synced_count` is the number of systems whose intel was actually copied.
+    - `{:ok, synced_count, errors}` on partial failure. `synced_count` is the number
+      of systems successfully synced, and `errors` is a list of
+      `{solar_system_id, reason}` tuples for each system that failed to sync.
+    - `{:ok, :disabled}` if intel sharing is disabled.
+    - `{:error, :list_systems_failed}` if the visible systems could not be loaded.
+  """
+  def sync_all_visible_systems(subscriber_map_id, source_map_id) do
+    if WandererApp.Env.intel_sharing_enabled?() do
+      case MapSystemRepo.get_visible_by_map(subscriber_map_id) do
+        {:ok, systems} ->
+          results =
+            Enum.map(systems, fn system ->
+              {system.solar_system_id,
+               do_sync_system(subscriber_map_id, source_map_id, system.solar_system_id)}
+            end)
+
+          {synced_count, skipped_count, errors} =
+            Enum.reduce(results, {0, 0, []}, fn
+              {_sid, {:ok, %{} = _system}}, {ok, skip, errs} ->
+                {ok + 1, skip, errs}
+
+              {_sid, {:ok, reason}}, {ok, skip, errs} when is_atom(reason) ->
+                {ok, skip + 1, errs}
+
+              {sid, {:error, reason}}, {ok, skip, errs} ->
+                {ok, skip, [{sid, reason} | errs]}
+            end)
+
+          errors = Enum.reverse(errors)
+
+          if errors == [] do
+            Logger.debug(fn ->
+              "Intel sync backfill for map #{subscriber_map_id}: #{synced_count} synced, #{skipped_count} skipped"
+            end)
+
+            {:ok, synced_count}
+          else
+            Logger.error(fn ->
+              "Intel sync backfill for map #{subscriber_map_id}: #{synced_count} synced, " <>
+                "#{skipped_count} skipped, #{length(errors)} errors: #{inspect(errors)}"
+            end)
+
+            {:ok, synced_count, errors}
+          end
+
+        error ->
+          Logger.error(fn ->
+            "Failed to list visible systems for backfill: #{inspect(error)}"
+          end)
+
+          {:error, :list_systems_failed}
+      end
+    else
+      {:ok, :disabled}
+    end
+  end
+
+  defp do_sync_system(subscriber_map_id, source_map_id, solar_system_id) do
+    with {:source, {:ok, source_system}} <-
+           {:source, MapSystemRepo.get_by_map_and_solar_system_id(source_map_id, solar_system_id)},
+         {:subscriber, {:ok, subscriber_system}} <-
+           {:subscriber,
+            MapSystemRepo.get_by_map_and_solar_system_id(subscriber_map_id, solar_system_id)} do
+      intel_attrs = Map.take(source_system, @intel_fields)
+
+      case WandererApp.Api.MapSystem.update_intel(subscriber_system, intel_attrs) do
+        {:ok, updated_system} ->
+          comments_result =
+            sync_inherited_records(
+              subscriber_system.id,
+              source_system.id,
+              source_map_id,
+              WandererApp.Api.MapSystemComment,
+              &comment_attrs/3
+            )
+
+          structures_result =
+            sync_inherited_records(
+              subscriber_system.id,
+              source_system.id,
+              source_map_id,
+              WandererApp.Api.MapSystemStructure,
+              &structure_attrs/3
+            )
+
+          case {comments_result, structures_result} do
+            {:ok, :ok} ->
+              {:ok, updated_system}
+
+            {{:error, reason}, _} ->
+              Logger.error(fn ->
+                "Failed to sync comments for solar_system #{solar_system_id} " <>
+                  "from map #{source_map_id} to #{subscriber_map_id}: #{inspect(reason)}"
+              end)
+
+              {:error, reason}
+
+            {_, {:error, reason}} ->
+              Logger.error(fn ->
+                "Failed to sync structures for solar_system #{solar_system_id} " <>
+                  "from map #{source_map_id} to #{subscriber_map_id}: #{inspect(reason)}"
+              end)
+
+              {:error, reason}
+          end
+
+        {:error, reason} ->
+          Logger.error(fn ->
+            "Failed to sync intel for system #{solar_system_id}: #{inspect(reason)}"
+          end)
+
+          {:error, reason}
+      end
+    else
+      {:source, {:error, :not_found}} ->
+        {:ok, :no_source_data}
+
+      {:subscriber, {:error, :not_found}} ->
+        Logger.debug(fn ->
+          "Intel sync skipped for solar_system #{solar_system_id}: subscriber system not found on map #{subscriber_map_id}"
+        end)
+
+        {:ok, :subscriber_not_found}
+
+      {step, error} ->
+        Logger.debug(fn ->
+          "Intel sync skipped for solar_system #{solar_system_id} at #{step}: #{inspect(error)}"
+        end)
+
+        {:error, error}
+    end
+  end
+
+  defp sync_inherited_records(
+         subscriber_system_id,
+         source_system_id,
+         source_map_id,
+         api_module,
+         attrs_fn
+       ) do
+    with :ok <- delete_inherited(subscriber_system_id, source_map_id, api_module) do
+      copy_from_source(
+        subscriber_system_id,
+        source_system_id,
+        source_map_id,
+        api_module,
+        attrs_fn
+      )
+    end
+  end
+
+  defp delete_inherited(subscriber_system_id, source_map_id, api_module) do
+    case api_module.inherited_by_system(subscriber_system_id, source_map_id) do
+      {:ok, inherited_records} ->
+        errors =
+          inherited_records
+          |> Enum.reduce([], fn record, acc ->
+            case api_module.destroy(record) do
+              :ok -> acc
+              {:ok, _} -> acc
+              {:error, reason} -> [reason | acc]
+            end
+          end)
+
+        case errors do
+          [] -> :ok
+          details -> {:error, {:delete_failed, Enum.reverse(details)}}
+        end
+
+      {:error, reason} ->
+        {:error, {:delete_failed, [reason]}}
+    end
+  end
+
+  defp copy_from_source(
+         subscriber_system_id,
+         source_system_id,
+         source_map_id,
+         api_module,
+         attrs_fn
+       ) do
+    case api_module.by_system_id(source_system_id) do
+      {:ok, source_records} ->
+        errors =
+          source_records
+          |> Enum.reject(& &1.inherited_from_map_id)
+          |> Enum.reduce([], fn record, acc ->
+            case api_module.create(attrs_fn.(record, subscriber_system_id, source_map_id)) do
+              {:ok, _} -> acc
+              {:error, reason} -> [reason | acc]
+            end
+          end)
+
+        case errors do
+          [] -> :ok
+          details -> {:error, {:create_failed, Enum.reverse(details)}}
+        end
+
+      {:error, reason} ->
+        {:error, {:create_failed, [reason]}}
+    end
+  end
+
+  defp comment_attrs(comment, subscriber_system_id, source_map_id) do
+    %{
+      system_id: subscriber_system_id,
+      character_id: comment.character_id,
+      text: comment.text,
+      inherited_from_map_id: source_map_id
+    }
+  end
+
+  @structure_copy_fields [
+    :solar_system_name, :solar_system_id, :structure_type_id, :structure_type,
+    :character_eve_id, :name, :notes, :owner_name, :owner_ticker,
+    :owner_id, :status, :end_time
+  ]
+
+  defp structure_attrs(structure, subscriber_system_id, source_map_id) do
+    structure
+    |> Map.take(@structure_copy_fields)
+    |> Map.merge(%{
+      system_id: subscriber_system_id,
+      inherited_from_map_id: source_map_id
+    })
+  end
+end

--- a/lib/wanderer_app/map/server/map_server_systems_impl.ex
+++ b/lib/wanderer_app/map/server/map_server_systems_impl.ex
@@ -650,6 +650,8 @@ defmodule WandererApp.Map.Server.SystemsImpl do
               }
             )
 
+            maybe_sync_intel_from_source(map_id, updated_system)
+
             :ok
 
           _ ->
@@ -702,6 +704,8 @@ defmodule WandererApp.Map.Server.SystemsImpl do
                         operation: :upsert
                       }
                     )
+
+                    maybe_sync_intel_from_source(map_id, system)
 
                     :ok
 
@@ -909,6 +913,8 @@ defmodule WandererApp.Map.Server.SystemsImpl do
           })
 
           track_add_system(map_id, user_id, character_id, system.solar_system_id)
+
+          maybe_sync_intel_from_source(map_id, system)
 
           :ok
 
@@ -1132,5 +1138,26 @@ defmodule WandererApp.Map.Server.SystemsImpl do
     })
 
     :ok
+  end
+
+  defp maybe_sync_intel_from_source(map_id, system) do
+    with true <- WandererApp.Env.intel_sharing_enabled?(),
+         {:ok, %{map: %{intel_source_map_id: source_id}}} when not is_nil(source_id) <-
+           WandererApp.Map.get_map_state(map_id, false) do
+      Task.Supervisor.start_child(WandererApp.TaskSupervisor, fn ->
+        case WandererApp.Map.IntelSync.sync_system(map_id, source_id, system.solar_system_id) do
+          {:ok, updated_system} when is_map(updated_system) ->
+            intel_fields = WandererApp.Map.IntelSync.intel_fields()
+            update = Map.take(updated_system, [:solar_system_id | intel_fields])
+            WandererApp.Map.update_system_by_solar_system_id(map_id, update)
+            update_map_system_last_activity(map_id, updated_system)
+
+          _ ->
+            :ok
+        end
+      end)
+    else
+      _ -> :ok
+    end
   end
 end

--- a/lib/wanderer_app/repositories/map_repo.ex
+++ b/lib/wanderer_app/repositories/map_repo.ex
@@ -195,4 +195,8 @@ defmodule WandererApp.MapRepo do
     {:ok, data} = options_to_form_data(options)
     data
   end
+
+  def set_intel_source_map(map, source_map_id) do
+    WandererApp.Api.Map.set_intel_source_map(map, %{intel_source_map_id: source_map_id})
+  end
 end

--- a/lib/wanderer_app_web/live/map/event_handlers/map_core_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/event_handlers/map_core_event_handler.ex
@@ -343,9 +343,192 @@ defmodule WandererAppWeb.MapCoreEventHandler do
     {:noreply, socket}
   end
 
+  def handle_ui_event(
+        "get_intel_source_maps",
+        _params,
+        %{
+          assigns: %{
+            current_user: current_user,
+            map_id: map_id,
+            user_permissions: %{manage_map: true}
+          }
+        } = socket
+      ) do
+    if WandererApp.Env.intel_sharing_enabled?() do
+      case WandererApp.Maps.get_available_maps(current_user) do
+        {:ok, maps} ->
+          character_ids = Enum.map(current_user.characters, & &1.id)
+
+          candidates =
+            Enum.filter(maps, fn m -> m.id != map_id and not m.deleted end)
+
+          loaded_candidates =
+            case Ash.load(candidates, :user_permissions, actor: current_user) do
+              {:ok, loaded} -> loaded
+              _ -> candidates
+            end
+
+          eligible_maps =
+            loaded_candidates
+            |> Enum.filter(fn m ->
+              m.owner_id in character_ids or
+                has_manage_access?(m, character_ids)
+            end)
+            |> Enum.map(fn m -> %{id: m.id, name: m.name, slug: m.slug} end)
+
+          {:reply, %{maps: eligible_maps}, socket}
+
+        _error ->
+          {:reply, %{maps: []}, socket}
+      end
+    else
+      {:reply, %{maps: []}, socket}
+    end
+  end
+
+  def handle_ui_event("get_intel_source_maps", _params, socket) do
+    {:reply, %{maps: []}, socket}
+  end
+
+  def handle_ui_event(
+        "set_intel_source_map",
+        %{"intel_source_map_id" => source_map_id},
+        %{
+          assigns: %{
+            map_id: map_id,
+            user_permissions: %{manage_map: true}
+          }
+        } = socket
+      ) do
+    if WandererApp.Env.intel_sharing_enabled?() do
+      source_map_id = if source_map_id in [nil, ""], do: nil, else: source_map_id
+      current_user = socket.assigns[:current_user]
+
+      with {:ok, source_map} <- fetch_source_map(source_map_id),
+           :ok <- validate_no_circular_ref(map_id, source_map),
+           :ok <- validate_source_access(current_user, source_map),
+           {:ok, map} <- WandererApp.MapRepo.get(map_id),
+           {:ok, updated_map} <-
+             WandererApp.MapRepo.set_intel_source_map(map, source_map_id) do
+        # Update the map state cache so subsequent reads see the new value
+        WandererApp.Map.update_map_state(map_id, %{map: updated_map})
+
+        if source_map_id do
+          Task.Supervisor.start_child(WandererApp.TaskSupervisor, fn ->
+            WandererApp.Map.IntelSync.sync_all_visible_systems(map_id, source_map_id)
+          end)
+        end
+
+        source_name = if source_map, do: source_map.name, else: nil
+
+        {:reply,
+         %{
+           success: true,
+           intel_source_map_id: source_map_id,
+           intel_source_map_name: source_name
+         }, socket}
+      else
+        {:error, :circular_reference} ->
+          {:reply, %{success: false, error: "circular_reference"}, socket}
+
+        {:error, :unauthorized_source} ->
+          {:reply, %{success: false, error: "unauthorized_source"}, socket}
+
+        {:error, reason} ->
+          Logger.error("Failed to set intel source map: #{inspect(reason)}")
+          {:reply, %{success: false, error: "update_failed"}, socket}
+      end
+    else
+      {:reply, %{success: false, error: "feature_disabled"}, socket}
+    end
+  end
+
   def handle_ui_event(event, body, socket) do
     Logger.debug(fn -> "unhandled map ui event: #{inspect(event)} #{inspect(body)}" end)
     {:noreply, socket}
+  end
+
+  defp maybe_add_intel_source_info(options, map_id) do
+    if WandererApp.Env.intel_sharing_enabled?() do
+      with {:ok, %{map: %{intel_source_map_id: source_id}}} when not is_nil(source_id) <-
+             WandererApp.Map.get_map_state(map_id, false),
+           {:ok, source_map} <- WandererApp.MapRepo.get(source_id) do
+        options
+        |> Map.put("intel_source_map_id", source_id)
+        |> Map.put("intel_source_map_name", source_map.name)
+      else
+        _ ->
+          options
+          |> Map.put("intel_source_map_id", nil)
+          |> Map.put("intel_source_map_name", nil)
+      end
+    else
+      options
+    end
+  end
+
+  defp fetch_source_map(nil), do: {:ok, nil}
+
+  defp fetch_source_map(source_map_id) do
+    case WandererApp.MapRepo.get(source_map_id) do
+      {:ok, source_map} -> {:ok, source_map}
+      _ -> {:error, :source_not_found}
+    end
+  end
+
+  defp validate_no_circular_ref(_map_id, nil), do: :ok
+
+  defp validate_no_circular_ref(map_id, %{id: source_id} = source_map) do
+    if source_id == map_id do
+      {:error, :circular_reference}
+    else
+      # Start walking from the source map's own intel_source_map_id
+      # (we already have the source map struct, no need to re-fetch it)
+      next_id = Map.get(source_map, :intel_source_map_id)
+      walk_intel_chain(next_id, MapSet.new([map_id, source_id]))
+    end
+  end
+
+  defp walk_intel_chain(nil, _visited), do: :ok
+
+  defp walk_intel_chain(current_id, visited) do
+    if MapSet.member?(visited, current_id) do
+      {:error, :circular_reference}
+    else
+      case WandererApp.MapRepo.get(current_id) do
+        {:ok, %{intel_source_map_id: next_id}} ->
+          walk_intel_chain(next_id, MapSet.put(visited, current_id))
+
+        _ ->
+          :ok
+      end
+    end
+  end
+
+  defp validate_source_access(_current_user, nil), do: :ok
+
+  defp validate_source_access(current_user, source_map) do
+    case WandererApp.Maps.get_user_role_for_map(source_map, current_user) do
+      role when role in [:admin, :manager] -> :ok
+      _ -> {:error, :unauthorized_source}
+    end
+  end
+
+  defp has_manage_access?(map, character_ids) do
+    user_permissions =
+      case Map.get(map, :user_permissions) do
+        perms when is_list(perms) -> perms
+        _ -> []
+      end
+
+    permissions =
+      WandererApp.Permissions.get_map_permissions(
+        user_permissions,
+        map.owner_id,
+        character_ids
+      )
+
+    permissions.admin_map or permissions.manage_map
   end
 
   defp save_default_settings(map_id, settings, current_user) do
@@ -438,15 +621,17 @@ defmodule WandererAppWeb.MapCoreEventHandler do
          user_permissions,
          owner_id
        ) do
-    with user_permissions <-
-           WandererApp.Permissions.get_map_permissions(
-             user_permissions,
-             owner_id,
-             current_user_characters |> Enum.map(& &1.id)
-           ),
-         {:ok, map_user_settings} <- WandererApp.MapUserSettingsRepo.get(map_id, current_user_id),
-         {:ok, %{characters: available_map_characters}} =
-           WandererApp.Maps.load_characters(map, current_user_id) do
+    user_permissions =
+      WandererApp.Permissions.get_map_permissions(
+        user_permissions,
+        owner_id,
+        current_user_characters |> Enum.map(& &1.id)
+      )
+
+    with {:ok, map_user_settings} <- WandererApp.MapUserSettingsRepo.get(map_id, current_user_id) do
+      {:ok, %{characters: available_map_characters}} =
+        WandererApp.Maps.load_characters(map, current_user_id)
+
       tracked_data =
         get_tracked_data(
           available_map_characters,
@@ -686,6 +871,8 @@ defmodule WandererAppWeb.MapCoreEventHandler do
       map_id
       |> WandererApp.Map.get_options()
 
+    options = maybe_add_intel_source_info(options, map_id)
+
     map_characters =
       map_id
       |> WandererApp.Map.list_characters()
@@ -716,6 +903,7 @@ defmodule WandererAppWeb.MapCoreEventHandler do
           user_permissions: user_permissions,
           characters: map_characters,
           options: options,
+          client_env: WandererApp.Env.to_client_env(),
           classes: WandererApp.CachedInfo.get_wormhole_classes!(),
           wormholes: WandererApp.CachedInfo.get_wormhole_types!(),
           effects: WandererApp.CachedInfo.get_effects!(),

--- a/lib/wanderer_app_web/live/map/event_handlers/map_structures_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/event_handlers/map_structures_event_handler.ex
@@ -151,7 +151,8 @@ defmodule WandererAppWeb.MapStructuresEventHandler do
           :end_time,
           :inserted_at,
           :updated_at,
-          :structure_type
+          :structure_type,
+          :inherited_from_map_id
         ])
         |> Map.update!(:inserted_at, &Calendar.strftime(&1, "%Y/%m/%d %H:%M:%S"))
         |> Map.update!(:updated_at, &Calendar.strftime(&1, "%Y/%m/%d %H:%M:%S"))

--- a/lib/wanderer_app_web/live/map/event_handlers/map_system_comments_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/event_handlers/map_system_comments_event_handler.ex
@@ -158,14 +158,15 @@ defmodule WandererAppWeb.MapSystemCommentsEventHandler do
           system: system,
           text: text,
           updated_at: updated_at
-        } = _comment
+        } = comment
       ) do
     %{
       id: id,
       characterEveId: character.eve_id,
       solarSystemId: system.solar_system_id,
       text: text,
-      updated_at: updated_at
+      updated_at: updated_at,
+      inherited_from_map_id: comment.inherited_from_map_id
     }
   end
 
@@ -177,7 +178,7 @@ defmodule WandererAppWeb.MapSystemCommentsEventHandler do
           character: character,
           text: text,
           updated_at: updated_at
-        } = _comment,
+        } = comment,
         solar_system_id
       ) do
     %{
@@ -185,7 +186,8 @@ defmodule WandererAppWeb.MapSystemCommentsEventHandler do
       characterEveId: character.eve_id,
       solarSystemId: solar_system_id,
       text: text,
-      updated_at: updated_at
+      updated_at: updated_at,
+      inherited_from_map_id: comment.inherited_from_map_id
     }
   end
 end

--- a/lib/wanderer_app_web/live/map/event_handlers/map_systems_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/event_handlers/map_systems_event_handler.ex
@@ -4,6 +4,7 @@ defmodule WandererAppWeb.MapSystemsEventHandler do
   require Logger
 
   alias WandererAppWeb.{MapEventHandler, MapCoreEventHandler}
+  alias WandererApp.Map.Server.Impl
 
   def handle_server_event(%{event: :add_system, payload: system}, socket) do
     # Schedule kill update for the new system after a short delay to allow subscription
@@ -317,6 +318,49 @@ defmodule WandererAppWeb.MapSystemsEventHandler do
     )
 
     {:noreply, socket}
+  end
+
+  def handle_ui_event(
+        "sync_intel",
+        %{"solar_system_id" => solar_system_id},
+        %{assigns: %{map_id: map_id, map_loaded?: true, user_permissions: %{update_system: true}}} =
+          socket
+      ) do
+    if WandererApp.Env.intel_sharing_enabled?() do
+      case WandererAppWeb.Helpers.APIUtils.parse_int(solar_system_id) do
+        {:error, _} ->
+          {:reply, %{success: false, error: "invalid_system_id"}, socket}
+
+        {:ok, solar_system_id_int} ->
+          case WandererApp.MapRepo.get(map_id) do
+            {:ok, %{intel_source_map_id: source_map_id}} when not is_nil(source_map_id) ->
+              case WandererApp.Map.IntelSync.sync_system(map_id, source_map_id, solar_system_id_int) do
+                {:ok, updated_system} when is_map(updated_system) ->
+                  intel_fields = WandererApp.Map.IntelSync.intel_fields()
+
+                  update =
+                    Map.take(updated_system, [:solar_system_id | intel_fields])
+
+                  WandererApp.Map.update_system_by_solar_system_id(map_id, update)
+                  Impl.broadcast!(map_id, :update_system, updated_system)
+
+                  {:reply, %{success: true}, socket}
+
+                _ ->
+                  {:reply, %{success: false, error: "no_source_data"}, socket}
+              end
+
+            _ ->
+              {:reply, %{success: false, error: "no_intel_source"}, socket}
+          end
+      end
+    else
+      {:reply, %{success: false, error: "feature_disabled"}, socket}
+    end
+  end
+
+  def handle_ui_event("sync_intel", _params, socket) do
+    {:reply, %{success: false, error: "forbidden"}, socket}
   end
 
   def handle_ui_event(event, body, socket),

--- a/lib/wanderer_app_web/live/map/map_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/map_event_handler.ex
@@ -58,7 +58,8 @@ defmodule WandererAppWeb.MapEventHandler do
     "update_system_tag",
     "update_system_temporary_name",
     "update_system_status",
-    "manual_paste_systems_and_connections"
+    "manual_paste_systems_and_connections",
+    "sync_intel"
   ]
 
   @map_system_comments_events [

--- a/priv/repo/migrations/20260209100000_add_intel_source_map_id.exs
+++ b/priv/repo/migrations/20260209100000_add_intel_source_map_id.exs
@@ -1,0 +1,30 @@
+defmodule WandererApp.Repo.Migrations.AddIntelSourceMapId do
+  @moduledoc """
+  Adds intel_source_map_id to maps_v1 for cross-map intel sharing.
+  A self-referencing FK that designates which map provides intel to this map.
+  """
+  use Ecto.Migration
+
+  def up do
+    alter table(:maps_v1) do
+      add :intel_source_map_id,
+          references(:maps_v1,
+            column: :id,
+            name: "maps_v1_intel_source_map_id_fkey",
+            type: :uuid,
+            on_delete: :nilify_all
+          ),
+          null: true
+    end
+
+    create index(:maps_v1, [:intel_source_map_id])
+  end
+
+  def down do
+    drop_if_exists index(:maps_v1, [:intel_source_map_id])
+
+    alter table(:maps_v1) do
+      remove :intel_source_map_id
+    end
+  end
+end

--- a/priv/repo/migrations/20260209100001_add_inherited_from_map_id.exs
+++ b/priv/repo/migrations/20260209100001_add_inherited_from_map_id.exs
@@ -1,0 +1,44 @@
+defmodule WandererApp.Repo.Migrations.AddInheritedFromMapId do
+  @moduledoc """
+  Adds inherited_from_map_id to comments and structures tables.
+  Tracks which records were copied from a source map during intel sync.
+  Records with this field set are read-only on the subscriber map.
+  """
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    repo().query!(
+      "ALTER TABLE map_system_comments_v1 ADD COLUMN IF NOT EXISTS inherited_from_map_id uuid REFERENCES maps_v1(id) ON DELETE CASCADE",
+      []
+    )
+
+    repo().query!(
+      "ALTER TABLE map_system_structures_v1 ADD COLUMN IF NOT EXISTS inherited_from_map_id uuid REFERENCES maps_v1(id) ON DELETE CASCADE",
+      []
+    )
+
+    create_if_not_exists index(:map_system_comments_v1, [:inherited_from_map_id],
+                           concurrently: true
+                         )
+
+    create_if_not_exists index(:map_system_structures_v1, [:inherited_from_map_id],
+                           concurrently: true
+                         )
+  end
+
+  def down do
+    drop_if_exists index(:map_system_comments_v1, [:inherited_from_map_id], concurrently: true)
+    drop_if_exists index(:map_system_structures_v1, [:inherited_from_map_id], concurrently: true)
+
+    alter table(:map_system_comments_v1) do
+      remove :inherited_from_map_id
+    end
+
+    alter table(:map_system_structures_v1) do
+      remove :inherited_from_map_id
+    end
+  end
+end

--- a/test/unit/map/intel_sync_test.exs
+++ b/test/unit/map/intel_sync_test.exs
@@ -1,0 +1,311 @@
+defmodule WandererApp.Map.IntelSyncTest do
+  use WandererApp.DataCase, async: false
+
+  import Mox
+  import WandererApp.MapTestHelpers
+
+  alias WandererApp.Map.IntelSync
+
+  setup :verify_on_exit!
+
+  setup do
+    Mox.set_mox_global()
+    setup_ddrt_mocks()
+    setup_system_static_info_cache()
+
+    previous_intel_sharing =
+      Application.get_env(:wanderer_app, :intel_sharing_enabled)
+
+    on_exit(fn ->
+      Application.put_env(:wanderer_app, :intel_sharing_enabled, previous_intel_sharing)
+    end)
+
+    user = insert(:user)
+    character = insert(:character, %{user_id: user.id})
+    source_map = insert(:map, %{owner_id: character.id})
+    subscriber_map = insert(:map, %{owner_id: character.id})
+
+    # Set subscriber's intel source
+    {:ok, _} = WandererApp.MapRepo.set_intel_source_map(subscriber_map, source_map.id)
+
+    # Create a system on the source map with intel fields populated
+    source_system =
+      insert(:map_system, %{
+        map_id: source_map.id,
+        solar_system_id: 30_000_142,
+        visible: true
+      })
+
+    # Update source system with intel data
+    {:ok, source_system} =
+      WandererApp.Api.MapSystem.update_intel(source_system, %{
+        custom_name: "Source Custom Name",
+        description: "Source description",
+        tag: "T1",
+        temporary_name: "TmpName",
+        labels: Jason.encode!(["la"]),
+        status: 1
+      })
+
+    # Create matching system on subscriber map with empty intel
+    subscriber_system =
+      insert(:map_system, %{
+        map_id: subscriber_map.id,
+        solar_system_id: 30_000_142,
+        visible: true
+      })
+
+    %{
+      source_map: source_map,
+      subscriber_map: subscriber_map,
+      source_system: source_system,
+      subscriber_system: subscriber_system,
+      character: character,
+      user: user
+    }
+  end
+
+  defp enable_intel_sharing do
+    Application.put_env(:wanderer_app, :intel_sharing_enabled, true)
+  end
+
+  defp disable_intel_sharing do
+    Application.put_env(:wanderer_app, :intel_sharing_enabled, false)
+  end
+
+  describe "sync_system/3" do
+    test "copies intel fields from source to subscriber", ctx do
+      enable_intel_sharing()
+
+      assert {:ok, updated_system} =
+               IntelSync.sync_system(
+                 ctx.subscriber_map.id,
+                 ctx.source_map.id,
+                 30_000_142
+               )
+
+      assert updated_system.custom_name == "Source Custom Name"
+      assert updated_system.description == "Source description"
+      assert updated_system.tag == "T1"
+      assert updated_system.temporary_name == "TmpName"
+      assert updated_system.labels == Jason.encode!(["la"])
+      assert updated_system.status == 1
+    end
+
+    test "returns {:ok, :no_source_data} when source has no system", ctx do
+      enable_intel_sharing()
+
+      assert {:ok, :no_source_data} =
+               IntelSync.sync_system(
+                 ctx.subscriber_map.id,
+                 ctx.source_map.id,
+                 99_999_999
+               )
+    end
+
+    test "returns {:ok, :disabled} when feature flag is off", ctx do
+      disable_intel_sharing()
+
+      assert {:ok, :disabled} =
+               IntelSync.sync_system(
+                 ctx.subscriber_map.id,
+                 ctx.source_map.id,
+                 30_000_142
+               )
+    end
+
+    test "copies comments and marks them inherited", ctx do
+      enable_intel_sharing()
+
+      # Create a comment on the source system
+      {:ok, _comment} =
+        WandererApp.Api.MapSystemComment.create(%{
+          system_id: ctx.source_system.id,
+          character_id: ctx.character.id,
+          text: "Intel comment from source"
+        })
+
+      # Sync
+      {:ok, _updated} =
+        IntelSync.sync_system(
+          ctx.subscriber_map.id,
+          ctx.source_map.id,
+          30_000_142
+        )
+
+      # Fetch comments for subscriber system
+      {:ok, comments} =
+        WandererApp.Api.MapSystemComment.by_system_id(ctx.subscriber_system.id)
+
+      inherited =
+        Enum.filter(comments, fn c ->
+          c.inherited_from_map_id == ctx.source_map.id
+        end)
+
+      assert length(inherited) == 1
+      assert Enum.any?(inherited, fn c -> c.text == "Intel comment from source" end)
+    end
+
+    test "copies structures and marks them inherited", ctx do
+      enable_intel_sharing()
+
+      # Create a structure on the source system
+      {:ok, _structure} =
+        WandererApp.Api.MapSystemStructure.create(%{
+          system_id: ctx.source_system.id,
+          structure_type_id: "35825",
+          structure_type: "Astrahus",
+          character_eve_id: "2000000001",
+          solar_system_name: "Jita",
+          solar_system_id: 30_000_142,
+          name: "Test Structure From Source",
+          status: "anchored"
+        })
+
+      # Sync
+      {:ok, _updated} =
+        IntelSync.sync_system(
+          ctx.subscriber_map.id,
+          ctx.source_map.id,
+          30_000_142
+        )
+
+      # Fetch structures for subscriber system
+      {:ok, structures} =
+        WandererApp.Api.MapSystemStructure.by_system_id(ctx.subscriber_system.id)
+
+      inherited =
+        Enum.filter(structures, fn s ->
+          s.inherited_from_map_id == ctx.source_map.id
+        end)
+
+      assert length(inherited) == 1
+      assert Enum.any?(inherited, fn s -> s.name == "Test Structure From Source" end)
+    end
+
+    test "replaces inherited comments on re-sync (does not duplicate)", ctx do
+      enable_intel_sharing()
+
+      # Create a comment on the source system
+      {:ok, _comment} =
+        WandererApp.Api.MapSystemComment.create(%{
+          system_id: ctx.source_system.id,
+          character_id: ctx.character.id,
+          text: "Re-sync comment"
+        })
+
+      # Sync once
+      {:ok, _} =
+        IntelSync.sync_system(
+          ctx.subscriber_map.id,
+          ctx.source_map.id,
+          30_000_142
+        )
+
+      {:ok, comments_after_first} =
+        WandererApp.Api.MapSystemComment.by_system_id(ctx.subscriber_system.id)
+
+      inherited_count_first =
+        comments_after_first
+        |> Enum.count(fn c -> c.inherited_from_map_id == ctx.source_map.id end)
+
+      # Sync again
+      {:ok, _} =
+        IntelSync.sync_system(
+          ctx.subscriber_map.id,
+          ctx.source_map.id,
+          30_000_142
+        )
+
+      {:ok, comments_after_second} =
+        WandererApp.Api.MapSystemComment.by_system_id(ctx.subscriber_system.id)
+
+      inherited_count_second =
+        comments_after_second
+        |> Enum.count(fn c -> c.inherited_from_map_id == ctx.source_map.id end)
+
+      assert inherited_count_first == inherited_count_second
+    end
+
+    test "does NOT copy already-inherited comments from source", ctx do
+      enable_intel_sharing()
+
+      # Use the subscriber_map.id as the "other" map so the FK constraint is satisfied
+      # (inherited_from_map_id must reference a real map)
+      other_map_id = ctx.subscriber_map.id
+
+      {:ok, _inherited_comment} =
+        WandererApp.Api.MapSystemComment.create(%{
+          system_id: ctx.source_system.id,
+          character_id: ctx.character.id,
+          text: "Already inherited comment",
+          inherited_from_map_id: other_map_id
+        })
+
+      # Sync
+      {:ok, _} =
+        IntelSync.sync_system(
+          ctx.subscriber_map.id,
+          ctx.source_map.id,
+          30_000_142
+        )
+
+      # Fetch comments for subscriber system
+      {:ok, comments} =
+        WandererApp.Api.MapSystemComment.by_system_id(ctx.subscriber_system.id)
+
+      # The already-inherited comment should NOT be copied
+      already_inherited =
+        Enum.filter(comments, fn c ->
+          c.text == "Already inherited comment"
+        end)
+
+      assert length(already_inherited) == 0
+    end
+  end
+
+  describe "sync_all_visible_systems/2" do
+    test "syncs all visible systems", ctx do
+      enable_intel_sharing()
+
+      # Create a second system on both maps (first one is already set up in setup)
+      source_system_2 =
+        insert(:map_system, %{
+          map_id: ctx.source_map.id,
+          solar_system_id: 30_002_659,
+          visible: true
+        })
+
+      {:ok, _source_system_2} =
+        WandererApp.Api.MapSystem.update_intel(source_system_2, %{
+          custom_name: "Source System 2",
+          description: "Description 2"
+        })
+
+      _subscriber_system_2 =
+        insert(:map_system, %{
+          map_id: ctx.subscriber_map.id,
+          solar_system_id: 30_002_659,
+          visible: true
+        })
+
+      assert {:ok, count} =
+               IntelSync.sync_all_visible_systems(
+                 ctx.subscriber_map.id,
+                 ctx.source_map.id
+               )
+
+      assert count == 2
+    end
+
+    test "returns {:ok, :disabled} when feature off", ctx do
+      disable_intel_sharing()
+
+      assert {:ok, :disabled} =
+               IntelSync.sync_all_visible_systems(
+                 ctx.subscriber_map.id,
+                 ctx.source_map.id
+               )
+    end
+  end
+end

--- a/test/unit/map/intel_sync_validation_test.exs
+++ b/test/unit/map/intel_sync_validation_test.exs
@@ -1,0 +1,78 @@
+defmodule WandererApp.Map.IntelSyncValidationTest do
+  use WandererApp.DataCase, async: false
+
+  import Mox
+  import WandererApp.MapTestHelpers
+
+  setup :verify_on_exit!
+
+  setup do
+    Mox.set_mox_global()
+    setup_ddrt_mocks()
+
+    user = insert(:user)
+    character = insert(:character, %{user_id: user.id})
+    map_a = insert(:map, %{owner_id: character.id})
+    map_b = insert(:map, %{owner_id: character.id})
+
+    # Load user with characters for get_user_role_for_map
+    {:ok, user_with_characters} = Ash.load(user, :characters)
+
+    %{
+      map_a: map_a,
+      map_b: map_b,
+      user: user_with_characters,
+      character: character
+    }
+  end
+
+  describe "get_user_role_for_map/2" do
+    test "returns :admin for map owner", ctx do
+      assert :admin == WandererApp.Maps.get_user_role_for_map(ctx.map_a, ctx.user)
+    end
+
+    test "returns nil for unrelated user", ctx do
+      other_user = insert(:user)
+      {:ok, other_user_with_characters} = Ash.load(other_user, :characters)
+
+      assert nil == WandererApp.Maps.get_user_role_for_map(ctx.map_a, other_user_with_characters)
+    end
+  end
+
+  describe "MapRepo.set_intel_source_map/2" do
+    test "succeeds for valid configuration", ctx do
+      {:ok, _updated} = WandererApp.MapRepo.set_intel_source_map(ctx.map_a, ctx.map_b.id)
+
+      # Reload and verify
+      {:ok, reloaded} = WandererApp.MapRepo.get(ctx.map_a.id)
+      assert reloaded.intel_source_map_id == ctx.map_b.id
+    end
+
+    test "can clear the source", ctx do
+      # Set it first
+      {:ok, _updated} = WandererApp.MapRepo.set_intel_source_map(ctx.map_a, ctx.map_b.id)
+
+      # Reload to get fresh record
+      {:ok, map_with_source} = WandererApp.MapRepo.get(ctx.map_a.id)
+      assert map_with_source.intel_source_map_id == ctx.map_b.id
+
+      # Clear it
+      {:ok, _cleared} = WandererApp.MapRepo.set_intel_source_map(map_with_source, nil)
+
+      # Reload and verify
+      {:ok, reloaded} = WandererApp.MapRepo.get(ctx.map_a.id)
+      assert reloaded.intel_source_map_id == nil
+    end
+
+    test "rejects setting a map as its own intel source", ctx do
+      result = WandererApp.MapRepo.set_intel_source_map(ctx.map_a, ctx.map_a.id)
+      assert {:error, _} = result
+    end
+
+    test "rejects a non-existent map ID as source", ctx do
+      fake_id = Ash.UUID.generate()
+      result = WandererApp.MapRepo.set_intel_source_map(ctx.map_a, fake_id)
+      assert {:error, _} = result
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Intel Source map linking in Map Settings, allowing managers to designate a source map for data synchronization.
  * Added sync button on solar system nodes to manually sync intel data from a linked source map.
  * Inherited comments and structures now display as read-only with "inherited" badge indicators.

* **Bug Fixes**
  * Corrected empty state message in comments section.

* **Improvements**
  * System details become read-only when a map has an intel source linked.
  * Intel data auto-syncs when systems are added or updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->