### PR TITLE
fix: corporation typeahead crash and silent ESI search failures

### DIFF
--- a/lib/wanderer_app/character.ex
+++ b/lib/wanderer_app/character.ex
@@ -173,30 +173,52 @@ defmodule WandererApp.Character do
     :ok
   end
 
+  @doc """
+  Searches EVE entities via ESI as `character_id`.
+
+  Returns `{:ok, results}` on success and `{:error, reason}` when the lookup
+  could not be performed — a missing character, or an ESI call that failed or
+  timed out.
+
+  A failed lookup deliberately does NOT collapse into `{:ok, []}`. Every caller
+  is a typeahead, and "ESI refused this request" rendered as an empty dropdown is
+  indistinguishable from "no such corporation": the user retypes the name they
+  know is correct and concludes the feature is broken. Callers that cannot act on
+  the reason should still degrade explicitly rather than by accident.
+
+  One gap remains by design: the per-hit detail lookups that turn ESI ids into
+  labels are best-effort, so a hit whose detail lookup fails is dropped from an
+  otherwise successful `{:ok, results}` rather than failing the search. Those
+  drops are logged.
+  """
   def search(character_id, opts \\ []) do
-    get_character(character_id)
-    |> case do
+    case get_character(character_id) do
       {:ok, %{access_token: access_token, eve_id: eve_id} = _character} ->
-        case WandererApp.Esi.search(eve_id |> String.to_integer(),
-               access_token: access_token,
-               character_id: character_id,
-               refresh_token?: true,
-               params: opts[:params]
-             ) do
+        WandererApp.Esi.search(eve_id |> String.to_integer(),
+          access_token: access_token,
+          character_id: character_id,
+          refresh_token?: true,
+          params: opts[:params]
+        )
+        |> case do
           {:ok, result} ->
-            {:ok, result |> prepare_search_results()}
+            {:ok, prepare_search_results(result)}
 
-          {:error, error} ->
-            Logger.warning("#{__MODULE__} failed search: #{inspect(error)}")
-            {:ok, []}
+          {:error, reason} ->
+            Logger.warning("#{__MODULE__} failed search: #{inspect(reason)}")
+            {:error, reason}
 
-          error ->
-            Logger.warning("#{__MODULE__} failed search: #{inspect(error)}")
-            {:ok, []}
+          other ->
+            Logger.warning("#{__MODULE__} failed search: #{inspect(other)}")
+            {:error, other}
         end
 
-      _error ->
-        {:ok, []}
+      other ->
+        Logger.warning(
+          "#{__MODULE__} search could not resolve character #{inspect(character_id)}: #{inspect(other)}"
+        )
+
+        {:error, :character_not_found}
     end
   end
 
@@ -327,21 +349,36 @@ defmodule WandererApp.Character do
 
   defp load_eve_info([], _, _), do: {:ok, []}
 
-  defp load_eve_info(eve_ids, method, map_function),
-    do:
-      {:ok,
-       Enum.map(eve_ids, fn eve_id ->
-         Task.async(fn -> apply(WandererApp.Esi, method, [eve_id]) end)
-       end)
-       # 145000 == Timeout in milliseconds
-       |> Enum.map(fn task -> Task.await(task, 145_000) end)
-       |> Enum.map(fn result ->
-         case result do
-           {:ok, result} -> map_function.(result)
-           _ -> nil
-         end
-       end)
-       |> Enum.filter(fn result -> not is_nil(result) end)}
+  defp load_eve_info(eve_ids, method, map_function) do
+    results =
+      eve_ids
+      |> Enum.map(fn eve_id ->
+        Task.async(fn -> apply(WandererApp.Esi, method, [eve_id]) end)
+      end)
+      # 145000 == Timeout in milliseconds
+      |> Enum.map(fn task -> Task.await(task, 145_000) end)
+      |> Enum.map(fn result ->
+        case result do
+          {:ok, result} -> map_function.(result)
+          _ -> nil
+        end
+      end)
+
+    # A hit whose detail lookup failed is dropped rather than failing the whole
+    # search: partial results still let the user pick the entity they wanted.
+    # Logged in aggregate (not per id) so an ESI outage costs one line per search
+    # rather than one per hit — without it, `search/2` answers `{:ok, []}` from a
+    # total detail-lookup failure and looks indistinguishable from "no matches".
+    dropped = Enum.count(results, &is_nil/1)
+
+    if dropped > 0 do
+      Logger.warning(
+        "#{__MODULE__} #{method} dropped #{dropped}/#{length(eve_ids)} search hits with failed detail lookups"
+      )
+    end
+
+    {:ok, Enum.reject(results, &is_nil/1)}
+  end
 
   defp map_alliance_info(info) do
     %{

--- a/lib/wanderer_app/esi/api_client.ex
+++ b/lib/wanderer_app/esi/api_client.ex
@@ -724,7 +724,20 @@ defmodule WandererApp.Esi.ApiClient do
             pool
           )
 
-        {:error, _error} ->
+        {:error, reason} ->
+          # The reason is deliberately logged rather than returned. It is the
+          # actionable half of the failure — `:invalid_grant` means "re-authorise
+          # this character", which is exactly what the corporation-search message
+          # tells the user — but `tracker.ex` and `transactions_tracker_impl.ex`
+          # branch on `{:error, :forbidden}` (see the
+          # `error in [:forbidden, :not_found, :timeout]` guards), so widening
+          # what this returns would silently change character-tracking behaviour.
+          # Surfacing it to callers needs those guards revisited first.
+          Logger.warning(
+            "TOKEN_REFRESH_FAILED: reporting #{inspect(status)} to caller, refresh reason was #{inspect(reason)}",
+            character_id: character_id
+          )
+
           {:error, status}
       end
     end
@@ -751,6 +764,31 @@ defmodule WandererApp.Esi.ApiClient do
     handle_refresh_token_result(refresh_token_result, character, character_id, expires_at, scopes)
   end
 
+  # Seconds since the access token expired, for logs and telemetry only.
+  #
+  # `expires_at` is a nullable `:integer` on `WandererApp.Api.Character`, so a
+  # character that has never completed an OAuth exchange carries `nil` — and
+  # since `is_access_token_expired?/1` reports exactly those characters as
+  # expired, they are routed straight into the refresh-and-retry path below.
+  # `DateTime.from_unix!(nil)` raises `FunctionClauseError`, which took down
+  # every authenticated ESI call for such a character (the corporation typeahead
+  # in map settings just swallowed it into an empty dropdown).
+  #
+  # Diagnostic timing must never be the thing that fails a request, so an
+  # unusable `expires_at` degrades to `nil` rather than raising.
+  #
+  # Public (like `is_access_token_expired?/1`) only so the regression test can
+  # reach it; it is not part of the module's API.
+  @doc false
+  def time_since_expiry(expires_at) when is_integer(expires_at) do
+    case DateTime.from_unix(expires_at) do
+      {:ok, datetime} -> DateTime.diff(DateTime.utc_now(), datetime, :second)
+      {:error, _reason} -> nil
+    end
+  end
+
+  def time_since_expiry(_expires_at), do: nil
+
   defp handle_refresh_token_result(
          {:ok, %OAuth2.AccessToken{} = token},
          character,
@@ -759,8 +797,7 @@ defmodule WandererApp.Esi.ApiClient do
          scopes
        ) do
     # Log token refresh success with timing info
-    expires_at_datetime = DateTime.from_unix!(expires_at)
-    time_since_expiry = DateTime.diff(DateTime.utc_now(), expires_at_datetime, :second)
+    time_since_expiry = time_since_expiry(expires_at)
 
     Logger.debug(
       fn ->
@@ -803,8 +840,7 @@ defmodule WandererApp.Esi.ApiClient do
          expires_at,
          scopes
        ) do
-    expires_at_datetime = DateTime.from_unix!(expires_at)
-    time_since_expiry = DateTime.diff(DateTime.utc_now(), expires_at_datetime, :second)
+    time_since_expiry = time_since_expiry(expires_at)
 
     # Track consecutive invalid_grant failures before permanently invalidating tokens.
     # EVE SSO can return invalid_grant for transient server issues, so we require
@@ -852,8 +888,7 @@ defmodule WandererApp.Esi.ApiClient do
          expires_at,
          _scopes
        ) do
-    expires_at_datetime = DateTime.from_unix!(expires_at)
-    time_since_expiry = DateTime.diff(DateTime.utc_now(), expires_at_datetime, :second)
+    time_since_expiry = time_since_expiry(expires_at)
 
     Logger.warning("TOKEN_REFRESH_FAILED: Connection refused during token refresh",
       character_id: character_id,
@@ -879,8 +914,7 @@ defmodule WandererApp.Esi.ApiClient do
          expires_at,
          _scopes
        ) do
-    time_since_expiry =
-      DateTime.diff(DateTime.utc_now(), DateTime.from_unix!(expires_at), :second)
+    time_since_expiry = time_since_expiry(expires_at)
 
     Logger.warning("TOKEN_REFRESH_FAILED: Transient OAuth2 error during token refresh",
       character_id: character_id,
@@ -898,8 +932,7 @@ defmodule WandererApp.Esi.ApiClient do
   end
 
   defp handle_refresh_token_result(error, _character, character_id, expires_at, _scopes) do
-    time_since_expiry =
-      DateTime.diff(DateTime.utc_now(), DateTime.from_unix!(expires_at), :second)
+    time_since_expiry = time_since_expiry(expires_at)
 
     Logger.warning("TOKEN_REFRESH_FAILED: Unexpected error during token refresh",
       character_id: character_id,

--- a/lib/wanderer_app/esi/corporation_search.ex
+++ b/lib/wanderer_app/esi/corporation_search.ex
@@ -36,8 +36,9 @@ defmodule WandererApp.Esi.CorporationSearch do
   Returns `{:ok, []}` when the user has no characters or the term is too short,
   so callers can render "no matches" without distinguishing those cases from a
   genuinely empty result. An ESI failure is passed through as `{:error, reason}`
-  — both callers degrade that to an empty dropdown, but the tuple is not
-  swallowed here.
+  and is not swallowed here — the map settings notifications tab turns that into
+  a visible message, while the system-settings dialog logs it and still renders
+  an empty dropdown.
 
   At most `max_results/0` hits are returned.
 
@@ -70,7 +71,23 @@ defmodule WandererApp.Esi.CorporationSearch do
     end
   end
 
-  def search(_characters, _search, _opts), do: {:ok, []}
+  # A list of characters with a search term that is not a binary is a real,
+  # expected state: the typeahead fires before anything has been typed. Answering
+  # `{:ok, []}` is correct there.
+  def search(characters, _search, _opts) when is_list(characters), do: {:ok, []}
+
+  # Anything else is a programming error, not a user state — most likely
+  # `characters` arriving as `%Ash.NotLoaded{}` from an unloaded association, or
+  # the arguments passed in the wrong order. This used to be folded into the
+  # `{:ok, []}` clause above, which reported success and rendered a permanently
+  # empty dropdown with nothing in the logs to explain it.
+  def search(characters, _search, _opts) do
+    Logger.warning(
+      "[CorporationSearch] search called with unusable characters: #{inspect(characters)}"
+    )
+
+    {:error, :invalid_characters}
+  end
 
   @doc """
   Human-readable label for a stored corporation id.

--- a/lib/wanderer_app_web/live/access_lists/access_lists_live.ex
+++ b/lib/wanderer_app_web/live/access_lists/access_lists_live.ex
@@ -378,9 +378,19 @@ defmodule WandererAppWeb.AccessListsLive do
     uniq_search_req_id = UUID.uuid4(:default)
 
     Task.async(fn ->
-      {:ok, options} = search(active_character_id, text)
+      # `search/2` reports an unusable ESI lookup as `{:error, reason}`. This task
+      # is linked to the LiveView, so hard-matching `{:ok, options}` here would
+      # turn a transient ESI failure into a crashed ACL session. Carry the failure
+      # back as data instead: the dropdown still empties, but the caller can tell
+      # "lookup failed" from "no such member" and say so.
+      case search(active_character_id, text) do
+        {:ok, options} ->
+          {:search_results, uniq_search_req_id, options, nil}
 
-      {:search_results, uniq_search_req_id, options}
+        {:error, reason} ->
+          Logger.warning("ACL member search failed: #{inspect(reason)}")
+          {:search_results, uniq_search_req_id, [], reason}
+      end
     end)
 
     {:noreply, socket |> assign(uniq_search_req_id: uniq_search_req_id)}
@@ -395,9 +405,23 @@ defmodule WandererAppWeb.AccessListsLive do
     Process.demonitor(ref, [:flush])
 
     case result do
-      {:search_results, ^uniq_search_req_id, options} ->
+      {:search_results, ^uniq_search_req_id, options, nil} ->
         send_update(LiveSelect.Component, options: options, id: member_search_id)
         {:noreply, socket |> assign(member_search_options: options)}
+
+      {:search_results, ^uniq_search_req_id, options, _reason} ->
+        # The dropdown is emptied either way, but without a flash an ESI outage
+        # is indistinguishable from "there is no such character or corporation",
+        # so the user retypes a name they know is correct.
+        send_update(LiveSelect.Component, options: options, id: member_search_id)
+
+        {:noreply,
+         socket
+         |> assign(member_search_options: options)
+         |> put_flash(
+           :error,
+           "Member search is unavailable right now. This lookup runs as one of your characters — if it keeps failing, re-authorise a character and try again."
+         )}
 
       _ ->
         {:noreply, socket}

--- a/lib/wanderer_app_web/live/map/event_handlers/map_systems_event_handler.ex
+++ b/lib/wanderer_app_web/live/map/event_handlers/map_systems_event_handler.ex
@@ -503,8 +503,15 @@ defmodule WandererAppWeb.MapSystemsEventHandler do
 
     response =
       case WandererApp.Esi.CorporationSearch.search(user_chars, search) do
-        {:ok, results} -> %{results: results}
-        _ -> %{results: []}
+        {:ok, results} ->
+          %{results: results}
+
+        other ->
+          # The reply shape stays `%{results: []}` because the JS consumers only
+          # read `.results`, but a failed ESI lookup must not be indistinguishable
+          # from "no such corporation" in the logs as well as in the dropdown.
+          Logger.warning("get_corporation_names failed: #{inspect(other)}")
+          %{results: []}
       end
 
     {:reply, response, socket}
@@ -516,8 +523,12 @@ defmodule WandererAppWeb.MapSystemsEventHandler do
 
     response =
       case search_alliance_names(user_chars, search) do
-        {:ok, results} -> %{results: results}
-        _ -> %{results: []}
+        {:ok, results} ->
+          %{results: results}
+
+        other ->
+          Logger.warning("get_alliance_names failed: #{inspect(other)}")
+          %{results: []}
       end
 
     {:reply, response, socket}

--- a/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
+++ b/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
@@ -28,6 +28,15 @@ defmodule WandererAppWeb.MapNotificationsComponent do
 
   @roles [:system, :character]
 
+  # Shown under the corporation box when the lookup itself failed, as opposed to
+  # succeeding with no matches.
+  @corp_search_error "Corporation search is unavailable right now. This lookup runs as one of your characters — if it keeps failing, re-authorise a character and try again."
+
+  # Shown under the excluded-systems box when the lookup itself failed. Unlike the
+  # corporation search this one never leaves the app, so a failure here means the
+  # database or the Ash read is unhealthy rather than anything the user can fix.
+  @system_search_error "System search is unavailable right now. Try again in a moment."
+
   @impl true
   def update(%{map_id: map_id} = assigns, socket) do
     notification =
@@ -44,7 +53,9 @@ defmodule WandererAppWeb.MapNotificationsComponent do
      |> assign(:min_search_length, @min_search_length)
      |> assign(:corp_min_search_length, CorporationSearch.min_search_length())
      |> assign_new(:system_options, fn -> [] end)
+     |> assign_new(:system_search_error, fn -> nil end)
      |> assign_new(:corp_options, fn -> [] end)
+     |> assign_new(:corp_search_error, fn -> nil end)
      |> assign_new(:error, fn -> nil end)
      |> assign_new(:flash_message, fn -> nil end)
      |> assign_notification(notification)}
@@ -144,19 +155,25 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   # fired. Answering unconditionally with system options would fill the
   # corporation dropdown with solar systems.
   def handle_event("live_select_change", %{"id" => @focus_corp_select_id, "text" => text}, socket) do
-    options = search_corporations(socket.assigns[:current_user], text)
+    {options, corp_search_error} = search_corporations(socket.assigns[:current_user], text)
 
     send_update(LiveSelect.Component, id: @focus_corp_select_id, options: options)
 
-    {:noreply, assign(socket, :corp_options, options)}
+    {:noreply,
+     socket
+     |> assign(:corp_options, options)
+     |> assign(:corp_search_error, corp_search_error)}
   end
 
   def handle_event("live_select_change", %{"id" => id, "text" => text}, socket) do
-    options = search_systems(text)
+    {options, system_search_error} = search_systems(text)
 
     send_update(LiveSelect.Component, id: id, options: options)
 
-    {:noreply, assign(socket, :system_options, options)}
+    {:noreply,
+     socket
+     |> assign(:system_options, options)
+     |> assign(:system_search_error, system_search_error)}
   end
 
   def handle_event("add-excluded", %{"excluded" => %{"excluded_system" => raw}}, socket) do
@@ -435,45 +452,58 @@ defmodule WandererAppWeb.MapNotificationsComponent do
 
   # Mirrors the ACL live_select pattern in maps_live: search server-side, feed
   # `{label, value}` options back into the component.
+  #
+  # Returns `{options, error_message_or_nil}` for the same reason
+  # `search_corporations/2` does: this is a database lookup that can fail, and an
+  # empty dropdown reads as "there is no system by that name".
   defp search_systems(text) when is_binary(text) and byte_size(text) >= @min_search_length do
     case MapSolarSystem.find_by_name(%{name: text}) do
       {:ok, systems} ->
-        systems
-        |> Enum.take(@max_search_results)
-        |> Enum.map(&{"#{&1.solar_system_name} (#{&1.region_name})", &1.solar_system_id})
+        {systems
+         |> Enum.take(@max_search_results)
+         |> Enum.map(&{"#{&1.solar_system_name} (#{&1.region_name})", &1.solar_system_id}), nil}
 
-      _ ->
-        []
+      other ->
+        Logger.warning("[MapNotifications] system search failed: #{inspect(other)}")
+        {[], @system_search_error}
     end
   end
 
-  defp search_systems(_), do: []
+  defp search_systems(_), do: {[], nil}
 
-  # `CorporationSearch.search/2` enforces its own minimum length and returns
+  # `CorporationSearch.search/3` enforces its own minimum length and returns
   # `{:ok, []}` for a user with no characters, so no length guard is needed here.
   #
+  # Returns `{options, error_message_or_nil}`. The distinction matters: this
+  # lookup leaves the app and can fail for reasons the user can act on (an ESI
+  # outage, a character whose token needs re-authorising), and an empty dropdown
+  # is indistinguishable from "that corporation does not exist". Reporting only
+  # into the log is what made a crash in the token-refresh path present as a
+  # typeahead that silently did nothing.
+  #
   # The rescue is not belt-and-braces: the search runs as one of the user's
-  # characters, and a character whose ESI token has never been refreshed makes
-  # `Character.search/2` raise. Unrescued that kills the LiveView on a keystroke
-  # in the corporation box, taking the whole settings tab with it. An empty
-  # dropdown is the right degradation for a lookup this component cannot fix.
+  # characters, and `Character.search/2` reaches ESI's token-refresh path.
+  # Unrescued, a raise there kills the LiveView on a keystroke in the
+  # corporation box, taking the whole settings tab with it.
   defp search_corporations(%{characters: characters}, text) when is_list(characters) do
     case CorporationSearch.search(characters, text) do
       {:ok, results} ->
-        results
-        |> Enum.take(@max_search_results)
-        |> Enum.map(&{&1.formatted, &1.id})
+        {results |> Enum.take(@max_search_results) |> Enum.map(&{&1.formatted, &1.id}), nil}
 
-      _ ->
-        []
+      {:error, reason} ->
+        Logger.warning("[MapNotifications] corporation search failed: #{inspect(reason)}")
+        {[], @corp_search_error}
     end
   rescue
     error ->
-      Logger.warning("[MapNotifications] corporation search failed: #{inspect(error)}")
-      []
+      Logger.warning(
+        "[MapNotifications] corporation search crashed: #{Exception.format(:error, error, __STACKTRACE__)}"
+      )
+
+      {[], @corp_search_error}
   end
 
-  defp search_corporations(_current_user, _text), do: []
+  defp search_corporations(_current_user, _text), do: {[], nil}
 
   # One query for every excluded system, not one per system. Falls back to the
   # bare id for anything the lookup did not return, and keeps the stored order.
@@ -616,7 +646,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
 
         <.input :if={@webhook} field={wf[:enabled]} type="checkbox" label="Enabled" />
 
-        <.button type="submit">{if @webhook, do: "Save", else: "Add"}</.button>
+        <.button type="submit" class="self-start">{if @webhook, do: "Save", else: "Add"}</.button>
       </.form>
 
       <div :if={@webhook} class="flex items-center gap-2">
@@ -631,7 +661,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         <.button
           :if={@removable?}
           type="button"
-          class="btn-error"
+          class="p-button-danger self-start"
           phx-click="remove-webhook"
           phx-value-role={@role}
           phx-target={@myself}
@@ -666,7 +696,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   @impl true
   def render(assigns) do
     ~H"""
-    <div id={@id} class="flex flex-col gap-4">
+    <div id={@id} class="flex max-w-3xl flex-col gap-4">
       <p class="text-sm opacity-70">
         Posts kills to Discord. These filters are separate from the Kills widget's
         own filters, which are per-user and only affect what you see in the map UI.
@@ -681,7 +711,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         id="discord-notification-form"
         phx-submit="save"
         phx-target={@myself}
-        class="flex flex-col gap-3"
+        class="flex flex-col gap-3 rounded border border-white/10 p-3"
       >
         <.input
           :if={is_nil(@notification)}
@@ -695,7 +725,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         <.input field={f[:wh_only]} type="checkbox" label="Only wormhole kills" />
         <.input field={f[:enabled]} type="checkbox" label="Enabled for this map" />
 
-        <.button type="submit">Save</.button>
+        <.button type="submit" class="self-start">Save</.button>
       </.form>
 
       <.webhook_row
@@ -725,7 +755,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         myself={@myself}
       />
 
-      <div :if={@notification} class="flex flex-col gap-2">
+      <div :if={@notification} class="flex flex-col gap-2 rounded border border-white/10 p-3">
         <h4 class="text-sm font-semibold">Excluded systems</h4>
 
         <ul class="flex flex-col gap-1">
@@ -749,7 +779,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
           phx-submit="add-excluded"
           phx-target={@myself}
           class="grid items-end gap-2"
-          style="grid-template-columns: 1fr auto"
+          style="grid-template-columns: minmax(0, 24rem) auto"
         >
           <.live_select
             field={ef[:excluded_system]}
@@ -764,9 +794,11 @@ defmodule WandererAppWeb.MapNotificationsComponent do
           />
           <.button type="submit">Add</.button>
         </.form>
+
+        <p :if={@system_search_error} class="text-sm text-amber-400">{@system_search_error}</p>
       </div>
 
-      <div :if={@notification} class="flex flex-col gap-2">
+      <div :if={@notification} class="flex flex-col gap-2 rounded border border-white/10 p-3">
         <h4 class="text-sm font-semibold">Focus corporations</h4>
         <p class="text-xs opacity-70">
           Kills involving these corporations are treated as relevant even when the
@@ -802,7 +834,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
           phx-submit="add-focus-corp"
           phx-target={@myself}
           class="grid items-end gap-2"
-          style="grid-template-columns: 1fr auto"
+          style="grid-template-columns: minmax(0, 24rem) auto"
         >
           <.live_select
             field={cf[:focus_corp]}
@@ -817,12 +849,14 @@ defmodule WandererAppWeb.MapNotificationsComponent do
           />
           <.button type="submit">Add</.button>
         </.form>
+
+        <p :if={@corp_search_error} class="text-sm text-amber-400">{@corp_search_error}</p>
       </div>
 
       <div :if={@notification} class="flex items-center gap-2">
         <.button
           type="button"
-          class="btn-error"
+          class="p-button-danger self-start"
           phx-click="delete"
           phx-target={@myself}
           data-confirm="Remove Discord notifications for this map?"

--- a/test/unit/esi/api_client_token_expiry_test.exs
+++ b/test/unit/esi/api_client_token_expiry_test.exs
@@ -64,4 +64,40 @@ defmodule WandererApp.Esi.ApiClientTokenExpiryTest do
     # "row absent".
     assert ApiClient.is_access_token_expired?(Ecto.UUID.generate())
   end
+
+  describe "time_since_expiry/1" do
+    # `is_access_token_expired?/1` reports a nil `expires_at` as expired, which
+    # sends exactly those characters down the refresh-and-retry path. Every
+    # `handle_refresh_token_result/5` clause there logs how long ago the token
+    # expired, and computing that with `DateTime.from_unix!/1` raised
+    # `FunctionClauseError` on the same nil the predicate above tolerates.
+    #
+    # The visible symptom was the corporation typeahead in map settings: the
+    # LiveView rescued the raise and rendered an empty dropdown, so the search
+    # looked like it returned no matches instead of like it had crashed.
+
+    test "returns elapsed seconds for a timestamp in the past" do
+      assert ApiClient.time_since_expiry(unix_now() - 60) in 59..61
+    end
+
+    test "returns a negative value for a timestamp in the future" do
+      assert ApiClient.time_since_expiry(unix_now() + 60) in -61..-59
+    end
+
+    test "returns nil for a nil expires_at rather than raising" do
+      assert ApiClient.time_since_expiry(nil) == nil
+    end
+
+    test "returns nil for a non-integer expires_at rather than raising" do
+      # Belt-and-braces for shapes the cache could hold after a schema change:
+      # this value is only ever used as log/telemetry metadata, so no shape of it
+      # is worth failing an ESI call over.
+      assert ApiClient.time_since_expiry(DateTime.utc_now()) == nil
+      assert ApiClient.time_since_expiry("1700000000") == nil
+    end
+
+    test "returns nil for an out-of-range unix timestamp rather than raising" do
+      assert ApiClient.time_since_expiry(1_000_000_000_000_000_000_000) == nil
+    end
+  end
 end

--- a/test/unit/esi/corporation_search_test.exs
+++ b/test/unit/esi/corporation_search_test.exs
@@ -20,6 +20,20 @@ defmodule WandererApp.Esi.CorporationSearchTest do
       assert {:ok, []} = CorporationSearch.search([%{id: Ecto.UUID.generate()}], nil)
     end
 
+    test "reports unusable characters as an error rather than as no results" do
+      # `MapSystemsEventHandler` passes `current_user.characters` straight
+      # through, so an unloaded association reaches here as `%Ash.NotLoaded{}`.
+      # Answering `{:ok, []}` rendered a permanently empty dropdown that looked
+      # exactly like "no corporation by that name", with nothing in the logs.
+      assert {:error, :invalid_characters} =
+               CorporationSearch.search(%Ash.NotLoaded{}, "Karmafleet")
+    end
+
+    test "reports swapped arguments as an error rather than as no results" do
+      assert {:error, :invalid_characters} =
+               CorporationSearch.search("Karmafleet", [%{id: Ecto.UUID.generate()}])
+    end
+
     test "min_search_length is three, matching the pre-extraction behaviour" do
       assert CorporationSearch.min_search_length() == 3
     end

--- a/test/wanderer_app_web/live/map_notifications_test.exs
+++ b/test/wanderer_app_web/live/map_notifications_test.exs
@@ -639,6 +639,47 @@ defmodule WandererAppWeb.MapNotificationsTest do
     refute render(view) =~ "Jita (The Forge)"
   end
 
+  test "a corporation keystroke reports a failed lookup instead of an empty dropdown", %{
+    conn: conn,
+    map: map
+  } do
+    notification_with_webhooks(map, [:system])
+
+    view = open_notifications(conn, map)
+
+    # `Factory.create_character/1` builds through the `:link` action, which accepts
+    # only [:eve_id, :name, :user_id] — so the character has no access token and a
+    # nil `expires_at`, exactly like an account that never completed an OAuth
+    # exchange. `is_access_token_expired?/1` reports nil as expired, so this
+    # keystroke goes down ESI's refresh-and-retry path.
+    #
+    # That path used to compute its log timing with `DateTime.from_unix!(nil)` and
+    # raise FunctionClauseError, which `search_corporations/2` rescued into `[]`.
+    # The dropdown then looked exactly like a search with no matches, which is why
+    # the typeahead appeared to do nothing at all rather than to be broken.
+    log =
+      capture_log(fn ->
+        view
+        |> with_target("#map-notifications")
+        |> render_change("live_select_change", %{
+          "id" => "focus_corp_live_select_component",
+          "text" => "Hard Knocks",
+          "field" => "focus_corp"
+        })
+      end)
+
+    refute log =~ "FunctionClauseError"
+    refute log =~ "DateTime.from_unix"
+
+    # Unconditional on purpose. `setup` gives this user exactly one character and
+    # it has no access token, so the lookup cannot succeed however the test host
+    # is configured — with no network egress the HTTP call fails, and with egress
+    # EVE SSO rejects the nil refresh token. Guarding this assertion on the log
+    # contents would let it pass vacuously the moment the keystroke stopped
+    # reaching the search at all, which is the exact regression it guards.
+    assert render(view) =~ "Corporation search is unavailable right now."
+  end
+
   test "send test message reports the global kill-switch", %{conn: conn, map: map} do
     notification_with_webhooks(map, [:system])
 


### PR DESCRIPTION
Fixes the two issues reported against the notifications feature in `e791d4e1`.

## The typeahead was crashing, not returning nothing

The cause was not in the LiveComponent. `e791d4e1` correctly fixed `is_access_token_expired?/1` to report a nil `expires_at` as expired instead of raising — but that means characters with a nil `expires_at` are now *routed into* `handle_refresh_token_result/5`, and all five of its clauses opened by computing a `time_since_expiry` log field with `DateTime.from_unix!(expires_at)`. `DateTime.from_unix!(nil)` raises `FunctionClauseError`.

So every authenticated ESI call for such a character died, and `search_corporations/2`'s `rescue` turned that into `[]` — visually identical to "no corporation by that name".

`time_since_expiry/1` now degrades to `nil` for any unusable value. This is on the path of **every** authenticated ESI call, not just search, so it is the main thing worth reviewing.

## Failed lookups were indistinguishable from empty ones

`Character.search/2` collapsed ESI errors into `{:ok, []}`, so nothing above it could tell the two apart. It now returns `{:error, reason}`, and every caller is updated:

| Caller | Behavior |
|---|---|
| Notifications tab | visible message |
| ACL member search | flash + empty dropdown |
| Map systems handler | logs; reply shape unchanged (JS reads only `.results`) |

`CorporationSearch.search/3` also stopped reporting `{:ok, []}` for an unusable `characters` argument — that clause is how an `%Ash.NotLoaded{}` association produced a permanently empty dropdown with nothing in the logs. The same treatment was applied to the excluded-systems picker next door.

`api_client.ex` logs the discarded refresh reason but deliberately still returns `{:error, status}`: `tracker.ex` and `transactions_tracker_impl.ex` branch on `{:error, :forbidden}`, so widening the return value would silently change character-tracking behavior.

## UI

- Buttons stretched full width — flex `align-items: stretch`; fixed with `self-start`
- Labels misaligned — form columns are now `minmax(0, 24rem) auto` instead of `1fr auto`
- Colors — `btn-error` is DaisyUI and inert in this theme without `.btn`; replaced with PrimeReact `p-button-danger`. Sections are bordered and the panel is `max-w-3xl`

## Tests

Added regression coverage for `time_since_expiry/1` (5 cases), the `CorporationSearch` error contract (2 cases), and one asserting the corporation keystroke produces a visible failure rather than an empty dropdown.

Worth noting: the pre-existing test at `map_notifications_test.exs:605` asserts only that corp search does not return *systems*, so it passed against a typeahead that returned nothing at all.

## Verification

- `mix test test/unit/esi test/unit/character test/wanderer_app_web` → **117 tests, 0 failures**
- `mix format` applied; `mix credo` reports only pre-existing findings on untouched lines
- The full suite has **7 failures in `auth_controller_test.exs` and `slug_recovery_test.exs`** — confirmed pre-existing by stashing this branch's changes and re-running against `e791d4e1`

**Not verified:** the UI changes have not been checked in a browser. They are reasoned from the Tailwind/PrimeReact classes and the reported screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)