### PR TITLE
fix: stop Add buttons stretching and surface the corp-search failure reason

### DIFF
--- a/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
+++ b/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
@@ -32,6 +32,15 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   # succeeding with no matches.
   @corp_search_error "Corporation search is unavailable right now. This lookup runs as one of your characters — if it keeps failing, re-authorise a character and try again."
 
+  # The failure reason is rendered alongside the message rather than only logged.
+  # This surface is map-admin-only and the reasons are ESI status atoms
+  # (`:forbidden`, `:not_found`, `:timeout`, `:error_limited`), not secrets.
+  # Without it the banner is identical for "this character needs re-authorising"
+  # and "ESI is rate-limiting us", which is the difference between a user-fixable
+  # problem and one they should wait out — and it makes the failure diagnosable
+  # from a screenshot instead of requiring server log access.
+  defp corp_search_error(reason), do: "#{@corp_search_error} (#{inspect(reason)})"
+
   # Shown under the excluded-systems box when the lookup itself failed. Unlike the
   # corporation search this one never leaves the app, so a failure here means the
   # database or the Ash read is unhealthy rather than anything the user can fix.
@@ -492,7 +501,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
 
       {:error, reason} ->
         Logger.warning("[MapNotifications] corporation search failed: #{inspect(reason)}")
-        {[], @corp_search_error}
+        {[], corp_search_error(reason)}
     end
   rescue
     error ->
@@ -500,7 +509,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         "[MapNotifications] corporation search crashed: #{Exception.format(:error, error, __STACKTRACE__)}"
       )
 
-      {[], @corp_search_error}
+      {[], corp_search_error(error.__struct__)}
   end
 
   defp search_corporations(_current_user, _text), do: {[], nil}
@@ -779,7 +788,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
           phx-submit="add-excluded"
           phx-target={@myself}
           class="grid items-end gap-2"
-          style="grid-template-columns: minmax(0, 24rem) auto"
+          style="grid-template-columns: minmax(0, 24rem) max-content"
         >
           <.live_select
             field={ef[:excluded_system]}
@@ -834,7 +843,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
           phx-submit="add-focus-corp"
           phx-target={@myself}
           class="grid items-end gap-2"
-          style="grid-template-columns: minmax(0, 24rem) auto"
+          style="grid-template-columns: minmax(0, 24rem) max-content"
         >
           <.live_select
             field={cf[:focus_corp]}

--- a/test/wanderer_app_web/live/map_notifications_test.exs
+++ b/test/wanderer_app_web/live/map_notifications_test.exs
@@ -678,6 +678,14 @@ defmodule WandererAppWeb.MapNotificationsTest do
     # contents would let it pass vacuously the moment the keystroke stopped
     # reaching the search at all, which is the exact regression it guards.
     assert render(view) =~ "Corporation search is unavailable right now."
+
+    # The reason has to reach the page, not just the log. The generic sentence
+    # alone cannot distinguish "re-authorise this character" from "ESI is
+    # rate-limiting us", and reading it off a screenshot is the only diagnostic
+    # available for a deployment whose logs we cannot see. Asserting on the
+    # parenthesised suffix rather than a specific atom keeps this independent of
+    # whichever failure the test host produces.
+    assert render(view) =~ ~r/Corporation search is unavailable right now\..*\(.+\)/s
   end
 
   test "send test message reports the global kill-switch", %{conn: conn, map: map} do


### PR DESCRIPTION
Follow-up to #103, which did not close either reported issue.

## 1. "Add" buttons still spanned the panel — fixed at the root cause

`grid-template-columns: minmax(0, 24rem) auto` on the two forms: an `auto` track absorbs all leftover free space, and a grid item defaults to `justify-self: stretch`. So each button filled:

```
768 (max-w-3xl) − 24 (p-3) − 384 (24rem input) − 8 (gap-2) = 352px
```

Measured against `notifier.jpg` (image scaled ~1.6×): panel 1228→768, input 614→384, button 561→350. Both known values land exactly, which is what confirms the arithmetic rather than assuming it.

`self-start`, added in #103, sets `align-self` — the cross axis. It worked for the buttons in the flex containers but could never have constrained width inside a grid. The second track is now `max-content`.

Deliberately an inline style, not a `justify-self-start` class: #103's UI miss came from reasoning about Tailwind classes that may not be in the built bundle, and an inline style has no such dependency.

## 2. Corporation search still fails — the reason is now visible

The banner from #103 **is** rendering in production, so the error-propagation half of #103 works. But it printed the same sentence for every cause, leaving the actual reason only in the server logs.

Traced the whole path this time and found no deterministic defect:
- `/characters/{id}/search` with `categories=corporation` is valid — verified against the live ESI swagger (`corporation` is in the enum) and by probing the URL, which returns **401 (auth layer reached)**, not 404/400.
- `esi-search.search_structures.v1` is present in all three scope tiers in `config.exs` / `runtime.exs`.
- `do_get_retry/5` correctly merges the *refreshed* bearer token — no stale-token bug.

That leaves a genuine token/authorization failure for the specific character, which cannot be identified without the reason. So the banner now renders it. `:forbidden` (re-authorise the character) and `:error_limited` (wait it out) call for opposite user responses. Map-admin-only surface; the reasons are ESI status atoms, not secrets.

**This is instrumentation, not a fix for issue 2.** Per systematic debugging, no fix without a confirmed root cause — the next screenshot will name it.

## Verification

- `mix test` on the three affected files: **57 tests, 0 failures**
- New assertion that the reason reaches the page, not just the log
- `mix compile` clean for both changed files (remaining warnings are pre-existing, in unrelated files)
- **Not verified in a browser** — no browser or running server in this environment. The button fix rests on the arithmetic above rather than a rendered check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)