### PR TITLE
fix(json-api): correct JsonApiFormatter payload contract against real producers

### DIFF
--- a/lib/wanderer_app/external_events.ex
+++ b/lib/wanderer_app/external_events.ex
@@ -40,16 +40,22 @@ defmodule WandererApp.ExternalEvents do
 
   ## Examples
 
-      # System events
+      # System events - see map_server_systems_impl.ex
       WandererApp.ExternalEvents.broadcast("map_123", :add_system, %{
+        system_id: "0198f0a1-2222-7000-8000-000000000002",
         solar_system_id: 31000199,
-        name: "J123456"
+        name: "J123456",
+        position_x: 100,
+        position_y: 200
       })
 
-      # Kill events
+      # Kill events carry a BATCH of killmails, not a single kill -
+      # see kills/message_handler.ex:126
       WandererApp.ExternalEvents.broadcast("map_123", :map_kill, %{
-        killmail_id: 98765,
-        victim_ship_type: "Rifter"
+        "solar_system_id" => 31000199,
+        "killmails" => [%{"killmail_id" => 98765, "victim_ship_name" => "Rifter"}],
+        "timestamp" => "2026-08-04T12:00:00Z",
+        "type" => :killmail_update
       })
   """
   @spec broadcast(String.t(), Event.event_type(), map()) :: :ok

--- a/lib/wanderer_app/external_events.ex
+++ b/lib/wanderer_app/external_events.ex
@@ -13,8 +13,11 @@ defmodule WandererApp.ExternalEvents do
 
       # From event producers, call this in ADDITION to existing broadcasts
       WandererApp.ExternalEvents.broadcast("map_123", :add_system, %{
+        system_id: "0198f0a1-2222-7000-8000-000000000002",
         solar_system_id: 31000199,
-        name: "J123456"
+        name: "J123456",
+        position_x: 100,
+        position_y: 200
       })
 
   This is additive-only and does not replace any existing functionality.

--- a/lib/wanderer_app/external_events/json_api_formatter.ex
+++ b/lib/wanderer_app/external_events/json_api_formatter.ex
@@ -58,7 +58,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
 
   # Event-specific resource data formatting
   #
-  # Producer: map_server_systems_impl.ex:636, :690 and :902. The :902 variant
+  # Producer: map_server_systems_impl.ex:673, :729 and :943. The :943 variant
   # omits :name, so that attribute is legitimately nil there.
   defp format_resource_data(%Event{type: :add_system, payload: payload} = event) do
     {type, id} = system_identity(event, payload)
@@ -77,7 +77,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
     }
   end
 
-  # Producer: map_server_systems_impl.ex:348. name/position_x/position_y are
+  # Producer: map_server_systems_impl.ex:385. name/position_x/position_y are
   # deliberately sent as nil and are omitted here rather than echoed as nulls.
   defp format_resource_data(%Event{type: :deleted_system, payload: payload} = event) do
     {type, id} = system_identity(event, payload)
@@ -113,7 +113,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
     }
   end
 
-  # Producer: map_server_systems_impl.ex:1119
+  # Producer: map_server_systems_impl.ex:1187
   defp format_resource_data(%Event{type: :system_metadata_changed, payload: payload} = event) do
     {type, id} = system_identity(event, payload)
 
@@ -197,7 +197,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
     }
   end
 
-  # Producer: map_server_connections_impl.ex:748. Endpoints are EVE solar
+  # Producer: map_server_connections_impl.ex:779. Endpoints are EVE solar
   # system ids, so they are attributes: no map_systems UUID is available.
   defp format_resource_data(%Event{type: :connection_added, payload: payload} = event) do
     %{
@@ -218,7 +218,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
     }
   end
 
-  # Producer: map_server_connections_impl.ex:1083
+  # Producer: map_server_connections_impl.ex:1104
   defp format_resource_data(%Event{type: :connection_removed, payload: payload} = event) do
     %{
       "type" => "map_connections",
@@ -235,7 +235,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
     }
   end
 
-  # Producer: map_server_connections_impl.ex:1140
+  # Producer: map_server_connections_impl.ex:1161
   defp format_resource_data(%Event{type: :connection_updated, payload: payload} = event) do
     %{
       "type" => "map_connections",
@@ -256,7 +256,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
     }
   end
 
-  # Producer: map_server_characters_impl.ex:1030 and :1041. The payload is a
+  # Producer: map_server_characters_impl.ex:1037 and :1048. The payload is a
   # WandererApp.Api.Character struct - fields are projected through
   # @character_attribute_keys so tokens can never reach the wire.
   defp format_resource_data(%Event{type: :character_added, payload: payload} = event) do
@@ -293,7 +293,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
     }
   end
 
-  # Producer: map_server_characters_impl.ex:485. Sends %{characters: [...]},
+  # Producer: map_server_characters_impl.ex:486. Sends %{characters: [...]},
   # a list of Api.Character structs, so `data` is an array.
   defp format_resource_data(%Event{type: :characters_updated, payload: payload} = event) do
     payload
@@ -371,7 +371,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
 
   # Producer: kills/message_handler.ex:126. The payload is a BATCH -
   # %{"solar_system_id", "killmails", "timestamp", "type"} - and every
-  # per-kill field lives on the elements of "killmails" (built at :296-346).
+  # per-kill field lives on the elements of "killmails" (built at :298-350).
   #
   # Guard on presence of the key, not on its value: a batch that legitimately
   # carries no kills must render as [], and a present-but-nil "killmails" is a

--- a/lib/wanderer_app/external_events/json_api_formatter.ex
+++ b/lib/wanderer_app/external_events/json_api_formatter.ex
@@ -136,49 +136,64 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
     }
   end
 
+  # Producer: map_server_signatures_impl.ex:148 and :159.
+  #
+  # The producer sends sig.eve_id - the in-game signature code, not the record
+  # UUID. api/map_system_signature.ex is uuid_primary_key with eve_id unique
+  # only as identity :uniq_system_eve_id, [:system_id, :eve_id], so the code
+  # neither resolves as a map_system_signatures id nor is globally unique.
+  # Identity is therefore the event ULID and the code is an attribute.
   defp format_resource_data(%Event{type: :signature_added, payload: payload} = event) do
     %{
-      "type" => "map_system_signatures",
-      "id" => payload["signature_id"] || payload[:signature_id],
+      "type" => "signature_events",
+      "id" => event.id,
       "attributes" => %{
-        "signature_id" => payload["signature_identifier"] || payload[:signature_identifier],
-        "signature_type" => payload["signature_type"] || payload[:signature_type],
-        "name" => payload["name"] || payload[:name],
+        "solar_system_id" => fetch(payload, :solar_system_id),
+        "signature_id" => fetch(payload, :signature_id),
+        "name" => fetch(payload, :name),
+        "kind" => fetch(payload, :kind),
+        "group" => fetch(payload, :group),
+        # The producer key is :type; renamed on the wire because JSON:API
+        # forbids an attribute named "type".
+        "signature_type" => fetch(payload, :type),
         "created_at" => event.timestamp
       },
-      "relationships" => %{
-        "system" => %{
-          "data" => %{
-            "type" => "map_systems",
-            "id" => payload["system_id"] || payload[:system_id]
-          }
-        },
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
-      }
+      "relationships" => %{"map" => map_relationship(event)}
     }
   end
 
+  # Producer: map_server_signatures_impl.ex:159 and :245. Sends only
+  # solar_system_id and signature_id.
   defp format_resource_data(%Event{type: :signature_removed, payload: payload} = event) do
     %{
-      "type" => "map_system_signatures",
-      "id" => payload["signature_id"] || payload[:signature_id],
+      "type" => "signature_events",
+      "id" => event.id,
+      "attributes" => %{
+        "solar_system_id" => fetch(payload, :solar_system_id),
+        "signature_id" => fetch(payload, :signature_id)
+      },
       "meta" => %{
         "deleted" => true,
         "deleted_at" => event.timestamp
       },
-      "relationships" => %{
-        "system" => %{
-          "data" => %{
-            "type" => "map_systems",
-            "id" => payload["system_id"] || payload[:system_id]
-          }
-        },
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
-      }
+      "relationships" => %{"map" => map_relationship(event)}
+    }
+  end
+
+  # Producer: map_server_signatures_impl.ex:166 and :250. A summary event that
+  # names no single signature, so the event ULID is the identity.
+  defp format_resource_data(%Event{type: :signatures_updated, payload: payload} = event) do
+    %{
+      "type" => "signature_updates",
+      "id" => event.id,
+      "attributes" => %{
+        "solar_system_id" => fetch(payload, :solar_system_id),
+        "added_count" => fetch(payload, :added_count),
+        "updated_count" => fetch(payload, :updated_count),
+        "removed_count" => fetch(payload, :removed_count),
+        "updated_at" => event.timestamp
+      },
+      "relationships" => %{"map" => map_relationship(event)}
     }
   end
 

--- a/lib/wanderer_app/external_events/json_api_formatter.ex
+++ b/lib/wanderer_app/external_events/json_api_formatter.ex
@@ -197,70 +197,62 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
     }
   end
 
+  # Producer: map_server_connections_impl.ex:748. Endpoints are EVE solar
+  # system ids, so they are attributes: no map_systems UUID is available.
   defp format_resource_data(%Event{type: :connection_added, payload: payload} = event) do
     %{
       "type" => "map_connections",
-      "id" => payload["connection_id"] || payload[:connection_id],
+      "id" => rid(fetch(payload, :connection_id)),
       "attributes" => %{
-        "type" => payload["type"] || payload[:type],
-        "time_status" => payload["time_status"] || payload[:time_status],
-        "mass_status" => payload["mass_status"] || payload[:mass_status],
-        "ship_size_type" => payload["ship_size_type"] || payload[:ship_size_type],
+        "solar_system_source_id" => fetch(payload, :solar_system_source_id),
+        "solar_system_target_id" => fetch(payload, :solar_system_target_id),
+        # The producer key is :type; renamed on the wire because JSON:API
+        # forbids an attribute named "type".
+        "connection_type" => fetch(payload, :type),
+        "ship_size_type" => fetch(payload, :ship_size_type),
+        "mass_status" => fetch(payload, :mass_status),
+        "time_status" => fetch(payload, :time_status),
         "created_at" => event.timestamp
       },
-      "relationships" => %{
-        "solar_system_source" => %{
-          "data" => %{
-            "type" => "map_systems",
-            "id" => payload["solar_system_source"] || payload[:solar_system_source]
-          }
-        },
-        "solar_system_target" => %{
-          "data" => %{
-            "type" => "map_systems",
-            "id" => payload["solar_system_target"] || payload[:solar_system_target]
-          }
-        },
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
-      }
+      "relationships" => %{"map" => map_relationship(event)}
     }
   end
 
+  # Producer: map_server_connections_impl.ex:1083
   defp format_resource_data(%Event{type: :connection_removed, payload: payload} = event) do
     %{
       "type" => "map_connections",
-      "id" => payload["connection_id"] || payload[:connection_id],
+      "id" => rid(fetch(payload, :connection_id)),
+      "attributes" => %{
+        "solar_system_source_id" => fetch(payload, :solar_system_source_id),
+        "solar_system_target_id" => fetch(payload, :solar_system_target_id)
+      },
       "meta" => %{
         "deleted" => true,
         "deleted_at" => event.timestamp
       },
-      "relationships" => %{
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
-      }
+      "relationships" => %{"map" => map_relationship(event)}
     }
   end
 
+  # Producer: map_server_connections_impl.ex:1140
   defp format_resource_data(%Event{type: :connection_updated, payload: payload} = event) do
     %{
       "type" => "map_connections",
-      "id" => payload["connection_id"] || payload[:connection_id],
+      "id" => rid(fetch(payload, :connection_id)),
       "attributes" => %{
-        "type" => payload["type"] || payload[:type],
-        "time_status" => payload["time_status"] || payload[:time_status],
-        "mass_status" => payload["mass_status"] || payload[:mass_status],
-        "ship_size_type" => payload["ship_size_type"] || payload[:ship_size_type],
-        "locked" => payload["locked"] || payload[:locked],
+        "solar_system_source_id" => fetch(payload, :solar_system_source_id),
+        "solar_system_target_id" => fetch(payload, :solar_system_target_id),
+        # Renamed from the producer's :type - JSON:API reserves "type".
+        "connection_type" => fetch(payload, :type),
+        "ship_size_type" => fetch(payload, :ship_size_type),
+        "mass_status" => fetch(payload, :mass_status),
+        "time_status" => fetch(payload, :time_status),
+        "locked" => fetch(payload, :locked),
+        "custom_info" => fetch(payload, :custom_info),
         "updated_at" => event.timestamp
       },
-      "relationships" => %{
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
-      }
+      "relationships" => %{"map" => map_relationship(event)}
     }
   end
 

--- a/lib/wanderer_app/external_events/json_api_formatter.ex
+++ b/lib/wanderer_app/external_events/json_api_formatter.ex
@@ -256,74 +256,57 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
     }
   end
 
+  # Producer: map_server_characters_impl.ex:1030 and :1041. The payload is a
+  # WandererApp.Api.Character struct - fields are projected through
+  # @character_attribute_keys so tokens can never reach the wire.
   defp format_resource_data(%Event{type: :character_added, payload: payload} = event) do
     %{
       "type" => "characters",
-      "id" => payload["character_id"] || payload[:character_id],
-      "attributes" => %{
-        "eve_id" => payload["eve_id"] || payload[:eve_id],
-        "name" => payload["name"] || payload[:name],
-        "corporation_name" => payload["corporation_name"] || payload[:corporation_name],
-        "corporation_ticker" => payload["corporation_ticker"] || payload[:corporation_ticker],
-        "added_at" => event.timestamp
-      },
-      "relationships" => %{
-        "system" => %{
-          "data" => %{
-            "type" => "map_systems",
-            "id" => payload["system_id"] || payload[:system_id]
-          }
-        },
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
-      }
+      "id" => rid(fetch(payload, :id)),
+      "attributes" => Map.put(character_attrs(payload), "added_at", event.timestamp),
+      "relationships" => %{"map" => map_relationship(event)}
     }
   end
 
+  # Producer: map_server_characters_impl.ex:301. Also an Api.Character struct.
   defp format_resource_data(%Event{type: :character_removed, payload: payload} = event) do
     %{
       "type" => "characters",
-      "id" => payload["character_id"] || payload[:character_id],
+      "id" => rid(fetch(payload, :id)),
+      "attributes" => character_attrs(payload),
       "meta" => %{
-        "removed_from_system" => true,
+        "removed" => true,
         "removed_at" => event.timestamp
       },
-      "relationships" => %{
-        "system" => %{
-          "data" => %{
-            "type" => "map_systems",
-            "id" => payload["system_id"] || payload[:system_id]
-          }
-        },
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
-      }
+      "relationships" => %{"map" => map_relationship(event)}
     }
   end
 
+  # No producer for :character_updated exists in lib/. Field-enumerated anyway
+  # so that a future producer cannot leak a raw struct through this clause.
   defp format_resource_data(%Event{type: :character_updated, payload: payload} = event) do
     %{
       "type" => "characters",
-      "id" => payload["character_id"] || payload[:character_id],
-      "attributes" => %{
-        "ship_type_id" => payload["ship_type_id"] || payload[:ship_type_id],
-        "ship_name" => payload["ship_name"] || payload[:ship_name],
-        "updated_at" => event.timestamp
-      },
-      "relationships" => %{
-        "system" => %{
-          "data" => %{
-            "type" => "map_systems",
-            "id" => payload["system_id"] || payload[:system_id]
-          }
-        },
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
-      }
+      "id" => rid(fetch(payload, :id)),
+      "attributes" => Map.put(character_attrs(payload), "updated_at", event.timestamp),
+      "relationships" => %{"map" => map_relationship(event)}
     }
+  end
+
+  # Producer: map_server_characters_impl.ex:485. Sends %{characters: [...]},
+  # a list of Api.Character structs, so `data` is an array.
+  defp format_resource_data(%Event{type: :characters_updated, payload: payload} = event) do
+    payload
+    |> fetch(:characters)
+    |> List.wrap()
+    |> Enum.map(fn character ->
+      %{
+        "type" => "characters",
+        "id" => rid(fetch(character, :id)),
+        "attributes" => Map.put(character_attrs(character), "updated_at", event.timestamp),
+        "relationships" => %{"map" => map_relationship(event)}
+      }
+    end)
   end
 
   defp format_resource_data(%Event{type: :acl_member_added, payload: payload} = event) do

--- a/lib/wanderer_app/external_events/json_api_formatter.ex
+++ b/lib/wanderer_app/external_events/json_api_formatter.ex
@@ -369,29 +369,50 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
     }
   end
 
+  # Producer: kills/message_handler.ex:126. The payload is a BATCH -
+  # %{"solar_system_id", "killmails", "timestamp", "type"} - and every
+  # per-kill field lives on the elements of "killmails" (built at :296-346).
+  #
+  # Guard on presence of the key, not on its value: a batch that legitimately
+  # carries no kills must render as [], and a present-but-nil "killmails" is a
+  # malformed batch rather than a kill count. fetch/2 cannot tell absent from
+  # present-nil, so dispatch on has_key?/2.
   defp format_resource_data(%Event{type: :map_kill, payload: payload} = event) do
-    %{
-      "type" => "kills",
-      "id" => payload["killmail_id"] || payload[:killmail_id],
-      "attributes" => %{
-        "killmail_id" => payload["killmail_id"] || payload[:killmail_id],
-        "victim_character_name" =>
-          payload["victim_character_name"] || payload[:victim_character_name],
-        "victim_ship_type" => payload["victim_ship_type"] || payload[:victim_ship_type],
-        "occurred_at" => payload["killmail_time"] || payload[:killmail_time] || event.timestamp
-      },
-      "relationships" => %{
-        "system" => %{
-          "data" => %{
-            "type" => "map_systems",
-            "id" => payload["system_id"] || payload[:system_id]
-          }
-        },
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
+    if has_key?(payload, :killmails) do
+      solar_system_id = fetch(payload, :solar_system_id)
+
+      payload
+      |> fetch(:killmails)
+      |> List.wrap()
+      |> Enum.map(fn kill ->
+        %{
+          "type" => "kills",
+          "id" => rid(fetch(kill, :killmail_id)),
+          "attributes" => %{
+            # The batch's solar_system_id, not the kill's: only the batch id
+            # is guaranteed to name a system this map contains, since it is
+            # what routed the event here.
+            "solar_system_id" => solar_system_id,
+            "kill_time" => fetch(kill, :kill_time),
+            "victim_char_id" => fetch(kill, :victim_char_id),
+            "victim_char_name" => fetch(kill, :victim_char_name),
+            "victim_corp_ticker" => fetch(kill, :victim_corp_ticker),
+            "victim_corp_name" => fetch(kill, :victim_corp_name),
+            "victim_alliance_ticker" => fetch(kill, :victim_alliance_ticker),
+            "victim_alliance_name" => fetch(kill, :victim_alliance_name),
+            "victim_ship_type_id" => fetch(kill, :victim_ship_type_id),
+            "victim_ship_name" => fetch(kill, :victim_ship_name),
+            "final_blow_char_name" => fetch(kill, :final_blow_char_name),
+            "attacker_count" => fetch(kill, :attacker_count),
+            "total_value" => fetch(kill, :total_value),
+            "npc" => fetch(kill, :npc)
+          },
+          "relationships" => %{"map" => map_relationship(event)}
         }
-      }
-    }
+      end)
+    else
+      format_kill_count(event, payload)
+    end
   end
 
   # Producer: map_server_pings_impl.ex:41. This producer does send the
@@ -496,6 +517,22 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
 
   defp map_relationship(%Event{map_id: map_id}) do
     relationship("maps", map_id)
+  end
+
+  # Producer: kills/message_handler.ex:111. Kill-count updates reuse :map_kill
+  # with a count and no "killmails" key. A summary names no single kill, so the
+  # event ULID is the identity.
+  defp format_kill_count(%Event{} = event, payload) do
+    %{
+      "type" => "kill_counts",
+      "id" => event.id,
+      "attributes" => %{
+        "solar_system_id" => fetch(payload, :solar_system_id),
+        "count" => fetch(payload, :count),
+        "updated_at" => event.timestamp
+      },
+      "relationships" => %{"map" => map_relationship(event)}
+    }
   end
 
   # An empty to-one relationship is represented as "data": null. Emitting

--- a/lib/wanderer_app/external_events/json_api_formatter.ex
+++ b/lib/wanderer_app/external_events/json_api_formatter.ex
@@ -8,6 +8,23 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
 
   alias WandererApp.ExternalEvents.Event
 
+  # Explicit allowlist for character payloads. Character events broadcast a
+  # WandererApp.Api.Character struct, which also carries the OAuth token fields
+  # and the owner hash - those must never be read.
+  #
+  # :id is deliberately absent: it is the resource identity, and JSON:API
+  # forbids an attribute named "id".
+  @character_attribute_keys [
+    :eve_id,
+    :name,
+    :corporation_id,
+    :corporation_ticker,
+    :alliance_id,
+    :ship_name,
+    :solar_system_id,
+    :online
+  ]
+
   @doc """
   Formats an event into JSON:API structure.
 
@@ -40,73 +57,82 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
   end
 
   # Event-specific resource data formatting
+  #
+  # Producer: map_server_systems_impl.ex:635 and :899. The :899 variant omits
+  # :name, so that attribute is legitimately nil there.
   defp format_resource_data(%Event{type: :add_system, payload: payload} = event) do
+    {type, id} = system_identity(event, payload)
+
     %{
-      "type" => "map_systems",
-      "id" => payload["system_id"] || payload[:system_id],
+      "type" => type,
+      "id" => id,
       "attributes" => %{
-        "solar_system_id" => payload["solar_system_id"] || payload[:solar_system_id],
-        "name" => payload["name"] || payload[:name],
-        "locked" => payload["locked"] || payload[:locked],
-        "x" => payload["x"] || payload[:x],
-        "y" => payload["y"] || payload[:y],
+        "solar_system_id" => fetch(payload, :solar_system_id),
+        "name" => fetch(payload, :name),
+        "position_x" => fetch(payload, :position_x),
+        "position_y" => fetch(payload, :position_y),
         "created_at" => event.timestamp
       },
-      "relationships" => %{
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
-      }
+      "relationships" => %{"map" => map_relationship(event)}
     }
   end
 
+  # Producer: map_server_systems_impl.ex:348. name/position_x/position_y are
+  # deliberately sent as nil and are omitted here rather than echoed as nulls.
   defp format_resource_data(%Event{type: :deleted_system, payload: payload} = event) do
+    {type, id} = system_identity(event, payload)
+
     %{
-      "type" => "map_systems",
-      "id" => payload["system_id"] || payload[:system_id],
+      "type" => type,
+      "id" => id,
+      "attributes" => %{
+        "solar_system_id" => fetch(payload, :solar_system_id)
+      },
       "meta" => %{
         "deleted" => true,
         "deleted_at" => event.timestamp
       },
-      "relationships" => %{
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
-      }
+      "relationships" => %{"map" => map_relationship(event)}
     }
   end
 
+  # No producer for :system_renamed exists in lib/. This clause bounds the
+  # output shape; its attribute names are unverified against a real payload.
   defp format_resource_data(%Event{type: :system_renamed, payload: payload} = event) do
+    {type, id} = system_identity(event, payload)
+
     %{
-      "type" => "map_systems",
-      "id" => payload["system_id"] || payload[:system_id],
+      "type" => type,
+      "id" => id,
       "attributes" => %{
-        "name" => payload["name"] || payload[:name],
+        "solar_system_id" => fetch(payload, :solar_system_id),
+        "name" => fetch(payload, :name),
         "updated_at" => event.timestamp
       },
-      "relationships" => %{
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
-      }
+      "relationships" => %{"map" => map_relationship(event)}
     }
   end
 
+  # Producer: map_server_systems_impl.ex:1115
   defp format_resource_data(%Event{type: :system_metadata_changed, payload: payload} = event) do
+    {type, id} = system_identity(event, payload)
+
     %{
-      "type" => "map_systems",
-      "id" => payload["system_id"] || payload[:system_id],
+      "type" => type,
+      "id" => id,
       "attributes" => %{
-        "locked" => payload["locked"] || payload[:locked],
-        "position_x" => payload["position_x"] || payload[:position_x],
-        "position_y" => payload["position_y"] || payload[:position_y],
+        "solar_system_id" => fetch(payload, :solar_system_id),
+        "name" => fetch(payload, :name),
+        "temporary_name" => fetch(payload, :temporary_name),
+        "labels" => fetch(payload, :labels),
+        "description" => fetch(payload, :description),
+        "status" => fetch(payload, :status),
+        "locked" => fetch(payload, :locked),
+        "position_x" => fetch(payload, :position_x),
+        "position_y" => fetch(payload, :position_y),
         "updated_at" => event.timestamp
       },
-      "relationships" => %{
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
-      }
+      "relationships" => %{"map" => map_relationship(event)}
     }
   end
 
@@ -437,6 +463,69 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
         }
       }
     }
+  end
+
+  # --- Payload helpers -------------------------------------------------------
+  #
+  # These live after the last format_resource_data/1 clause on purpose:
+  # interleaving them triggers "clauses with the same name and arity should be
+  # grouped together", which `mix compile` reports and `credo` does not.
+
+  # Reads a key from a payload that may be atom-keyed, string-keyed, or a
+  # struct. Structs do not implement Access, so `payload[key]` raises for the
+  # Api.Character structs that character events broadcast. Using Map.fetch/2
+  # rather than `a || b` also preserves `false`, which the previous idiom
+  # silently converted to nil.
+  defp fetch(payload, key) when is_atom(key) do
+    case Map.fetch(payload, key) do
+      {:ok, value} -> value
+      :error -> Map.get(payload, Atom.to_string(key))
+    end
+  end
+
+  # Presence check that tolerates both key styles. Needed where an absent key
+  # and a present nil mean different things - see the :map_kill clause, whose
+  # two variants are distinguished by whether "killmails" was sent at all.
+  defp has_key?(payload, key) when is_atom(key) do
+    Map.has_key?(payload, key) or Map.has_key?(payload, Atom.to_string(key))
+  end
+
+  # JSON:API requires a string id on every resource object.
+  defp rid(nil), do: nil
+  defp rid(value) when is_binary(value), do: value
+  defp rid(value), do: to_string(value)
+
+  # System events identify a map_systems record when the producer sent its
+  # UUID. Events broadcast before that producer change - replayed from a
+  # queue, say - have no UUID, and a null id is not valid JSON:API. Those fall
+  # back to the aggregate shape used by the signature events: the event ULID as
+  # identity, under a type that makes no claim to be a UUID-keyed resource.
+  defp system_identity(%Event{} = event, payload) do
+    case rid(fetch(payload, :system_id)) do
+      nil -> {"system_events", event.id}
+      system_id -> {"map_systems", system_id}
+    end
+  end
+
+  defp map_relationship(%Event{map_id: map_id}) do
+    relationship("maps", map_id)
+  end
+
+  # An empty to-one relationship is represented as "data": null. Emitting
+  # %{"type" => t, "id" => nil} instead would be an invalid identifier object.
+  defp relationship(type, id) do
+    case rid(id) do
+      nil -> %{"data" => nil}
+      id -> %{"data" => %{"type" => type, "id" => id}}
+    end
+  end
+
+  # Projects a character payload through @character_attribute_keys. Never pass
+  # a character payload through wholesale - it carries OAuth credentials.
+  defp character_attrs(payload) do
+    Map.new(@character_attribute_keys, fn key ->
+      {Atom.to_string(key), fetch(payload, key)}
+    end)
   end
 
   # Legacy event formatting (for events already in map format)

--- a/lib/wanderer_app/external_events/json_api_formatter.ex
+++ b/lib/wanderer_app/external_events/json_api_formatter.ex
@@ -58,8 +58,8 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
 
   # Event-specific resource data formatting
   #
-  # Producer: map_server_systems_impl.ex:635 and :899. The :899 variant omits
-  # :name, so that attribute is legitimately nil there.
+  # Producer: map_server_systems_impl.ex:636, :690 and :902. The :902 variant
+  # omits :name, so that attribute is legitimately nil there.
   defp format_resource_data(%Event{type: :add_system, payload: payload} = event) do
     {type, id} = system_identity(event, payload)
 
@@ -113,7 +113,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
     }
   end
 
-  # Producer: map_server_systems_impl.ex:1115
+  # Producer: map_server_systems_impl.ex:1119
   defp format_resource_data(%Event{type: :system_metadata_changed, payload: payload} = event) do
     {type, id} = system_identity(event, payload)
 
@@ -136,7 +136,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
     }
   end
 
-  # Producer: map_server_signatures_impl.ex:148 and :159.
+  # Producer: map_server_signatures_impl.ex:148 - the only :signature_added site.
   #
   # The producer sends sig.eve_id - the in-game signature code, not the record
   # UUID. api/map_system_signature.ex is uuid_primary_key with eve_id unique
@@ -384,6 +384,13 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
       payload
       |> fetch(:killmails)
       |> List.wrap()
+      # A kills resource has no identity but its killmail_id, and the
+      # producer does not guarantee one: validate_flat_format_kill/1 checks
+      # required fields with Map.has_key?/2, so a present-but-nil id is
+      # broadcast. Dropping the element is the only honest option - a null
+      # id is invalid JSON:API, and any fabricated id (the event ULID, say)
+      # would collide across the rest of the batch.
+      |> Enum.reject(&is_nil(fetch(&1, :killmail_id)))
       |> Enum.map(fn kill ->
         %{
           "type" => "kills",
@@ -465,11 +472,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
       "type" => "events",
       "id" => event.id,
       "attributes" => payload,
-      "relationships" => %{
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
-      }
+      "relationships" => %{"map" => map_relationship(event)}
     }
   end
 
@@ -663,7 +666,8 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
            ] ->
         "updated"
 
-      :signatures_updated ->
+      # Both bulk types summarise many records under one event.
+      type when type in [:signatures_updated, :characters_updated] ->
         "bulk_updated"
 
       :map_kill ->

--- a/lib/wanderer_app/external_events/json_api_formatter.ex
+++ b/lib/wanderer_app/external_events/json_api_formatter.ex
@@ -309,70 +309,62 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
     end)
   end
 
+  # Producer: acl_event_broadcaster.ex:52. member_id is a real
+  # access_list_members UUID and acl_id a real access_lists UUID.
   defp format_resource_data(%Event{type: :acl_member_added, payload: payload} = event) do
     %{
       "type" => "access_list_members",
-      "id" => payload["member_id"] || payload[:member_id],
+      "id" => rid(fetch(payload, :member_id)),
       "attributes" => %{
-        "character_eve_id" => payload["character_eve_id"] || payload[:character_eve_id],
-        "character_name" => payload["character_name"] || payload[:character_name],
-        "role" => payload["role"] || payload[:role],
+        "member_name" => fetch(payload, :member_name),
+        "member_type" => fetch(payload, :member_type),
+        "eve_id" => fetch(payload, :eve_id),
+        "role" => fetch(payload, :role),
         "added_at" => event.timestamp
       },
       "relationships" => %{
-        "access_list" => %{
-          "data" => %{
-            "type" => "access_lists",
-            "id" => payload["access_list_id"] || payload[:access_list_id]
-          }
-        },
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
+        "access_list" => relationship("access_lists", fetch(payload, :acl_id)),
+        "map" => map_relationship(event)
       }
     }
   end
 
+  # Producer: acl_event_broadcaster.ex:52
   defp format_resource_data(%Event{type: :acl_member_removed, payload: payload} = event) do
     %{
       "type" => "access_list_members",
-      "id" => payload["member_id"] || payload[:member_id],
+      "id" => rid(fetch(payload, :member_id)),
+      "attributes" => %{
+        "member_name" => fetch(payload, :member_name),
+        "member_type" => fetch(payload, :member_type),
+        "eve_id" => fetch(payload, :eve_id)
+      },
       "meta" => %{
         "deleted" => true,
         "deleted_at" => event.timestamp
       },
       "relationships" => %{
-        "access_list" => %{
-          "data" => %{
-            "type" => "access_lists",
-            "id" => payload["access_list_id"] || payload[:access_list_id]
-          }
-        },
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
+        "access_list" => relationship("access_lists", fetch(payload, :acl_id)),
+        "map" => map_relationship(event)
       }
     }
   end
 
+  # Producer: acl_event_broadcaster.ex:52
   defp format_resource_data(%Event{type: :acl_member_updated, payload: payload} = event) do
     %{
       "type" => "access_list_members",
-      "id" => payload["member_id"] || payload[:member_id],
+      "id" => rid(fetch(payload, :member_id)),
       "attributes" => %{
-        "role" => payload["role"] || payload[:role],
+        "member_name" => fetch(payload, :member_name),
+        "member_type" => fetch(payload, :member_type),
+        "eve_id" => fetch(payload, :eve_id),
+        "role" => fetch(payload, :role),
         "updated_at" => event.timestamp
       },
       "relationships" => %{
-        "access_list" => %{
-          "data" => %{
-            "type" => "access_lists",
-            "id" => payload["access_list_id"] || payload[:access_list_id]
-          }
-        },
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
+        "access_list" => relationship("access_lists", fetch(payload, :acl_id)),
+        "map" => map_relationship(event)
       }
     }
   end
@@ -402,41 +394,46 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
     }
   end
 
+  # Producer: map_server_pings_impl.ex:41. This producer does send the
+  # MapSystem UUID as :system_id, so the system relationship is real here.
   defp format_resource_data(%Event{type: :rally_point_added, payload: payload} = event) do
     %{
       "type" => "rally_points",
-      "id" => payload["rally_point_id"] || payload[:rally_point_id],
+      "id" => rid(fetch(payload, :rally_point_id)),
       "attributes" => %{
-        "name" => payload["name"] || payload[:name],
-        "description" => payload["description"] || payload[:description],
-        "created_at" => event.timestamp
+        "solar_system_id" => fetch(payload, :solar_system_id),
+        "system_name" => fetch(payload, :system_name),
+        "character_name" => fetch(payload, :character_name),
+        "character_eve_id" => fetch(payload, :character_eve_id),
+        "message" => fetch(payload, :message),
+        "created_at" => fetch(payload, :created_at) || event.timestamp
       },
       "relationships" => %{
-        "system" => %{
-          "data" => %{
-            "type" => "map_systems",
-            "id" => payload["system_id"] || payload[:system_id]
-          }
-        },
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
+        "system" => relationship("map_systems", fetch(payload, :system_id)),
+        "map" => map_relationship(event)
       }
     }
   end
 
+  # Producer: map_server_pings_impl.ex:94. Note the id key is :id here, not
+  # :rally_point_id as on the added event.
   defp format_resource_data(%Event{type: :rally_point_removed, payload: payload} = event) do
     %{
       "type" => "rally_points",
-      "id" => payload["rally_point_id"] || payload[:rally_point_id],
+      "id" => rid(fetch(payload, :id)),
+      "attributes" => %{
+        "solar_system_id" => fetch(payload, :solar_system_id),
+        "system_name" => fetch(payload, :system_name),
+        "character_name" => fetch(payload, :character_name),
+        "character_eve_id" => fetch(payload, :character_eve_id)
+      },
       "meta" => %{
         "deleted" => true,
         "deleted_at" => event.timestamp
       },
       "relationships" => %{
-        "map" => %{
-          "data" => %{"type" => "maps", "id" => event.map_id}
-        }
+        "system" => relationship("map_systems", fetch(payload, :system_id)),
+        "map" => map_relationship(event)
       }
     }
   end

--- a/lib/wanderer_app/external_events/json_api_formatter.ex
+++ b/lib/wanderer_app/external_events/json_api_formatter.ex
@@ -376,9 +376,10 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
   # Guard on presence of the key, not on its value: a batch that legitimately
   # carries no kills must render as [], and a present-but-nil "killmails" is a
   # malformed batch rather than a kill count. fetch/2 cannot tell absent from
-  # present-nil, so dispatch on has_key?/2.
+  # present-nil, so dispatch on key presence - in both key styles, since the
+  # producer sends string keys.
   defp format_resource_data(%Event{type: :map_kill, payload: payload} = event) do
-    if has_key?(payload, :killmails) do
+    if Map.has_key?(payload, :killmails) or Map.has_key?(payload, "killmails") do
       solar_system_id = fetch(payload, :solar_system_id)
 
       payload
@@ -492,13 +493,6 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatter do
       {:ok, value} -> value
       :error -> Map.get(payload, Atom.to_string(key))
     end
-  end
-
-  # Presence check that tolerates both key styles. Needed where an absent key
-  # and a present nil mean different things - see the :map_kill clause, whose
-  # two variants are distinguished by whether "killmails" was sent at all.
-  defp has_key?(payload, key) when is_atom(key) do
-    Map.has_key?(payload, key) or Map.has_key?(payload, Atom.to_string(key))
   end
 
   # JSON:API requires a string id on every resource object.

--- a/lib/wanderer_app/map/server/map_server_systems_impl.ex
+++ b/lib/wanderer_app/map/server/map_server_systems_impl.ex
@@ -383,6 +383,7 @@ defmodule WandererApp.Map.Server.SystemsImpl do
 
           # For consistency, include basic fields even for deleted systems
           WandererApp.ExternalEvents.broadcast(map_id, :deleted_system, %{
+            system_id: system_id,
             solar_system_id: solar_system_id,
             # System is deleted, name not available
             name: nil,
@@ -670,6 +671,7 @@ defmodule WandererApp.Map.Server.SystemsImpl do
 
             # ADDITIVE: Also broadcast to external event system (webhooks/WebSocket)
             WandererApp.ExternalEvents.broadcast(map_id, :add_system, %{
+              system_id: updated_system.id,
               solar_system_id: updated_system.solar_system_id,
               name: updated_system.name,
               position_x: updated_system.position_x,
@@ -938,6 +940,7 @@ defmodule WandererApp.Map.Server.SystemsImpl do
           end)
 
           WandererApp.ExternalEvents.broadcast(map_id, :add_system, %{
+            system_id: system.id,
             solar_system_id: system.solar_system_id,
             position_x: system.position_x,
             position_y: system.position_y

--- a/lib/wanderer_app/map/server/map_server_systems_impl.ex
+++ b/lib/wanderer_app/map/server/map_server_systems_impl.ex
@@ -727,6 +727,7 @@ defmodule WandererApp.Map.Server.SystemsImpl do
 
                     # ADDITIVE: Also broadcast to external event system (webhooks/WebSocket)
                     WandererApp.ExternalEvents.broadcast(map_id, :add_system, %{
+                      system_id: system.id,
                       solar_system_id: system.solar_system_id,
                       name: system.name,
                       position_x: system.position_x,

--- a/test/wanderer_app/external_events/json_api_formatter_test.exs
+++ b/test/wanderer_app/external_events/json_api_formatter_test.exs
@@ -41,7 +41,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       refute d["attributes"]["type"]
     end
 
-    # Fixture: map_server_systems_impl.ex:901 - this call site omits :name
+    # Fixture: map_server_systems_impl.ex:902 - this call site omits :name
     test "handles the producer variant that omits name" do
       d =
         data(:add_system, %{
@@ -100,7 +100,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
   end
 
   describe "system_metadata_changed" do
-    # Fixture: map_server_systems_impl.ex:1118
+    # Fixture: map_server_systems_impl.ex:1119
     test "renders every metadata attribute the producer sends" do
       d =
         data(:system_metadata_changed, %{
@@ -504,6 +504,34 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       assert d == []
     end
 
+    # validate_flat_format_kill/1 checks required fields with Map.has_key?/2
+    # (message_handler.ex:366), so a present-but-nil "killmail_id" is
+    # broadcast. A kills resource has no identity other than that id, and
+    # fabricating one - event.id, say - would collide across the batch, so
+    # the element is dropped rather than emitted with a null id.
+    test "a killmail with a nil id is skipped rather than emitted with a null id" do
+      d =
+        data(:map_kill, %{
+          "solar_system_id" => 31_000_199,
+          "killmails" => [killmail(1), %{killmail(2) | "killmail_id" => nil}]
+        })
+
+      assert length(d) == 1
+      assert hd(d)["id"] == "1"
+      assert hd(d)["attributes"]["victim_char_name"] == "Victim 1"
+      refute Enum.any?(d, &is_nil(&1["id"]))
+    end
+
+    test "a batch whose killmails all lack ids yields an empty array" do
+      d =
+        data(:map_kill, %{
+          "solar_system_id" => 31_000_199,
+          "killmails" => [%{killmail(1) | "killmail_id" => nil}]
+        })
+
+      assert d == []
+    end
+
     # Fixture: kills/message_handler.ex:111 - no killmails key at all
     test "the kill_count variant keeps the count instead of being discarded" do
       d =
@@ -518,6 +546,19 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       assert d["id"] == "01JQXYZ0000000000000000000"
       assert d["attributes"]["count"] == 7
       assert d["attributes"]["solar_system_id"] == 31_000_199
+    end
+  end
+
+  describe "event meta" do
+    # Both bulk event types summarise many records under one event, so they
+    # share an action vocabulary rather than one of them being "unknown".
+    test "the bulk event types report bulk_updated" do
+      meta = fn type, payload ->
+        JsonApiFormatter.format_event(event(type, payload))["meta"]["event_action"]
+      end
+
+      assert meta.(:signatures_updated, %{solar_system_id: 31_000_199}) == "bulk_updated"
+      assert meta.(:characters_updated, %{characters: [], timestamp: nil}) == "bulk_updated"
     end
   end
 
@@ -555,6 +596,10 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
         {:character_updated, char},
         {:characters_updated, %{characters: [char], timestamp: nil}},
         {:map_kill, %{"solar_system_id" => 31_000_199, "killmails" => [killmail(1)]}},
+        # The same event type also carries a count-only payload with no
+        # "killmails" key, which renders as a different resource. Without
+        # this fixture no invariant below ever runs over that shape.
+        {:map_kill, %{"solar_system_id" => 31_000_199, "count" => 7, "type" => :kill_count}},
         # acl_event_broadcaster.ex:52 sends the same payload shape - acl_id,
         # member_id, member_name, member_type, eve_id, role - for all three
         # ACL event types, so all three fixtures carry it.
@@ -594,6 +639,13 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
 
     defp resources(d) when is_list(d), do: d
     defp resources(d), do: [d]
+
+    # Every invariant below is a loop over all_event_fixtures/0, so a new
+    # event type with no fixture would be silently exempt from all of them.
+    test "the fixture list covers every supported event type" do
+      assert MapSet.new(all_event_fixtures(), &elem(&1, 0)) ==
+               MapSet.new(Event.supported_event_types())
+    end
 
     test "every event type is handled without raising" do
       for {type, payload} <- all_event_fixtures() do
@@ -678,6 +730,12 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       end
     end
 
+    # Timestamps the formatter injects itself from event.timestamp rather than
+    # reading them from the payload, so they are never nil. Left in, they would
+    # single-handedly satisfy the refute below for the 14 fixtures whose clause
+    # injects one - defeating the invariant exactly where it is most needed.
+    @formatter_injected_timestamps ~w(created_at updated_at added_at deleted_at removed_at)
+
     # This is the original bug's signature: a clause reading payload keys its
     # producer never sends renders every attribute as null while still
     # returning a well-formed-looking resource object. None of the invariants
@@ -686,7 +744,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
     test "no resource has an attributes map that is entirely null-valued" do
       for {type, payload} <- all_event_fixtures() do
         for resource <- resources(data(type, payload)) do
-          attrs = resource["attributes"] || %{}
+          attrs = Map.drop(resource["attributes"] || %{}, @formatter_injected_timestamps)
 
           refute attrs != %{} and Enum.all?(Map.values(attrs), &is_nil/1),
                  "#{type} emitted an attributes map with every value nil"

--- a/test/wanderer_app/external_events/json_api_formatter_test.exs
+++ b/test/wanderer_app/external_events/json_api_formatter_test.exs
@@ -126,4 +126,60 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       assert d["attributes"]["locked"] == false
     end
   end
+
+  describe "signature events" do
+    # Fixture: map_server_signatures_impl.ex:148
+    test "signature_added uses the event ULID as identity, not the EVE sig code" do
+      d =
+        data(:signature_added, %{
+          solar_system_id: 31_000_199,
+          signature_id: "ABC-123",
+          name: "Unstable Wormhole",
+          kind: "cosmic_signature",
+          group: "wormhole",
+          type: "K162"
+        })
+
+      assert d["type"] == "signature_events"
+      assert d["id"] == "01JQXYZ0000000000000000000"
+      assert d["attributes"]["signature_id"] == "ABC-123"
+      assert d["attributes"]["solar_system_id"] == 31_000_199
+      assert d["attributes"]["kind"] == "cosmic_signature"
+      assert d["attributes"]["group"] == "wormhole"
+      # Producer key :type, renamed because JSON:API reserves "type".
+      assert d["attributes"]["signature_type"] == "K162"
+      refute Map.has_key?(d["attributes"], "type")
+      refute Map.has_key?(d["attributes"], "id")
+      # No relationship may point at a map_system_signatures record we cannot name.
+      refute Map.has_key?(d["relationships"], "signature")
+    end
+
+    # Fixture: map_server_signatures_impl.ex:159 - only two keys are sent
+    test "signature_removed marks deletion with the sparse producer payload" do
+      d = data(:signature_removed, %{solar_system_id: 31_000_199, signature_id: "ABC-123"})
+
+      assert d["type"] == "signature_events"
+      assert d["id"] == "01JQXYZ0000000000000000000"
+      assert d["attributes"]["signature_id"] == "ABC-123"
+      assert d["meta"]["deleted"] == true
+    end
+
+    # Fixture: map_server_signatures_impl.ex:166 and :250 (same shape)
+    test "signatures_updated summarises counts instead of hitting the catch-all" do
+      d =
+        data(:signatures_updated, %{
+          solar_system_id: 31_000_199,
+          added_count: 2,
+          updated_count: 1,
+          removed_count: 0
+        })
+
+      assert d["type"] == "signature_updates"
+      assert d["id"] == "01JQXYZ0000000000000000000"
+      assert d["attributes"]["added_count"] == 2
+      assert d["attributes"]["updated_count"] == 1
+      assert d["attributes"]["removed_count"] == 0
+      assert d["attributes"]["solar_system_id"] == 31_000_199
+    end
+  end
 end

--- a/test/wanderer_app/external_events/json_api_formatter_test.exs
+++ b/test/wanderer_app/external_events/json_api_formatter_test.exs
@@ -337,4 +337,104 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       assert d["meta"]["removed"] == true
     end
   end
+
+  describe "acl member events" do
+    # Fixture: acl_event_broadcaster.ex:52
+    defp acl_payload do
+      %{
+        acl_id: "0198f0a1-bbbb-7000-8000-00000000000b",
+        member_id: "0198f0a1-cccc-7000-8000-00000000000c",
+        member_name: "Test Pilot",
+        member_type: "character",
+        eve_id: "2112625428",
+        role: "member"
+      }
+    end
+
+    test "acl_member_added reads member_name and eve_id, not character_*" do
+      d = data(:acl_member_added, acl_payload())
+
+      assert d["type"] == "access_list_members"
+      assert d["id"] == "0198f0a1-cccc-7000-8000-00000000000c"
+      assert d["attributes"]["member_name"] == "Test Pilot"
+      assert d["attributes"]["eve_id"] == "2112625428"
+      assert d["attributes"]["member_type"] == "character"
+      assert d["attributes"]["role"] == "member"
+
+      assert d["relationships"]["access_list"]["data"] == %{
+               "type" => "access_lists",
+               "id" => "0198f0a1-bbbb-7000-8000-00000000000b"
+             }
+    end
+
+    test "acl_member_updated reads acl_id for the access_list relationship" do
+      d = data(:acl_member_updated, acl_payload())
+
+      assert d["attributes"]["role"] == "member"
+
+      assert d["relationships"]["access_list"]["data"]["id"] ==
+               "0198f0a1-bbbb-7000-8000-00000000000b"
+    end
+
+    test "acl_member_removed marks deletion" do
+      d = data(:acl_member_removed, acl_payload())
+
+      assert d["id"] == "0198f0a1-cccc-7000-8000-00000000000c"
+      assert d["meta"]["deleted"] == true
+
+      assert d["relationships"]["access_list"]["data"]["id"] ==
+               "0198f0a1-bbbb-7000-8000-00000000000b"
+    end
+  end
+
+  describe "rally point events" do
+    # Fixture: map_server_pings_impl.ex:41
+    test "rally_point_added keeps the real system UUID relationship" do
+      d =
+        data(:rally_point_added, %{
+          rally_point_id: "0198f0a1-dddd-7000-8000-00000000000d",
+          solar_system_id: 31_000_199,
+          system_id: "0198f0a1-eeee-7000-8000-00000000000e",
+          character_id: "0198f0a1-ffff-7000-8000-00000000000f",
+          character_name: "Test Pilot",
+          character_eve_id: "2112625428",
+          system_name: "J123456",
+          message: "form up",
+          created_at: ~U[2026-08-04 11:00:00Z]
+        })
+
+      assert d["type"] == "rally_points"
+      assert d["id"] == "0198f0a1-dddd-7000-8000-00000000000d"
+      assert d["attributes"]["message"] == "form up"
+      assert d["attributes"]["character_name"] == "Test Pilot"
+      assert d["attributes"]["system_name"] == "J123456"
+      assert d["attributes"]["solar_system_id"] == 31_000_199
+
+      assert d["relationships"]["system"]["data"] == %{
+               "type" => "map_systems",
+               "id" => "0198f0a1-eeee-7000-8000-00000000000e"
+             }
+    end
+
+    # Fixture: map_server_pings_impl.ex:94 - the id key is :id, not :rally_point_id
+    test "rally_point_removed reads :id" do
+      d =
+        data(:rally_point_removed, %{
+          id: "0198f0a1-dddd-7000-8000-00000000000d",
+          solar_system_id: 31_000_199,
+          system_id: "0198f0a1-eeee-7000-8000-00000000000e",
+          character_id: "0198f0a1-ffff-7000-8000-00000000000f",
+          character_name: "Test Pilot",
+          character_eve_id: "2112625428",
+          system_name: "J123456"
+        })
+
+      assert d["type"] == "rally_points"
+      assert d["id"] == "0198f0a1-dddd-7000-8000-00000000000d"
+      assert d["meta"]["deleted"] == true
+
+      assert d["relationships"]["system"]["data"]["id"] ==
+               "0198f0a1-eeee-7000-8000-00000000000e"
+    end
+  end
 end

--- a/test/wanderer_app/external_events/json_api_formatter_test.exs
+++ b/test/wanderer_app/external_events/json_api_formatter_test.exs
@@ -18,7 +18,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
   defp data(type, payload), do: JsonApiFormatter.format_event(event(type, payload))["data"]
 
   describe "add_system" do
-    # Fixture: map_server_systems_impl.ex:635 (post-Task-1 shape)
+    # Fixture: map_server_systems_impl.ex:636 (post-Task-1 shape)
     test "uses the MapSystem UUID as identity and keeps EVE id as an attribute" do
       d =
         data(:add_system, %{
@@ -41,7 +41,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       refute d["attributes"]["type"]
     end
 
-    # Fixture: map_server_systems_impl.ex:899 - this call site omits :name
+    # Fixture: map_server_systems_impl.ex:901 - this call site omits :name
     test "handles the producer variant that omits name" do
       d =
         data(:add_system, %{
@@ -100,7 +100,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
   end
 
   describe "system_metadata_changed" do
-    # Fixture: map_server_systems_impl.ex:1115
+    # Fixture: map_server_systems_impl.ex:1118
     test "renders every metadata attribute the producer sends" do
       d =
         data(:system_metadata_changed, %{
@@ -327,6 +327,9 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       refute rendered =~ "SECRET-ACCESS-TOKEN"
       refute rendered =~ "SECRET-REFRESH-TOKEN"
       refute rendered =~ "SECRET-OWNER-HASH"
+      refute rendered =~ "access_token"
+      refute rendered =~ "refresh_token"
+      refute rendered =~ "character_owner_hash"
     end
 
     test "character_removed marks removal" do
@@ -515,6 +518,180 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       assert d["id"] == "01JQXYZ0000000000000000000"
       assert d["attributes"]["count"] == 7
       assert d["attributes"]["solar_system_id"] == 31_000_199
+    end
+  end
+
+  describe "module-wide invariants" do
+    # Every event type declared by Event.event_type/0, with a representative
+    # producer-shaped payload.
+    defp all_event_fixtures do
+      char = %WandererApp.Api.Character{
+        id: "0198f0a1-9999-7000-8000-000000000009",
+        eve_id: "2112625428",
+        name: "Test Pilot",
+        online: false,
+        access_token: "SECRET-ACCESS-TOKEN"
+      }
+
+      [
+        {:add_system, %{system_id: "u1", solar_system_id: 31_000_199}},
+        # Replayed pre-Task-1 payload: no system_id, must still be compliant.
+        {:add_system, %{solar_system_id: 31_000_199}},
+        {:deleted_system, %{system_id: "u1", solar_system_id: 31_000_199}},
+        {:system_renamed, %{system_id: "u1", name: "J1"}},
+        {:system_metadata_changed, %{system_id: "u1", solar_system_id: 31_000_199}},
+        {:signature_added, %{solar_system_id: 31_000_199, signature_id: "ABC-123"}},
+        {:signature_removed, %{solar_system_id: 31_000_199, signature_id: "ABC-123"}},
+        {:signatures_updated,
+         %{solar_system_id: 31_000_199, added_count: 1, updated_count: 0, removed_count: 0}},
+        {:connection_added,
+         %{connection_id: "u2", solar_system_source_id: 1, solar_system_target_id: 2}},
+        {:connection_removed,
+         %{connection_id: "u2", solar_system_source_id: 1, solar_system_target_id: 2}},
+        {:connection_updated,
+         %{connection_id: "u2", solar_system_source_id: 1, solar_system_target_id: 2}},
+        {:character_added, char},
+        {:character_removed, char},
+        {:character_updated, char},
+        {:characters_updated, %{characters: [char], timestamp: nil}},
+        {:map_kill, %{"solar_system_id" => 31_000_199, "killmails" => [killmail(1)]}},
+        # acl_event_broadcaster.ex:52 sends the same payload shape - acl_id,
+        # member_id, member_name, member_type, eve_id, role - for all three
+        # ACL event types, so all three fixtures carry it.
+        {:acl_member_added,
+         %{
+           member_id: "u3",
+           acl_id: "u4",
+           member_name: "Test Pilot",
+           member_type: "character",
+           eve_id: "2112625428"
+         }},
+        {:acl_member_removed,
+         %{
+           member_id: "u3",
+           acl_id: "u4",
+           member_name: "Test Pilot",
+           member_type: "character",
+           eve_id: "2112625428"
+         }},
+        {:acl_member_updated,
+         %{
+           member_id: "u3",
+           acl_id: "u4",
+           member_name: "Test Pilot",
+           member_type: "character",
+           eve_id: "2112625428",
+           role: "member"
+         }},
+        # solar_system_id matches the EVE-id sentinel used below so the
+        # "no EVE id as a relationship identifier" invariant has something to
+        # bite on for the rally-point "system" relationship.
+        {:rally_point_added,
+         %{rally_point_id: "u5", system_id: "u6", solar_system_id: 31_000_199}},
+        {:rally_point_removed, %{id: "u5", system_id: "u6", solar_system_id: 31_000_199}}
+      ]
+    end
+
+    defp resources(d) when is_list(d), do: d
+    defp resources(d), do: [d]
+
+    test "every event type is handled without raising" do
+      for {type, payload} <- all_event_fixtures() do
+        assert %{"data" => _, "meta" => _, "links" => _} =
+                 JsonApiFormatter.format_event(event(type, payload)),
+               "#{type} failed to format"
+      end
+    end
+
+    test "no event type falls through to the generic events fallback" do
+      for {type, payload} <- all_event_fixtures() do
+        for resource <- resources(data(type, payload)) do
+          refute resource["type"] == "events",
+                 "#{type} fell through to the generic fallback"
+        end
+      end
+    end
+
+    test "every resource id is a string" do
+      for {type, payload} <- all_event_fixtures() do
+        for resource <- resources(data(type, payload)) do
+          assert is_binary(resource["id"]), "#{type} emitted a non-string id"
+        end
+      end
+    end
+
+    test "every relationship is a valid identifier object or an explicit null" do
+      for {type, payload} <- all_event_fixtures() do
+        for resource <- resources(data(type, payload)),
+            {name, rel} <- resource["relationships"] || %{} do
+          assert Map.has_key?(rel, "data"), "#{type} relationship #{name} has no data member"
+
+          case rel["data"] do
+            nil ->
+              :ok
+
+            %{"type" => rel_type, "id" => id} ->
+              assert is_binary(rel_type) and is_binary(id),
+                     "#{type} relationship #{name} emitted a non-string type or id"
+
+            other ->
+              flunk("#{type} relationship #{name} emitted #{inspect(other)}")
+          end
+        end
+      end
+    end
+
+    # None of the fixtures above ever supply a nil to-one relationship id -
+    # acl_id and system_id are always present in the real producer payloads -
+    # so the null branch of the previous test never executes against them.
+    # This exercises it directly against the shared `relationship/2` helper.
+    test "an absent to-one relationship id emits an explicit null, not a null-id identifier" do
+      d = data(:acl_member_added, %{member_id: "u3", acl_id: nil, eve_id: "2112625428"})
+      assert d["relationships"]["access_list"] == %{"data" => nil}
+    end
+
+    test "no resource uses a reserved attribute name" do
+      for {type, payload} <- all_event_fixtures() do
+        for resource <- resources(data(type, payload)) do
+          attrs = resource["attributes"] || %{}
+
+          refute Map.has_key?(attrs, "id"), "#{type} has a reserved \"id\" attribute"
+          refute Map.has_key?(attrs, "type"), "#{type} has a reserved \"type\" attribute"
+        end
+      end
+    end
+
+    test "no EVE solar system id is used as a relationship identifier" do
+      for {type, payload} <- all_event_fixtures() do
+        for resource <- resources(data(type, payload)),
+            {name, rel} <- resource["relationships"] || %{} do
+          refute rel["data"]["id"] == "31000199",
+                 "#{type} relationship #{name} used an EVE id as an identifier"
+        end
+      end
+    end
+
+    test "no event type leaks an OAuth token" do
+      for {type, payload} <- all_event_fixtures() do
+        rendered = inspect(data(type, payload), limit: :infinity)
+        refute rendered =~ "SECRET-ACCESS-TOKEN", "#{type} leaked an access token"
+      end
+    end
+
+    # This is the original bug's signature: a clause reading payload keys its
+    # producer never sends renders every attribute as null while still
+    # returning a well-formed-looking resource object. None of the invariants
+    # above would catch it - a resource can have a string id, no reserved
+    # names, and no bad relationships while still being empty of information.
+    test "no resource has an attributes map that is entirely null-valued" do
+      for {type, payload} <- all_event_fixtures() do
+        for resource <- resources(data(type, payload)) do
+          attrs = resource["attributes"] || %{}
+
+          refute attrs != %{} and Enum.all?(Map.values(attrs), &is_nil/1),
+                 "#{type} emitted an attributes map with every value nil"
+        end
+      end
     end
   end
 end

--- a/test/wanderer_app/external_events/json_api_formatter_test.exs
+++ b/test/wanderer_app/external_events/json_api_formatter_test.exs
@@ -245,4 +245,96 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       assert d["meta"]["deleted"] == true
     end
   end
+
+  describe "character events" do
+    # Fixture: map_server_characters_impl.ex:1030 broadcasts an Api.Character
+    # struct, which carries OAuth tokens.
+    defp character_struct do
+      %WandererApp.Api.Character{
+        id: "0198f0a1-9999-7000-8000-000000000009",
+        eve_id: "2112625428",
+        name: "Test Pilot",
+        corporation_id: 98_000_001,
+        corporation_ticker: "TEST",
+        alliance_id: 99_000_001,
+        ship_name: "Astero",
+        solar_system_id: 31_000_199,
+        online: false,
+        access_token: "SECRET-ACCESS-TOKEN",
+        refresh_token: "SECRET-REFRESH-TOKEN",
+        character_owner_hash: "SECRET-OWNER-HASH"
+      }
+    end
+
+    test "character_added does not raise on a struct payload" do
+      d = data(:character_added, character_struct())
+
+      assert d["type"] == "characters"
+      assert d["id"] == "0198f0a1-9999-7000-8000-000000000009"
+      assert d["attributes"]["eve_id"] == "2112625428"
+      assert d["attributes"]["name"] == "Test Pilot"
+      assert d["attributes"]["corporation_ticker"] == "TEST"
+      assert d["attributes"]["solar_system_id"] == 31_000_199
+      # Regression: `payload["online"] || payload[:online]` turned false into nil.
+      assert d["attributes"]["online"] == false
+      # JSON:API forbids reserved attribute names; the UUID is the identity.
+      refute Map.has_key?(d["attributes"], "id")
+      refute Map.has_key?(d["attributes"], "type")
+    end
+
+    # Fixture: map_server_characters_impl.ex:485 sends a list of structs
+    test "characters_updated emits one resource per character" do
+      a = character_struct()
+      b = %{character_struct() | id: "0198f0a1-aaaa-7000-8000-00000000000a", name: "Second"}
+
+      d = data(:characters_updated, %{characters: [a, b], timestamp: ~U[2026-08-04 12:00:00Z]})
+
+      assert is_list(d)
+      assert length(d) == 2
+
+      assert Enum.map(d, & &1["id"]) == [
+               "0198f0a1-9999-7000-8000-000000000009",
+               "0198f0a1-aaaa-7000-8000-00000000000a"
+             ]
+
+      assert Enum.map(d, & &1["attributes"]["name"]) == ["Test Pilot", "Second"]
+      assert Enum.all?(d, &(&1["type"] == "characters"))
+    end
+
+    test "characters_updated handles an empty list" do
+      assert data(:characters_updated, %{characters: [], timestamp: nil}) == []
+    end
+
+    for event_type <- [:character_added, :character_removed, :character_updated] do
+      test "#{event_type} never leaks OAuth tokens" do
+        rendered = inspect(data(unquote(event_type), character_struct()), limit: :infinity)
+
+        refute rendered =~ "SECRET-ACCESS-TOKEN"
+        refute rendered =~ "SECRET-REFRESH-TOKEN"
+        refute rendered =~ "SECRET-OWNER-HASH"
+        refute rendered =~ "access_token"
+        refute rendered =~ "refresh_token"
+        refute rendered =~ "character_owner_hash"
+      end
+    end
+
+    test "characters_updated never leaks OAuth tokens" do
+      rendered =
+        inspect(data(:characters_updated, %{characters: [character_struct()], timestamp: nil}),
+          limit: :infinity
+        )
+
+      refute rendered =~ "SECRET-ACCESS-TOKEN"
+      refute rendered =~ "SECRET-REFRESH-TOKEN"
+      refute rendered =~ "SECRET-OWNER-HASH"
+    end
+
+    test "character_removed marks removal" do
+      d = data(:character_removed, character_struct())
+
+      assert d["type"] == "characters"
+      assert d["id"] == "0198f0a1-9999-7000-8000-000000000009"
+      assert d["meta"]["removed"] == true
+    end
+  end
 end

--- a/test/wanderer_app/external_events/json_api_formatter_test.exs
+++ b/test/wanderer_app/external_events/json_api_formatter_test.exs
@@ -18,7 +18,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
   defp data(type, payload), do: JsonApiFormatter.format_event(event(type, payload))["data"]
 
   describe "add_system" do
-    # Fixture: map_server_systems_impl.ex:636 (post-Task-1 shape)
+    # Fixture: map_server_systems_impl.ex:673 (post-Task-1 shape)
     test "uses the MapSystem UUID as identity and keeps EVE id as an attribute" do
       d =
         data(:add_system, %{
@@ -41,7 +41,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       refute d["attributes"]["type"]
     end
 
-    # Fixture: map_server_systems_impl.ex:902 - this call site omits :name
+    # Fixture: map_server_systems_impl.ex:943 - this call site omits :name
     test "handles the producer variant that omits name" do
       d =
         data(:add_system, %{
@@ -80,7 +80,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
   end
 
   describe "deleted_system" do
-    # Fixture: map_server_systems_impl.ex:348 - name/position are deliberately nil
+    # Fixture: map_server_systems_impl.ex:385 - name/position are deliberately nil
     test "marks deletion and preserves the producer's intentional nils" do
       d =
         data(:deleted_system, %{
@@ -100,7 +100,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
   end
 
   describe "system_metadata_changed" do
-    # Fixture: map_server_systems_impl.ex:1119
+    # Fixture: map_server_systems_impl.ex:1187
     test "renders every metadata attribute the producer sends" do
       d =
         data(:system_metadata_changed, %{
@@ -184,7 +184,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
   end
 
   describe "connection events" do
-    # Fixture: map_server_connections_impl.ex:748
+    # Fixture: map_server_connections_impl.ex:779
     test "connection_added reads solar_system_source_id, not solar_system_source" do
       d =
         data(:connection_added, %{
@@ -209,7 +209,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       assert d["relationships"] == %{"map" => %{"data" => %{"type" => "maps", "id" => @map_id}}}
     end
 
-    # Fixture: map_server_connections_impl.ex:1140
+    # Fixture: map_server_connections_impl.ex:1161
     test "connection_updated preserves locked: false" do
       d =
         data(:connection_updated, %{
@@ -230,7 +230,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       assert d["attributes"]["mass_status"] == 1
     end
 
-    # Fixture: map_server_connections_impl.ex:1083 - three keys only
+    # Fixture: map_server_connections_impl.ex:1104 - three keys only
     test "connection_removed marks deletion and keeps both endpoints" do
       d =
         data(:connection_removed, %{
@@ -247,7 +247,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
   end
 
   describe "character events" do
-    # Fixture: map_server_characters_impl.ex:1030 broadcasts an Api.Character
+    # Fixture: map_server_characters_impl.ex:1037 broadcasts an Api.Character
     # struct, which carries OAuth tokens.
     defp character_struct do
       %WandererApp.Api.Character{
@@ -282,7 +282,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       refute Map.has_key?(d["attributes"], "type")
     end
 
-    # Fixture: map_server_characters_impl.ex:485 sends a list of structs
+    # Fixture: map_server_characters_impl.ex:486 sends a list of structs
     test "characters_updated emits one resource per character" do
       a = character_struct()
       b = %{character_struct() | id: "0198f0a1-aaaa-7000-8000-00000000000a", name: "Second"}
@@ -442,7 +442,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
   end
 
   describe "map_kill" do
-    # Fixture: kills/message_handler.ex:126 (batch) and :296-346 (kill element)
+    # Fixture: kills/message_handler.ex:126 (batch) and :298-350 (kill element)
     defp killmail(id) do
       %{
         "killmail_id" => id,
@@ -504,8 +504,9 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       assert d == []
     end
 
-    # validate_flat_format_kill/1 checks required fields with Map.has_key?/2
-    # (message_handler.ex:366), so a present-but-nil "killmail_id" is
+    # validate_flat_format_kill/1 (message_handler.ex:247) checks required
+    # fields via validate_required_fields/2, which tests presence with
+    # Map.has_key?/2 (:444), so a present-but-nil "killmail_id" is
     # broadcast. A kills resource has no identity other than that id, and
     # fabricating one - event.id, say - would collide across the batch, so
     # the element is dropped rather than emitted with a null id.

--- a/test/wanderer_app/external_events/json_api_formatter_test.exs
+++ b/test/wanderer_app/external_events/json_api_formatter_test.exs
@@ -732,7 +732,7 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
 
     # Timestamps the formatter injects itself from event.timestamp rather than
     # reading them from the payload, so they are never nil. Left in, they would
-    # single-handedly satisfy the refute below for the 14 fixtures whose clause
+    # single-handedly satisfy the refute below for every fixture whose clause
     # injects one - defeating the invariant exactly where it is most needed.
     @formatter_injected_timestamps ~w(created_at updated_at added_at deleted_at removed_at)
 

--- a/test/wanderer_app/external_events/json_api_formatter_test.exs
+++ b/test/wanderer_app/external_events/json_api_formatter_test.exs
@@ -437,4 +437,84 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
                "0198f0a1-eeee-7000-8000-00000000000e"
     end
   end
+
+  describe "map_kill" do
+    # Fixture: kills/message_handler.ex:126 (batch) and :296-346 (kill element)
+    defp killmail(id) do
+      %{
+        "killmail_id" => id,
+        "kill_time" => "2026-08-04T11:59:00Z",
+        "solar_system_id" => 31_000_199,
+        "victim_char_id" => 2_112_625_428,
+        "victim_char_name" => "Victim #{id}",
+        "victim_corp_ticker" => "TEST",
+        "victim_corp_name" => "Test Corp",
+        "victim_alliance_ticker" => "TSTA",
+        "victim_alliance_name" => "Test Alliance",
+        "victim_ship_type_id" => 587,
+        "victim_ship_name" => "Rifter",
+        "final_blow_char_name" => "Killer",
+        "attacker_count" => 3,
+        "total_value" => 12_500_000.0,
+        "npc" => false
+      }
+    end
+
+    test "a batch of three kills yields three distinct resources" do
+      d =
+        data(:map_kill, %{
+          "solar_system_id" => 31_000_199,
+          "killmails" => [killmail(1), killmail(2), killmail(3)],
+          "timestamp" => "2026-08-04T12:00:00Z",
+          "type" => :killmail_update
+        })
+
+      assert is_list(d)
+      assert length(d) == 3
+      assert Enum.map(d, & &1["id"]) == ["1", "2", "3"]
+      # Each resource carries its own kill, not the first kill repeated.
+      assert Enum.map(d, & &1["attributes"]["victim_char_name"]) == [
+               "Victim 1",
+               "Victim 2",
+               "Victim 3"
+             ]
+
+      first = hd(d)
+      assert first["type"] == "kills"
+      assert first["attributes"]["victim_ship_type_id"] == 587
+      assert first["attributes"]["attacker_count"] == 3
+      assert first["attributes"]["total_value"] == 12_500_000.0
+      # Regression: `npc || nil` turned false into nil.
+      assert first["attributes"]["npc"] == false
+      # The batch's solar_system_id is authoritative - it routed the event here.
+      assert first["attributes"]["solar_system_id"] == 31_000_199
+    end
+
+    test "an empty batch yields an empty array" do
+      assert data(:map_kill, %{"solar_system_id" => 31_000_199, "killmails" => []}) == []
+    end
+
+    # Dispatch is on key presence, not value: a malformed batch is still a
+    # batch, not a kill count.
+    test "a present-but-nil killmails key is an empty batch, not a count" do
+      d = data(:map_kill, %{"solar_system_id" => 31_000_199, "killmails" => nil, "count" => 7})
+      assert d == []
+    end
+
+    # Fixture: kills/message_handler.ex:111 - no killmails key at all
+    test "the kill_count variant keeps the count instead of being discarded" do
+      d =
+        data(:map_kill, %{
+          "solar_system_id" => 31_000_199,
+          "count" => 7,
+          "type" => :kill_count
+        })
+
+      refute is_list(d)
+      assert d["type"] == "kill_counts"
+      assert d["id"] == "01JQXYZ0000000000000000000"
+      assert d["attributes"]["count"] == 7
+      assert d["attributes"]["solar_system_id"] == 31_000_199
+    end
+  end
 end

--- a/test/wanderer_app/external_events/json_api_formatter_test.exs
+++ b/test/wanderer_app/external_events/json_api_formatter_test.exs
@@ -1,0 +1,129 @@
+defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
+  use ExUnit.Case, async: true
+
+  alias WandererApp.ExternalEvents.{Event, JsonApiFormatter}
+
+  @map_id "0198f0a1-1111-7000-8000-000000000001"
+
+  defp event(type, payload) do
+    %Event{
+      id: "01JQXYZ0000000000000000000",
+      map_id: @map_id,
+      type: type,
+      payload: payload,
+      timestamp: ~U[2026-08-04 12:00:00Z]
+    }
+  end
+
+  defp data(type, payload), do: JsonApiFormatter.format_event(event(type, payload))["data"]
+
+  describe "add_system" do
+    # Fixture: map_server_systems_impl.ex:635 (post-Task-1 shape)
+    test "uses the MapSystem UUID as identity and keeps EVE id as an attribute" do
+      d =
+        data(:add_system, %{
+          system_id: "0198f0a1-2222-7000-8000-000000000002",
+          solar_system_id: 31_000_199,
+          name: "J123456",
+          position_x: 100,
+          position_y: 200
+        })
+
+      assert d["type"] == "map_systems"
+      assert d["id"] == "0198f0a1-2222-7000-8000-000000000002"
+      assert d["attributes"]["solar_system_id"] == 31_000_199
+      assert d["attributes"]["name"] == "J123456"
+      assert d["attributes"]["position_x"] == 100
+      assert d["attributes"]["position_y"] == 200
+      assert d["relationships"]["map"]["data"] == %{"type" => "maps", "id" => @map_id}
+      # The EVE id is data, not identity, and JSON:API forbids an "id" attribute.
+      refute d["attributes"]["id"]
+      refute d["attributes"]["type"]
+    end
+
+    # Fixture: map_server_systems_impl.ex:899 - this call site omits :name
+    test "handles the producer variant that omits name" do
+      d =
+        data(:add_system, %{
+          system_id: "0198f0a1-3333-7000-8000-000000000003",
+          solar_system_id: 31_000_200,
+          position_x: 10,
+          position_y: 20
+        })
+
+      assert d["id"] == "0198f0a1-3333-7000-8000-000000000003"
+      assert d["attributes"]["name"] == nil
+      assert d["attributes"]["position_x"] == 10
+    end
+
+    # A replayed pre-Task-1 event has no system_id. A null id is not valid
+    # JSON:API, so identity falls back to the event ULID under a type that
+    # makes no map_systems claim.
+    test "falls back to an event-keyed resource when system_id is absent" do
+      d = data(:add_system, %{solar_system_id: 31_000_199, position_x: 1, position_y: 2})
+
+      assert d["type"] == "system_events"
+      assert d["id"] == "01JQXYZ0000000000000000000"
+      assert d["attributes"]["solar_system_id"] == 31_000_199
+    end
+
+    test "accepts string-keyed payloads" do
+      d = data(:add_system, %{"system_id" => "abc", "solar_system_id" => 31_000_199})
+      assert d["id"] == "abc"
+      assert d["attributes"]["solar_system_id"] == 31_000_199
+    end
+
+    test "stringifies a non-string id" do
+      d = data(:add_system, %{system_id: 12_345, solar_system_id: 31_000_199})
+      assert d["id"] == "12345"
+    end
+  end
+
+  describe "deleted_system" do
+    # Fixture: map_server_systems_impl.ex:348 - name/position are deliberately nil
+    test "marks deletion and preserves the producer's intentional nils" do
+      d =
+        data(:deleted_system, %{
+          system_id: "0198f0a1-4444-7000-8000-000000000004",
+          solar_system_id: 31_000_199,
+          name: nil,
+          position_x: nil,
+          position_y: nil
+        })
+
+      assert d["type"] == "map_systems"
+      assert d["id"] == "0198f0a1-4444-7000-8000-000000000004"
+      assert d["attributes"]["solar_system_id"] == 31_000_199
+      assert d["meta"]["deleted"] == true
+      assert d["meta"]["deleted_at"] == ~U[2026-08-04 12:00:00Z]
+    end
+  end
+
+  describe "system_metadata_changed" do
+    # Fixture: map_server_systems_impl.ex:1115
+    test "renders every metadata attribute the producer sends" do
+      d =
+        data(:system_metadata_changed, %{
+          system_id: "0198f0a1-5555-7000-8000-000000000005",
+          solar_system_id: 31_000_199,
+          name: "J123456",
+          temporary_name: "Home",
+          labels: "dead end",
+          description: "staging",
+          status: 1,
+          locked: false,
+          position_x: 5,
+          position_y: 6
+        })
+
+      assert d["type"] == "map_systems"
+      assert d["id"] == "0198f0a1-5555-7000-8000-000000000005"
+      assert d["attributes"]["temporary_name"] == "Home"
+      assert d["attributes"]["labels"] == "dead end"
+      assert d["attributes"]["description"] == "staging"
+      assert d["attributes"]["status"] == 1
+      # Regression: `payload["locked"] || payload[:locked]` turned false into nil.
+      assert d["attributes"]["locked"] == false
+    end
+  end
+end

--- a/test/wanderer_app/external_events/json_api_formatter_test.exs
+++ b/test/wanderer_app/external_events/json_api_formatter_test.exs
@@ -182,4 +182,67 @@ defmodule WandererApp.ExternalEvents.JsonApiFormatterTest do
       assert d["attributes"]["solar_system_id"] == 31_000_199
     end
   end
+
+  describe "connection events" do
+    # Fixture: map_server_connections_impl.ex:748
+    test "connection_added reads solar_system_source_id, not solar_system_source" do
+      d =
+        data(:connection_added, %{
+          connection_id: "0198f0a1-6666-7000-8000-000000000006",
+          solar_system_source_id: 31_000_199,
+          solar_system_target_id: 31_000_200,
+          type: 0,
+          ship_size_type: 2,
+          mass_status: 0,
+          time_status: 0
+        })
+
+      assert d["type"] == "map_connections"
+      assert d["id"] == "0198f0a1-6666-7000-8000-000000000006"
+      assert d["attributes"]["solar_system_source_id"] == 31_000_199
+      assert d["attributes"]["solar_system_target_id"] == 31_000_200
+      assert d["attributes"]["ship_size_type"] == 2
+      # Producer key :type, renamed because JSON:API reserves "type".
+      assert d["attributes"]["connection_type"] == 0
+      refute Map.has_key?(d["attributes"], "type")
+      # EVE system ids are attributes; they must not become relationship ids.
+      assert d["relationships"] == %{"map" => %{"data" => %{"type" => "maps", "id" => @map_id}}}
+    end
+
+    # Fixture: map_server_connections_impl.ex:1140
+    test "connection_updated preserves locked: false" do
+      d =
+        data(:connection_updated, %{
+          connection_id: "0198f0a1-7777-7000-8000-000000000007",
+          solar_system_source_id: 31_000_199,
+          solar_system_target_id: 31_000_200,
+          type: 0,
+          ship_size_type: 2,
+          mass_status: 1,
+          time_status: 0,
+          locked: false,
+          custom_info: "eol"
+        })
+
+      assert d["id"] == "0198f0a1-7777-7000-8000-000000000007"
+      assert d["attributes"]["locked"] == false
+      assert d["attributes"]["custom_info"] == "eol"
+      assert d["attributes"]["mass_status"] == 1
+    end
+
+    # Fixture: map_server_connections_impl.ex:1083 - three keys only
+    test "connection_removed marks deletion and keeps both endpoints" do
+      d =
+        data(:connection_removed, %{
+          connection_id: "0198f0a1-8888-7000-8000-000000000008",
+          solar_system_source_id: 31_000_199,
+          solar_system_target_id: 31_000_200
+        })
+
+      assert d["type"] == "map_connections"
+      assert d["id"] == "0198f0a1-8888-7000-8000-000000000008"
+      assert d["attributes"]["solar_system_source_id"] == 31_000_199
+      assert d["meta"]["deleted"] == true
+    end
+  end
 end

--- a/test/wanderer_app/external_events/producer_payload_contract_test.exs
+++ b/test/wanderer_app/external_events/producer_payload_contract_test.exs
@@ -1,0 +1,92 @@
+defmodule WandererApp.ExternalEvents.ProducerPayloadContractTest do
+  @moduledoc """
+  Source-level contract test over the system-event producers.
+
+  The JSON:API formatter identifies system events by the `system_id` the
+  producer sends; without it every add_system falls back to the event-ULID
+  shape. That dependency is invisible from the formatter's own tests - they
+  are fed fixtures, not real broadcasts - so a refactor that drops the
+  `system_id:` line would leave the whole suite green while silently
+  reverting every add_system on the wire.
+
+  This test therefore reads the producer source, parses it, and asserts the
+  literal payload of every add_system/deleted_system broadcast. It is a
+  source-level test on purpose: exercising these code paths for real needs a
+  running map server, a database, and ESI static data, none of which this
+  invariant actually depends on.
+  """
+  use ExUnit.Case, async: true
+
+  @producer "lib/wanderer_app/map/server/map_server_systems_impl.ex"
+
+  # Every key each site sent before system_id was added, plus system_id.
+  # Removing or renaming any of these breaks live consumers: the legacy
+  # SSE/webhook path forwards payloads verbatim.
+  @expected_payload_keys %{
+    add_system: [
+      # :636 - do_add_system_from_location, existing-system branch
+      [:system_id, :solar_system_id, :name, :position_x, :position_y],
+      # :690 - do_add_system_from_location, MapSystemRepo.upsert/1 branch
+      [:system_id, :solar_system_id, :name, :position_x, :position_y],
+      # :902 - do_add_system
+      [:system_id, :solar_system_id, :position_x, :position_y]
+    ],
+    deleted_system: [
+      # :348 - delete_systems
+      [:system_id, :solar_system_id, :name, :position_x, :position_y]
+    ]
+  }
+
+  setup_all do
+    ast =
+      @producer
+      |> File.read!()
+      |> Code.string_to_quoted!()
+
+    {:ok, broadcasts: collect_broadcasts(ast)}
+  end
+
+  # Collects {event_type, payload_keys} for every literal
+  # WandererApp.ExternalEvents.broadcast(_, :atom, %{...}) call in the AST.
+  defp collect_broadcasts(ast) do
+    {_ast, found} =
+      Macro.prewalk(ast, [], fn
+        {{:., _, [{:__aliases__, _, [:WandererApp, :ExternalEvents]}, :broadcast]}, _,
+         [_map_id, event_type, {:%{}, _, pairs}]} = node,
+        acc
+        when is_atom(event_type) ->
+          keys = for {key, _value} <- pairs, is_atom(key), do: key
+          {node, [{event_type, keys} | acc]}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    Enum.reverse(found)
+  end
+
+  for {event_type, expected_sites} <- @expected_payload_keys do
+    test "every #{event_type} broadcast sends system_id and every key it sent before",
+         %{broadcasts: broadcasts} do
+      event_type = unquote(event_type)
+      expected_sites = unquote(Macro.escape(expected_sites))
+
+      sites =
+        for {^event_type, keys} <- broadcasts, do: keys
+
+      # A new, unpatched call site must fail this test rather than slip
+      # through as an extra element nobody checked.
+      assert length(sites) == length(expected_sites),
+             "expected #{length(expected_sites)} #{event_type} broadcast sites in " <>
+               "#{@producer}, found #{length(sites)}: #{inspect(sites)}"
+
+      for keys <- sites do
+        assert :system_id in keys,
+               "a #{event_type} broadcast omits :system_id (keys: #{inspect(keys)})"
+      end
+
+      assert Enum.sort(Enum.map(sites, &Enum.sort/1)) ==
+               Enum.sort(Enum.map(expected_sites, &Enum.sort/1))
+    end
+  end
+end

--- a/test/wanderer_app/external_events/producer_payload_contract_test.exs
+++ b/test/wanderer_app/external_events/producer_payload_contract_test.exs
@@ -24,15 +24,15 @@ defmodule WandererApp.ExternalEvents.ProducerPayloadContractTest do
   # SSE/webhook path forwards payloads verbatim.
   @expected_payload_keys %{
     add_system: [
-      # :636 - do_add_system_from_location, existing-system branch
+      # :673 - do_add_system_from_location, existing-system branch
       [:system_id, :solar_system_id, :name, :position_x, :position_y],
-      # :690 - do_add_system_from_location, MapSystemRepo.upsert/1 branch
+      # :729 - do_add_system_from_location, MapSystemRepo.upsert/1 branch
       [:system_id, :solar_system_id, :name, :position_x, :position_y],
-      # :902 - do_add_system
+      # :943 - do_add_system
       [:system_id, :solar_system_id, :position_x, :position_y]
     ],
     deleted_system: [
-      # :348 - delete_systems
+      # :385 - delete_systems
       [:system_id, :solar_system_id, :name, :position_x, :position_y]
     ]
   }


### PR DESCRIPTION
## What this fixes

`JsonApiFormatter.format_resource_data/1` read payload keys its producers never
send. `connection_added` read `solar_system_source` where the producer sends
`solar_system_source_id`; `acl_member_added` read `character_name` where the
producer sends `member_name`; `map_kill` read per-kill fields off a batch
envelope that carries none of them. Those events rendered as resource objects
with a null `id` and every attribute null — well-formed-looking and
information-free.

Three clauses were worse. `character_added`, `character_removed` and
`character_updated` used `payload[key]` bracket access on a
`WandererApp.Api.Character` struct. Structs don't implement `Access`, so every
one of those events raised `UndefinedFunctionError`.

Every clause is now rewritten against its actual producer, with the producer's
`file:line` in a comment above it.

## The producer change

Four broadcasts in `map_server_systems_impl.ex` (`:385`, `:673`, `:729`,
`:943`) now include `system_id:` — the `MapSystem` UUID. This is the **only
wire-visible producer change** and it is purely additive: no key is removed or
renamed, so the legacy SSE/webhook path that forwards payloads verbatim is
unaffected.

Note for anyone consuming these events: `:add_system` now emits **two different
`type` values** depending on payload vintage. With `system_id` it's
`map_systems` keyed by UUID; without it (a replayed pre-change event) it's
`system_events` keyed by the event ULID, because a null `id` is not valid
JSON:API. A consumer has to handle both.

## Things worth knowing before approving

- **The character allowlist is an allowlist.** `Api.Character` carries
  `access_token`, `refresh_token` and `character_owner_hash`.
  `@character_attribute_keys` enumerates the eight fields that may be emitted,
  so a field added to the Ash resource later defaults to *excluded*. A
  `Map.drop/2` denylist would work today and leak the moment someone adds a
  field.
- **Malformed kill batches now emit fewer elements.**
  `validate_flat_format_kill/1` checks required fields with `Map.has_key?/2`, so
  a present-but-`nil` `killmail_id` gets broadcast. Those elements are now
  dropped rather than emitted with `"id": null` — a fabricated id (the event
  ULID, say) would collide across the batch. This only changes output for
  batches that were previously emitting invalid JSON:API.
- **`system_events` and `signature_updates` are new type names** with no
  endpoint serving them. `kills` and `rally_points` already had that property
  before this change.
- **`format_event/1` has no caller in `lib/`** — only `format_legacy_event/1` is
  wired up, at `events_controller.ex:424`. This makes the public surface correct
  before it gets used, rather than after.
- **A strict consumer** validating with `additionalProperties: false` would
  reject the additive `system_id`.
- `format_legacy_resource_data/1` still uses bracket access and still reads
  `payload["server_time"]`. That path takes a plain map, not a struct, and is
  out of scope by decision — not an oversight.

## Tests

7 → 49 tests in `json_api_formatter_test.exs`: a describe block per event family
with producer-shaped fixtures, plus nine module-wide invariants that loop over
every supported event type (string ids, no reserved attribute names, valid
relationship objects, no EVE id used as an identifier, no token leaks, and no
entirely-null attributes map — the original bug's signature).

`producer_payload_contract_test.exs` is new. It parses the producer's source
with `Code.string_to_quoted/1` and asserts the literal payload keys of all four
broadcast sites, plus the site *count* — so a new, unpatched `:add_system` site
fails the build instead of slipping through. This is a source-level test on
purpose: exercising these paths for real needs a running map server, a database
and ESI static data, none of which the invariant depends on.

## Verification

- `mix test test/wanderer_app/external_events/` → **62 tests, 0 failures**
- `mix credo --strict` on both changed lib files → no issues
- `mix format --check-formatted` on all changed files → clean
- `mix compile` → no new warnings from the changed files

The 9 failures in a wider `external_events + unit/map + integration/map` run are
all `MapScopesTest`, which passes 52/52 in isolation — pre-existing cross-file
interference, unrelated to this branch, and nondeterministic even with a fixed
seed.

## Reviewer focus

1. `@character_attribute_keys` — the security boundary.
2. `system_identity/2` — the two-`type` polymorphism described above.
3. The dropped-killmail path in the `:map_kill` clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
