### PR TITLE
fix: name the character the corporation search runs as

### DIFF
--- a/lib/wanderer_app/character.ex
+++ b/lib/wanderer_app/character.ex
@@ -193,7 +193,7 @@ defmodule WandererApp.Character do
   """
   def search(character_id, opts \\ []) do
     case get_character(character_id) do
-      {:ok, %{access_token: access_token, eve_id: eve_id} = _character} ->
+      {:ok, %{access_token: access_token, eve_id: eve_id} = character} ->
         WandererApp.Esi.search(eve_id |> String.to_integer(),
           access_token: access_token,
           character_id: character_id,
@@ -205,11 +205,20 @@ defmodule WandererApp.Character do
             {:ok, prepare_search_results(result)}
 
           {:error, reason} ->
-            Logger.warning("#{__MODULE__} failed search: #{inspect(reason)}")
+            # The character is named because the caller ran this as one specific
+            # character out of possibly several, and the reason alone cannot tell
+            # an operator which token is the stale one.
+            Logger.warning(
+              "#{__MODULE__} failed search as #{Map.get(character, :name)} (#{eve_id}): #{inspect(reason)}"
+            )
+
             {:error, reason}
 
           other ->
-            Logger.warning("#{__MODULE__} failed search: #{inspect(other)}")
+            Logger.warning(
+              "#{__MODULE__} failed search as #{Map.get(character, :name)} (#{eve_id}): #{inspect(other)}"
+            )
+
             {:error, other}
         end
 

--- a/lib/wanderer_app/esi/corporation_search.ex
+++ b/lib/wanderer_app/esi/corporation_search.ex
@@ -90,6 +90,22 @@ defmodule WandererApp.Esi.CorporationSearch do
   end
 
   @doc """
+  The character a search would run as, or `:error` if there is none.
+
+  `search/3` uses the first of `characters` unconditionally, so on a multi-character
+  account exactly one character's token decides whether the feature works. Callers
+  need to name that character in a failure message: "re-authorise a character" is
+  unactionable when the user has several and cannot tell which one is being used —
+  re-authorising any of the others changes nothing.
+
+  Exposed so the message and the request cannot disagree about which character
+  that is; both go through here rather than each reaching for the head of the list.
+  """
+  @spec search_character(any()) :: {:ok, map()} | :error
+  def search_character([first_char | _]), do: {:ok, first_char}
+  def search_character(_characters), do: :error
+
+  @doc """
   Human-readable label for a stored corporation id.
 
   Falls back to `to_string(corp_id)` whenever ESI cannot answer: a saved focus

--- a/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
+++ b/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
@@ -39,7 +39,26 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   # and "ESI is rate-limiting us", which is the difference between a user-fixable
   # problem and one they should wait out — and it makes the failure diagnosable
   # from a screenshot instead of requiring server log access.
-  defp corp_search_error(reason), do: "#{@corp_search_error} (#{inspect(reason)})"
+  #
+  # The character is named for the same reason. `CorporationSearch.search/3` runs
+  # as the FIRST of the user's characters and only that one, so on a
+  # multi-character account a single stale token breaks the feature while every
+  # other character is fine. Telling the user to "re-authorise a character" is
+  # then actively misleading: re-authorising any of the others changes nothing.
+  # Naming it also distinguishes the two failures that look identical from the
+  # outside — a character-specific token problem versus ESI being down for
+  # everything.
+  defp corp_search_error(reason, characters) do
+    case CorporationSearch.search_character(characters) do
+      {:ok, %{name: name}} when is_binary(name) and name != "" ->
+        "Corporation search is unavailable right now. It runs as #{name}, so re-authorise" <>
+          " that character specifically — re-authorising a different one will not help." <>
+          " (#{inspect(reason)})"
+
+      _ ->
+        "#{@corp_search_error} (#{inspect(reason)})"
+    end
+  end
 
   # Shown under the excluded-systems box when the lookup itself failed. Unlike the
   # corporation search this one never leaves the app, so a failure here means the
@@ -500,8 +519,11 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         {results |> Enum.take(@max_search_results) |> Enum.map(&{&1.formatted, &1.id}), nil}
 
       {:error, reason} ->
-        Logger.warning("[MapNotifications] corporation search failed: #{inspect(reason)}")
-        {[], corp_search_error(reason)}
+        Logger.warning(
+          "[MapNotifications] corporation search failed as #{inspect(search_character_name(characters))}: #{inspect(reason)}"
+        )
+
+        {[], corp_search_error(reason, characters)}
     end
   rescue
     error ->
@@ -509,10 +531,18 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         "[MapNotifications] corporation search crashed: #{Exception.format(:error, error, __STACKTRACE__)}"
       )
 
-      {[], corp_search_error(error.__struct__)}
+      {[], corp_search_error(error.__struct__, characters)}
   end
 
   defp search_corporations(_current_user, _text), do: {[], nil}
+
+  # Log-only; the rendered message goes through `corp_search_error/2`.
+  defp search_character_name(characters) do
+    case CorporationSearch.search_character(characters) do
+      {:ok, %{name: name}} -> name
+      _ -> nil
+    end
+  end
 
   # One query for every excluded system, not one per system. Falls back to the
   # bare id for anything the lookup did not return, and keeps the stored order.

--- a/test/unit/esi/corporation_search_test.exs
+++ b/test/unit/esi/corporation_search_test.exs
@@ -119,6 +119,23 @@ defmodule WandererApp.Esi.CorporationSearchTest do
     end
   end
 
+  describe "search_character/1" do
+    # The message naming the character and the request using it must not be able
+    # to disagree, so both go through this function rather than each taking the
+    # head of the list independently.
+    test "names the character search/3 actually runs as" do
+      first = %{id: Ecto.UUID.generate(), name: "Alpha"}
+      second = %{id: Ecto.UUID.generate(), name: "Beta"}
+
+      assert {:ok, ^first} = CorporationSearch.search_character([first, second])
+    end
+
+    test "reports no character for an empty or unusable list" do
+      assert :error = CorporationSearch.search_character([])
+      assert :error = CorporationSearch.search_character(%Ash.NotLoaded{})
+    end
+  end
+
   describe "label_for/2" do
     test "renders ticker and name when ESI answers" do
       fetch = fn 98_000_001 -> {:ok, %{"name" => "Karmafleet", "ticker" => "KARMA"}} end

--- a/test/wanderer_app_web/live/map_notifications_test.exs
+++ b/test/wanderer_app_web/live/map_notifications_test.exs
@@ -641,7 +641,8 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
   test "a corporation keystroke reports a failed lookup instead of an empty dropdown", %{
     conn: conn,
-    map: map
+    map: map,
+    character: character
   } do
     notification_with_webhooks(map, [:system])
 
@@ -686,6 +687,12 @@ defmodule WandererAppWeb.MapNotificationsTest do
     # parenthesised suffix rather than a specific atom keeps this independent of
     # whichever failure the test host produces.
     assert render(view) =~ ~r/Corporation search is unavailable right now\..*\(.+\)/s
+
+    # The search runs as ONE character. On a multi-character account the generic
+    # advice to "re-authorise a character" sends the user to re-authorise the
+    # wrong one and conclude the feature is simply broken, so the message has to
+    # name the character whose token was actually used.
+    assert render(view) =~ character.name
   end
 
   test "send test message reports the global kill-switch", %{conn: conn, map: map} do


### PR DESCRIPTION
## Why

The corporation typeahead still fails in production with `(:forbidden)`. This does **not** fix that — it makes the failure name itself, because the current message actively misleads.

`CorporationSearch.search/3` runs the search as `hd(characters)` — the **first** of the user's characters, and only that one. On a multi-character account a single stale token breaks the feature while every other character is fine. Telling the user to "re-authorise a character" then sends them to re-authorise the wrong one and conclude the feature is simply broken. That is exactly what happened here.

## What I ruled out first

Investigated against the dev database (`psql`) rather than by reasoning about class names:

- **Not a missing scope in general.** The dev character has `esi-search.search_structures.v1`, and that scope has been in `config.exs`/`runtime.exs` since the initial commit — so it is not a case of tokens predating the scope.
- **Not negative caching.** `get_search/4` is wrapped in `@decorate cacheable` with no `match:`, but Nebulex 2.6's default match predicate explicitly refuses to cache `{:error, _}`. No poisoned 1-hour entry.
- **Not a stale bearer on retry.** `do_get_retry/5` merges the refreshed token correctly.
- **Not a bad URL or category.** A live probe returns 401 (not 404), and `corporation` is in the endpoint's category enum.

`:forbidden` on this GET path can only come from `do_get_retry/5` exhausting after a 401/403, so it is a genuine per-character token/authorisation failure — which is why identifying *which* character matters.

## What changed

- `CorporationSearch.search_character/1` — single source of truth for which character a search runs as, so the message and the request cannot disagree.
- The banner names that character: *"It runs as **X**, so re-authorise that character specifically — re-authorising a different one will not help."*
- Same name added to the log lines in `Character.search/2` and the notifications component.

## Verification

`mix test` on the notifications and corporation-search suites: **48 tests, 0 failures**. Compile is clean for all changed files. Log chain confirmed end to end:

```
Character failed search as Test Character 17282 (2000017282): :forbidden
[MapNotifications] corporation search failed as "Test Character 17282": :forbidden
```

Not verified in a browser — none available in this environment.

## Known issue, deliberately not fixed here

`has_many :characters` on `Api.User` has **no sort**, so Postgres returns those rows in unspecified order and the character the search runs as is not guaranteed stable across loads. The real fix is probably to skip characters that cannot search rather than to name the broken one — the codebase already has that pattern in `Character.can_track_wallet?/1`. Held back until the diagnosis is confirmed in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)