### PR TITLE
fix: corporation filter replaces tracked characters; add unknown-involvement verdict

### DIFF
--- a/lib/wanderer_app/external_events/discord/embed_formatter.ex
+++ b/lib/wanderer_app/external_events/discord/embed_formatter.ex
@@ -11,7 +11,8 @@ defmodule WandererApp.ExternalEvents.Discord.EmbedFormatter do
   the payload, decides the colour and the author line.
   """
 
-  @type verdict :: {:involved, :victim} | {:involved, :attacker} | :not_involved
+  @type verdict ::
+          {:involved, :victim} | {:involved, :attacker} | :not_involved | :unknown
 
   @max_embeds_per_message 10
   @max_kills_per_event 30
@@ -168,17 +169,20 @@ defmodule WandererApp.ExternalEvents.Discord.EmbedFormatter do
   defp color({:involved, :victim}, _value), do: @color_loss
   defp color({:involved, :attacker}, _value), do: @color_kill
 
-  defp color(:not_involved, value) when is_number(value) do
+  # `:unknown` renders exactly like `:not_involved`. Both mean "we cannot label
+  # this a kill or a loss", and an `:unknown` embed is already in the system
+  # channel — colouring it as ours would be a claim the verdict does not support.
+  defp color(verdict, value) when verdict in [:not_involved, :unknown] and is_number(value) do
     Enum.find_value(@value_colors, @color_default, fn {threshold, color} ->
       if value >= threshold, do: color
     end)
   end
 
-  defp color(:not_involved, _value), do: @color_default
+  defp color(verdict, _value) when verdict in [:not_involved, :unknown], do: @color_default
 
-  # Omitted entirely when we are not involved: neither "Kill" nor "Loss" would
-  # be a true statement about a fight none of our pilots were in.
-  defp author(_kill, :not_involved), do: nil
+  # Omitted entirely when we are not involved, or could not tell: neither "Kill"
+  # nor "Loss" would be a true statement about the fight.
+  defp author(_kill, verdict) when verdict in [:not_involved, :unknown], do: nil
   defp author(kill, {:involved, :victim}), do: author_line("Loss", kill["victim_corp_id"])
   defp author(kill, {:involved, :attacker}), do: author_line("Kill", kill["final_blow_corp_id"])
 

--- a/lib/wanderer_app/external_events/discord/matcher.ex
+++ b/lib/wanderer_app/external_events/discord/matcher.ex
@@ -15,6 +15,11 @@ defmodule WandererApp.ExternalEvents.Discord.Matcher do
   # invalidation to five minutes rather than the lifetime of the node.
   @ttl :timer.minutes(5)
 
+  # Throttle for the flat-payload warning below. Shares `@cache` because the
+  # entry is the same kind of thing: derived, per-node, and safe to lose.
+  @divergence_log_key "discord:attacker-divergence-warned"
+  @divergence_log_interval :timer.minutes(5)
+
   @doc """
   The EVE character ids tracked on `map_id`, as **integers**.
 
@@ -25,11 +30,18 @@ defmodule WandererApp.ExternalEvents.Discord.Matcher do
   integers. The conversion happens here, once per cache build, so that no
   comparison site anywhere else has to think about it.
 
-  Returns an empty `MapSet` if the map cannot be read (e.g. its server is not
-  running). Callers must treat that as "no tracked pilots" and fall back to
-  their conservative destination — this function never raises.
+  Returns `:unavailable` — never an empty `MapSet` — if the map cannot be read
+  (e.g. its server is not running, or the cache is down). An empty set is a
+  factual claim that nobody is tracked, and `involvement/3` acts on it: every
+  kill would be `:not_involved`, which is what *enables* the `excluded_systems`
+  and `wh_only` filters. With `wh_only` defaulting to true, a moment of cache
+  unavailability would therefore drop every k-space kill on the map silently.
+  `:unavailable` is propagated into an `:unknown` verdict instead, which
+  bypasses those filters and delivers to the system webhook.
+
+  This function never raises.
   """
-  @spec tracked_eve_ids(String.t()) :: MapSet.t(integer())
+  @spec tracked_eve_ids(String.t()) :: MapSet.t(integer()) | :unavailable
   def tracked_eve_ids(map_id) do
     case Cachex.get(@cache, cache_key(map_id)) do
       {:ok, %MapSet{} = ids} ->
@@ -45,13 +57,13 @@ defmodule WandererApp.ExternalEvents.Discord.Matcher do
     # its caller is `DiscordDispatcher.partition/3`: letting the raise through
     # would lose the entire killmail batch, not just this map's tracked set.
     # The documented "never raises" contract above is what makes the
-    # conservative empty-MapSet fallback safe for every caller.
+    # `:unavailable` fallback safe for every caller.
     error ->
       Logger.warning(
         "[Discord.Matcher] tracked-set cache unavailable for map #{map_id}: #{inspect(error)}"
       )
 
-      MapSet.new()
+      :unavailable
   end
 
   @doc """
@@ -106,7 +118,8 @@ defmodule WandererApp.ExternalEvents.Discord.Matcher do
       :error ->
         # Deliberately NOT cached: a transient failure must not be pinned for
         # the TTL, or every kill on this map is misrouted for five minutes.
-        MapSet.new()
+        # `:unavailable`, not an empty set — see `tracked_eve_ids/1`.
+        :unavailable
     end
   end
 
@@ -214,48 +227,77 @@ defmodule WandererApp.ExternalEvents.Discord.Matcher do
   # compare equal to the reset counter and be written back.
   defp version_key(map_id), do: "map:#{map_id}:tracked_eve_ids:version"
 
-  @type verdict :: {:involved, :victim} | {:involved, :attacker} | :not_involved
+  @type verdict ::
+          {:involved, :victim} | {:involved, :attacker} | :not_involved | :unknown
 
   @doc """
-  Decides whether a killmail involves this map's own pilots.
+  Decides whether a killmail is one the character channel is for.
 
-  Order is load-bearing (spec section 3): victim checks precede attacker checks,
-  so a kill where both sides are tracked renders as a *loss*. Losses are the
-  more urgent signal.
+  ## Which criterion applies
 
-  `focus_corp_ids` widens "tracked" rather than acting as a separate routing
-  concept, so corporation focus earns the same colouring and the same routing
-  carve-outs as character tracking.
+  `focus_corp_ids` **replaces** the tracked-character check rather than widening
+  it. When it is non-empty, membership of one of those corporations is the only
+  thing that sends a kill to the character channel; the map's tracked pilots are
+  not consulted at all, and their kills follow the ordinary system rules. When
+  it is empty, the map's tracked characters decide, which is the original
+  behaviour and the default.
+
+  It is deliberately one criterion or the other. A union would mean that turning
+  the corporation filter on could only ever *add* notifications, so an admin who
+  wants "the character channel is for my corp, not for whoever happens to be on
+  the map" would have no way to express it.
+
+  ## Ordering
+
+  Victim checks precede attacker checks, so a kill where both sides match
+  renders as a *loss*. Losses are the more urgent signal.
+
+  ## Verdicts
+
+  `:not_involved` is a positive finding — we looked and this kill is not ours.
+  It is what *enables* the `excluded_systems` and `wh_only` filters in
+  `Router`, so it must never be used to mean "could not tell". That case is
+  `:unknown`, which bypasses those filters and delivers to the system webhook.
   """
-  @spec involvement(map(), MapSet.t(integer()), [integer()]) :: verdict()
+  @spec involvement(map(), MapSet.t(integer()) | :unavailable, [integer()]) :: verdict()
   def involvement(kill, tracked_eve_ids, focus_corp_ids) when is_list(focus_corp_ids) do
-    cond do
-      MapSet.member?(tracked_eve_ids, parse_eve_id(kill["victim_char_id"])) ->
-        {:involved, :victim}
+    if focus_corp_ids == [] do
+      character_involvement(kill, tracked_eve_ids)
+    else
+      corporation_involvement(kill, focus_corp_ids)
+    end
+  end
 
-      parse_eve_id(kill["victim_corp_id"]) in focus_corp_ids ->
-        {:involved, :victim}
+  # No tracked set to compare against. Answering `:not_involved` here would
+  # assert that none of the map's pilots were in this fight, which is exactly
+  # what we failed to determine — and under the default `wh_only` that assertion
+  # drops the kill. Note the corporation-filter path above never reaches this:
+  # it does not need the tracked set, so a cache outage does not degrade it.
+  defp character_involvement(_kill, :unavailable), do: :unknown
 
-      attacker_match?(kill, tracked_eve_ids, focus_corp_ids) ->
-        {:involved, :attacker}
+  defp character_involvement(kill, tracked_eve_ids) do
+    if MapSet.member?(tracked_eve_ids, parse_eve_id(kill["victim_char_id"])) do
+      {:involved, :victim}
+    else
+      match_attackers(kill, "attacker_char_ids", &MapSet.member?(tracked_eve_ids, &1))
+    end
+  end
 
-      true ->
-        :not_involved
+  defp corporation_involvement(kill, focus_corp_ids) do
+    if parse_eve_id(kill["victim_corp_id"]) in focus_corp_ids do
+      {:involved, :victim}
+    else
+      match_attackers(kill, "attacker_corp_ids", &(&1 in focus_corp_ids))
     end
   end
 
   # ABSENT is not EMPTY. Nested-format payloads always carry the attacker keys
   # (possibly as empty lists); flat-format payloads omit them entirely. Treating
-  # a missing key as `[]` would assert "there were no tracked attackers", which
-  # we do not know. This is a compatibility behaviour for a payload shape we
-  # cannot enrich, not a normalization: admitting the data is unknown is better
-  # than pretending it is empty.
-  #
-  # Victim matching still runs normally either way — `victim_char_id` and
-  # `victim_corp_id` exist in both shapes. When the victim does not match and
-  # the attacker data is unknown, the verdict is `:not_involved`, which routes
-  # to the system webhook: the same conservative destination a matching-cache
-  # failure produces.
+  # a missing key as `[]` would assert "there were no attackers of ours", which
+  # we do not know — and the assertion is not free: it means a flat-format
+  # payload can only ever produce a loss, so *kills* by tracked pilots in
+  # k-space were dropped outright under the default `wh_only`. Reporting
+  # `:unknown` costs a kill in the system channel instead of no kill at all.
   #
   # `attacker_char_ids` / `attacker_corp_ids` are normalized to integers by
   # `collect_ids/2` (message_handler.ex) at flatten time — but only on the
@@ -265,26 +307,54 @@ defmodule WandererApp.ExternalEvents.Discord.Matcher do
   # (nothing today enforces that it can't), `parse_eve_id/1` is the backstop.
   # It passes integers straight through, so this costs nothing on the
   # already-normalized nested path.
-  defp attacker_match?(kill, tracked_eve_ids, focus_corp_ids) do
+  defp match_attackers(kill, key, match_fun) do
     if Map.has_key?(kill, "attacker_char_ids") or Map.has_key?(kill, "attacker_corp_ids") do
-      Enum.any?(
-        kill["attacker_char_ids"] || [],
-        &MapSet.member?(tracked_eve_ids, parse_eve_id(&1))
-      ) or
-        Enum.any?(kill["attacker_corp_ids"] || [], &(parse_eve_id(&1) in focus_corp_ids))
+      if Enum.any?(kill[key] || [], &match_fun.(parse_eve_id(&1))),
+        do: {:involved, :attacker},
+        else: :not_involved
     else
       log_attacker_divergence(kill)
-      false
+      :unknown
     end
   end
 
-  # Logged once per occurrence, at debug, with the killmail id. If flat-format
-  # payloads turn out to be common in production this is visible in the logs
-  # rather than inferred from notifications that never arrived.
+  # At warning, not debug: this is now the reason a kill lands in the system
+  # channel instead of the character channel, which is user-visible and worth
+  # explaining. Throttled to one line per interval because it fires per kill,
+  # and if flat payloads are the norm on some feed it would otherwise be the
+  # only thing in the log.
   defp log_attacker_divergence(kill) do
-    Logger.debug(fn ->
-      "[Discord] killmail #{kill["killmail_id"]}: attacker data absent from payload; " <>
-        "involvement decided on the victim alone"
-    end)
+    if divergence_log_allowed?() do
+      Logger.warning(
+        "[Discord] killmail #{kill["killmail_id"]}: attacker data absent from payload; " <>
+          "involvement decided on the victim alone, so kills by tracked pilots are " <>
+          "reported as :unknown and delivered to the system webhook. " <>
+          "(throttled to one line per #{div(@divergence_log_interval, 60_000)}m)"
+      )
+    end
+
+    :ok
+  end
+
+  @doc false
+  # Exposed only so tests can clear the throttle between cases. A warning
+  # suppressed by a previous test would make these assertions depend on run
+  # order, which is exactly the kind of flake that gets a real assertion deleted.
+  def divergence_log_key, do: @divergence_log_key
+
+  defp divergence_log_allowed?() do
+    case Cachex.get(@cache, @divergence_log_key) do
+      {:ok, nil} ->
+        Cachex.put(@cache, @divergence_log_key, true, ttl: @divergence_log_interval)
+        true
+
+      _ ->
+        false
+    end
+  rescue
+    # The cache is the throttle, not the signal. If it is unavailable, log —
+    # suppressing a warning because the suppression mechanism broke is the
+    # wrong direction, and a cache that is down is itself already warning here.
+    _ -> true
   end
 end

--- a/lib/wanderer_app/external_events/discord/router.ex
+++ b/lib/wanderer_app/external_events/discord/router.ex
@@ -6,14 +6,26 @@ defmodule WandererApp.ExternalEvents.Discord.Router do
 
   | # | Condition                                          | Destination       |
   |---|----------------------------------------------------|-------------------|
-  | 1 | System in `excluded_systems`, **not** involved     | drop              |
-  | 2 | `wh_only` on, system not a wormhole, not involved  | drop              |
-  | 3 | Involved                                           | character webhook |
-  | 4 | Otherwise                                          | system webhook    |
+  | 1 | System in `excluded_systems`, verdict `:not_involved` | drop            |
+  | 2 | `wh_only` on, system not a wormhole, `:not_involved`  | drop            |
+  | 3 | `{:involved, _}`                                   | character webhook |
+  | 4 | Otherwise (`:not_involved` past 1-2, or `:unknown`) | system webhook   |
 
-  Rules 1 and 2 are carve-outs: a kill involving your own pilots is always
-  interesting, wherever it happened, so the exclusion and wormhole-only filters
-  do not apply to it.
+  Rules 1 and 2 are carve-outs: a kill involving the pilots or corporations the
+  character channel is for is always interesting, wherever it happened, so the
+  exclusion and wormhole-only filters do not apply to it.
+
+  ## `:unknown` is not `:not_involved`
+
+  Only `:not_involved` — a positive finding that this kill is not ours — enables
+  rules 1 and 2. `:unknown` means `Matcher` could not determine involvement
+  (the tracked-character set was unavailable, or the payload carried no attacker
+  data). It bypasses rules 1 and 2 and lands on the **system** webhook.
+
+  This distinction is the whole point. Folding `:unknown` into `:not_involved`
+  would mean a cache outage silently drops every k-space kill on a map with the
+  default `wh_only`, and the only trace is one log line. Delivering a kill to
+  the system channel that a filter might have excluded is the cheaper error.
 
   ## Fallback
 
@@ -43,13 +55,16 @@ defmodule WandererApp.ExternalEvents.Discord.Router do
   @spec route(map(), struct(), verdict()) :: {:ok, struct()} | :drop
   def route(kill, notification, verdict) do
     involved? = match?({:involved, _}, verdict)
+    # Only a positive "this kill is not ours" opens the filters. `:unknown` must
+    # not, or an undetermined verdict is indistinguishable from an excluded one.
+    filterable? = verdict == :not_involved
     system_id = kill["solar_system_id"]
 
     cond do
-      not involved? and system_id in (notification.excluded_systems || []) ->
+      filterable? and system_id in (notification.excluded_systems || []) ->
         :drop
 
-      not involved? and notification.wh_only and not SystemClass.wormhole_system?(system_id) ->
+      filterable? and notification.wh_only and not SystemClass.wormhole_system?(system_id) ->
         :drop
 
       involved? ->

--- a/lib/wanderer_app_web/components/core_components.ex
+++ b/lib/wanderer_app_web/components/core_components.ex
@@ -723,6 +723,14 @@ defmodule WandererAppWeb.CoreComponents do
   # LiveSelect's own defaults (it derives an id from the field name).
   attr(:id, :string, default: nil)
   attr(:"phx-target", :any, default: nil)
+  # The `.label` row above the input is an empty spacer — it renders a blank
+  # `label-text` regardless of `@label`, so it exists purely to line this field
+  # up with sibling fields that do carry a label. In a two-column
+  # "input + button" row it is the opposite of helpful: the wrapper ends up
+  # taller than the input it contains, and any cross-axis alignment on the row
+  # lines the button up with the wrapper rather than with the input. Defaults to
+  # true so every existing call site keeps its current spacing.
+  attr(:label_row, :boolean, default: true)
   slot(:inner_block)
   slot(:option)
 
@@ -746,6 +754,7 @@ defmodule WandererAppWeb.CoreComponents do
           :input_class,
           :dropdown_extra_class,
           :option_extra_class,
+          :label_row,
           :id,
           :"phx-target"
         ]) ++ optional_opts
@@ -759,7 +768,7 @@ defmodule WandererAppWeb.CoreComponents do
         @label_class
       ]}
     >
-      <div for="form_description" class="label">
+      <div :if={@label_row} for="form_description" class="label">
         <span class="label-text"></span>
       </div>
       <LiveSelect.live_select

--- a/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
+++ b/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
@@ -817,7 +817,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
           id="excluded-system-form"
           phx-submit="add-excluded"
           phx-target={@myself}
-          class="grid items-end gap-2"
+          class="grid items-start gap-2"
           style="grid-template-columns: minmax(0, 24rem) max-content"
         >
           <.live_select
@@ -825,6 +825,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
             id={@excluded_select_id}
             phx-target={@myself}
             dropdown_extra_class="!h-24"
+            label_row={false}
             debounce={250}
             update_min_len={@min_search_length}
             mode={:single}
@@ -838,10 +839,12 @@ defmodule WandererAppWeb.MapNotificationsComponent do
       </div>
 
       <div :if={@notification} class="flex flex-col gap-2 rounded border border-white/10 p-3">
-        <h4 class="text-sm font-semibold">Focus corporations</h4>
+        <h4 class="text-sm font-semibold">Corporation filter</h4>
         <p class="text-xs opacity-70">
-          Kills involving these corporations are treated as relevant even when the
-          system or wormhole-only filters would otherwise drop them.
+          When set, only kills involving these corporations go to the character
+          channel, instead of your map-tracked characters. Everything else follows
+          the normal system rules. Leave empty to use map-tracked characters.
+          These kills ignore the excluded-system and wormhole-only filters.
         </p>
 
         <ul class="flex flex-wrap gap-2">
@@ -872,7 +875,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
           id="focus-corp-form"
           phx-submit="add-focus-corp"
           phx-target={@myself}
-          class="grid items-end gap-2"
+          class="grid items-start gap-2"
           style="grid-template-columns: minmax(0, 24rem) max-content"
         >
           <.live_select
@@ -880,6 +883,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
             id={@focus_corp_select_id}
             phx-target={@myself}
             dropdown_extra_class="!h-24"
+            label_row={false}
             debounce={250}
             update_min_len={@corp_min_search_length}
             mode={:single}

--- a/priv/posts/2026/08-02-discord-kill-notifications.md
+++ b/priv/posts/2026/08-02-discord-kill-notifications.md
@@ -31,13 +31,12 @@ owner and anyone granted admin rights over it.
 2. **Paste the URL** into the *Discord webhook URL (system channel)* field on
    the Notifications tab and hit **Save**.
 3. **Optionally add a character channel.** The *Character channel (optional)*
-   section takes a second webhook. Kills involving the map's tracked characters
-   go there instead, so you can keep them out of the chain-intel channel. You
-   can also list **focus corporations** there: a kill involving a character
-   from one of those corps counts as "yours" even if that character is not
-   tracked on the map, so the whole corp's kills land in the character channel
-   rather than the chain-intel one. If no character channel is configured,
-   these kills simply stay in the system channel — the split is opt-in.
+   section takes a second webhook. Kills involving your own pilots go there
+   instead, so you can keep them out of the chain-intel channel. By default
+   "your own pilots" means the map's tracked characters; the **Corporation
+   filter** below the field changes that. If no character channel is
+   configured, these kills simply stay in the system channel — the split is
+   opt-in.
 4. **Send a test message** to confirm the wiring before you rely on it. The
    button is right there under the form.
 
@@ -79,19 +78,69 @@ There is also an **Enabled** checkbox, so you can mute the feed without
 throwing away the webhook and its filter list.
 
 **Both filters have a deliberate carve-out:** they do not apply to a kill that
-involves one of your own pilots — a tracked character on the map, or a member
-of a focus corporation. A kill involving your people is interesting wherever it
-happened, so it is still delivered even from an excluded system, and even from
-k-space with *Only wormhole kills* left on. Those kills go to the character
-channel when one is configured, and to the system channel otherwise. If you
-want a system genuinely silent, the **Enabled** checkbox is the control that
-covers everything.
+involves one of your own pilots. A kill involving your people is interesting
+wherever it happened, so it is still delivered even from an excluded system, and
+even from k-space with *Only wormhole kills* left on. Those kills go to the
+character channel when one is configured, and to the system channel otherwise.
+If you want a system genuinely silent, the **Enabled** checkbox is the control
+that covers everything.
 
 **One thing worth being clear about:** these filters are *not* the same as the
 Kills widget filters. The widget's filters are per-user and only change what
 *you* see in the map UI. The Discord filters are per-map and server-side — they
 apply to everyone in the channel. The two look similar and are deliberately
 kept separate.
+
+## Corporation filter
+
+Under the character channel there is a **Corporation filter**. It answers one
+question: *who is the character channel for?*
+
+- **Leave it empty** and the answer is "the characters tracked on this map."
+  That is the default and it is what the feature did before this setting
+  existed.
+- **Add one or more corporations** and the answer becomes "members of these
+  corporations" — *instead of* the map's tracked characters, not in addition to
+  them.
+
+That replacement is the point. If your map tracks a mixed group of scouts and
+alts but the channel is meant to be your corp's kill feed, setting the filter
+takes the untracked-corp pilots' kills out of it. Those kills are not lost —
+they fall through to the normal system rules and land in the system channel if
+they pass the filters there.
+
+The carve-out above follows whichever criterion is active: with a corporation
+filter set, kills involving those corporations bypass the excluded-system and
+wormhole-only filters, and kills involving map-tracked characters no longer do.
+
+Matching looks at the victim first, then the attackers, and at *corporation*
+membership on both sides — so a corp member on either end of a killmail counts,
+whether or not that character is on the map.
+
+## Where a kill goes
+
+The full routing table, in order. "Ours" means the kill matched the active
+criterion — a map-tracked character, or a filtered corporation if the
+Corporation filter is set.
+
+1. Not ours, and the system is on the **excluded systems** list → dropped.
+2. Not ours, *Only wormhole kills* is on, and the system is k-space → dropped.
+3. Ours → the **character channel**, falling back to the system channel if no
+   character webhook is configured.
+4. Anything else → the **system channel**.
+
+There is a third possibility besides "ours" and "not ours": *undetermined*. A
+killmail can arrive without attacker information, or the map's tracked-character
+list can be briefly unreadable after a restart. In that case the map genuinely
+does not know whether the kill is yours.
+
+Undetermined kills are treated as neither. They do **not** get dropped by rules
+1 and 2 — those filters are only earned by a positive "this kill is not ours",
+and treating a missing answer as a "no" would mean a brief hiccup silently
+swallowed every k-space kill with the default settings. And they do **not** go
+to the character channel either, because that channel is supposed to mean "these
+are ours". They go to the system channel, and the server logs a warning so the
+cause is visible rather than inferred from a quiet channel.
 
 ## About the webhook URL
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -923,6 +923,14 @@ defmodule WandererAppWeb.Factory do
       "final_blow_ship_type_id" => 621,
       "final_blow_ship_name" => "Caracal",
       "attacker_count" => 3,
+      # `add_attacker_identity_data/2` attaches these to every nested payload
+      # that carried an "attackers" list, so a faithful fixture has them.
+      # Their ABSENCE is meaningful — it is what tells `Discord.Matcher` that
+      # involvement could not be determined — so a fixture that omitted them
+      # made every routing test exercise the `:unknown` path by accident.
+      # Tests that want the unknown path must drop these keys explicitly.
+      "attacker_char_ids" => [],
+      "attacker_corp_ids" => [],
       "total_value" => 84_000_000,
       "npc" => false
     }

--- a/test/unit/external_events/discord/matcher_involvement_test.exs
+++ b/test/unit/external_events/discord/matcher_involvement_test.exs
@@ -1,15 +1,14 @@
 defmodule WandererApp.ExternalEvents.Discord.MatcherInvolvementTest do
-  # `involvement/3` itself is pure: no database, no cache, no application env.
-  # This file is `async: false` for one reason only — two tests below assert
-  # on a `Logger.debug` message, and `config/test.exs` pins the *primary*
-  # Logger level to :warning. `capture_log`'s own `:level` option cannot
-  # override that (per its docs: "this setting does not override the overall
-  # Logger.level/0 value"), and `Logger.put_process_level/2` does not either:
-  # `:logger.allow/2` caches its verdict per *module* in a `persistent_term`,
-  # so it has no way to vary by calling process. The only lever that actually
-  # works is the global primary level, so we flip it for the duration of the
-  # affected tests and restore it in `on_exit` — which requires this file to
-  # not run concurrently with other async suites.
+  # `involvement/3` itself is pure: no database, no application env. This file is
+  # `async: false` for two reasons. First, several tests assert on the
+  # divergence log and `config/test.exs` pins the *primary* Logger level to
+  # :warning; `capture_log`'s own `:level` option cannot override that (per its
+  # docs: "this setting does not override the overall Logger.level/0 value"),
+  # and `Logger.put_process_level/2` does not either, because `:logger.allow/2`
+  # caches its verdict per *module* in a `persistent_term` and so has no way to
+  # vary by calling process. The only lever that works is the global primary
+  # level. Second, the divergence warning is throttled through a shared Cachex
+  # entry, which this file clears per test.
   use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
@@ -19,12 +18,20 @@ defmodule WandererApp.ExternalEvents.Discord.MatcherInvolvementTest do
   setup do
     previous_level = Logger.level()
     Logger.configure(level: :debug)
+    # The throttle is process-independent shared state, so without this a test
+    # that runs second sees its warning suppressed and fails for a reason that
+    # has nothing to do with what it is testing.
+    Cachex.del(:discord_notification_cache, Matcher.divergence_log_key())
     on_exit(fn -> Logger.configure(level: previous_level) end)
     :ok
   end
 
   @tracked MapSet.new([1001, 1002])
   @focus [500_001]
+  # The map's tracked characters are ignored while a corporation filter is set,
+  # so every corporation-mode test passes a tracked set that WOULD match if the
+  # old union behaviour came back.
+  @no_focus []
 
   # A nested-format kill: Task 5 guarantees the attacker keys are present, even
   # when the lists are empty.
@@ -55,133 +62,198 @@ defmodule WandererApp.ExternalEvents.Discord.MatcherInvolvementTest do
     )
   end
 
-  test "a tracked victim character is a loss" do
-    kill = nested(%{"victim_char_id" => 1001})
+  describe "character mode (no corporation filter)" do
+    test "a tracked victim character is a loss" do
+      kill = nested(%{"victim_char_id" => 1001})
 
-    assert Matcher.involvement(kill, @tracked, @focus) == {:involved, :victim}
-  end
+      assert Matcher.involvement(kill, @tracked, @no_focus) == {:involved, :victim}
+    end
 
-  test "a victim in a focused corporation is a loss" do
-    kill = nested(%{"victim_corp_id" => 500_001})
+    test "a tracked attacker character is a kill" do
+      kill = nested(%{"attacker_char_ids" => [4242, 1002]})
 
-    assert Matcher.involvement(kill, @tracked, @focus) == {:involved, :victim}
-  end
+      assert Matcher.involvement(kill, @tracked, @no_focus) == {:involved, :attacker}
+    end
 
-  test "a tracked attacker character is a kill" do
-    kill = nested(%{"attacker_char_ids" => [4242, 1002]})
+    test "an untouched kill is not involved" do
+      kill = nested(%{"attacker_char_ids" => [4242], "attacker_corp_ids" => [999_999]})
 
-    assert Matcher.involvement(kill, @tracked, @focus) == {:involved, :attacker}
-  end
+      assert Matcher.involvement(kill, @tracked, @no_focus) == :not_involved
+    end
 
-  test "an attacker in a focused corporation is a kill" do
-    kill = nested(%{"attacker_corp_ids" => [999_999, 500_001]})
+    # Pins the ordering from spec section 3. Reversing the two blocks leaves
+    # every other test in this file green while turning every self-inflicted
+    # loss into a green "kill" embed in the channel.
+    test "the victim check wins when both sides are tracked" do
+      kill = nested(%{"victim_char_id" => 1001, "attacker_char_ids" => [1002]})
 
-    assert Matcher.involvement(kill, @tracked, @focus) == {:involved, :attacker}
-  end
+      assert Matcher.involvement(kill, @tracked, @no_focus) == {:involved, :victim}
+    end
 
-  test "an untouched kill is not involved" do
-    kill = nested(%{"attacker_char_ids" => [4242], "attacker_corp_ids" => [999_999]})
+    test "corporation membership alone does not match" do
+      kill = nested(%{"victim_corp_id" => 500_001, "attacker_corp_ids" => [500_001]})
 
-    assert Matcher.involvement(kill, @tracked, @focus) == :not_involved
-  end
+      assert Matcher.involvement(kill, @tracked, @no_focus) == :not_involved
+    end
 
-  # Pins the ordering from spec section 3. Reversing the two blocks leaves every
-  # other test in this file green while turning every self-inflicted loss into a
-  # green "kill" embed in the channel.
-  test "the victim check wins when both sides are tracked" do
-    kill = nested(%{"victim_char_id" => 1001, "attacker_char_ids" => [1002]})
+    # `victim_char_id` is a pass-through on the flat-payload branch (Task 5) and
+    # is NOT normalized by `collect_ids/2` — unlike the attacker id lists, it can
+    # arrive as a binary. The comparison site here must coerce it the same way
+    # `tracked_eve_ids/1` coerces `eve_id`, or a string-typed tracked victim
+    # silently fails to match.
+    test "a string-typed victim char id still produces a loss verdict" do
+      kill = flat(%{"victim_char_id" => "1001"})
 
-    assert Matcher.involvement(kill, @tracked, @focus) == {:involved, :victim}
-  end
+      assert Matcher.involvement(kill, @tracked, @no_focus) == {:involved, :victim}
+    end
 
-  test "a flat payload with a tracked victim is still a loss" do
-    kill = flat(%{"victim_char_id" => 1001})
+    test "a malformed victim char id string does not match and does not crash" do
+      kill = nested(%{"victim_char_id" => "12345abc"})
 
-    assert Matcher.involvement(kill, @tracked, @focus) == {:involved, :victim}
-  end
-
-  test "a flat payload with no victim match is not involved and logs the divergence" do
-    kill = flat(%{"killmail_id" => 900_777})
-
-    log =
-      capture_log([level: :debug], fn ->
-        assert Matcher.involvement(kill, @tracked, @focus) == :not_involved
+      # `parse_eve_id/1` logs a warning for the non-numeric id; suppress it here
+      # so this test doesn't print a stray log line on every green run.
+      capture_log(fn ->
+        assert Matcher.involvement(kill, @tracked, @no_focus) == :not_involved
       end)
+    end
 
-    assert log =~ "900777"
-    assert log =~ "attacker data absent"
+    # `collect_ids/2` normalizes attacker ids to integers on the *nested*
+    # branch only (`add_attacker_identity_data/2`); the flat branch is a pure
+    # pass-through with no coercion. Nothing today enforces that a flat
+    # payload can't carry these keys as binaries, so the comparison site must
+    # coerce them too, or a string-typed tracked attacker silently misses.
+    test "a flat-shaped payload with string attacker ids still produces a kill verdict" do
+      kill = flat(%{"attacker_char_ids" => ["1002"], "attacker_corp_ids" => []})
+
+      assert Matcher.involvement(kill, @tracked, @no_focus) == {:involved, :attacker}
+    end
+
+    # NPC and structure kills legitimately have no character victim.
+    test "an absent victim char id does not match and does not crash" do
+      kill = nested(%{"victim_char_id" => nil, "victim_corp_id" => nil})
+
+      assert Matcher.involvement(kill, @tracked, @no_focus) == :not_involved
+    end
+
+    # Half-present attacker data: one key present, the other absent. The
+    # absent-vs-empty gate must not re-trigger on the missing half.
+    test "one attacker key present and the other absent still matches on the present key" do
+      kill = flat(%{"attacker_char_ids" => [1002]})
+
+      assert Matcher.involvement(kill, @tracked, @no_focus) == {:involved, :attacker}
+    end
   end
 
-  # THE case that distinguishes absent from empty. `Map.get(k, [])` in the
-  # implementation makes this test pass and the previous one fail; this one
-  # exists so nobody "fixes" that by silencing the log unconditionally.
-  test "present-but-empty attacker lists are not a divergence" do
-    kill = nested(%{"attacker_char_ids" => [], "attacker_corp_ids" => []})
+  describe "corporation filter mode" do
+    test "a victim in a filtered corporation is a loss" do
+      kill = nested(%{"victim_corp_id" => 500_001})
 
-    log =
-      capture_log([level: :debug], fn ->
-        assert Matcher.involvement(kill, @tracked, @focus) == :not_involved
+      assert Matcher.involvement(kill, @tracked, @focus) == {:involved, :victim}
+    end
+
+    test "an attacker in a filtered corporation is a kill" do
+      kill = nested(%{"attacker_corp_ids" => [999_999, 500_001]})
+
+      assert Matcher.involvement(kill, @tracked, @focus) == {:involved, :attacker}
+    end
+
+    test "the victim check still wins when both sides are in a filtered corporation" do
+      kill = nested(%{"victim_corp_id" => 500_001, "attacker_corp_ids" => [500_001]})
+
+      assert Matcher.involvement(kill, @tracked, @focus) == {:involved, :victim}
+    end
+
+    # THE test for the replacement semantic. The corporation filter answers
+    # "who is the character channel for", so setting it must be able to take
+    # map-tracked pilots OUT of that channel. If these two ever go green as
+    # `{:involved, _}` the filter has silently become a union again, and an
+    # admin who set it to narrow the channel has instead widened it.
+    test "a tracked victim character is NOT matched while a filter is set" do
+      kill = nested(%{"victim_char_id" => 1001})
+
+      assert Matcher.involvement(kill, @tracked, @focus) == :not_involved
+    end
+
+    test "a tracked attacker character is NOT matched while a filter is set" do
+      kill = nested(%{"attacker_char_ids" => [1002]})
+
+      assert Matcher.involvement(kill, @tracked, @focus) == :not_involved
+    end
+
+    # The filter does not read the tracked set at all, so the cache outage that
+    # produces `:unknown` in character mode cannot degrade this path.
+    test "an unavailable tracked set does not affect a filtered decision" do
+      kill = nested(%{"victim_corp_id" => 500_001})
+
+      assert Matcher.involvement(kill, :unavailable, @focus) == {:involved, :victim}
+    end
+
+    test "a corporation outside the filter is not involved" do
+      kill = nested(%{"victim_corp_id" => 700_000, "attacker_corp_ids" => [999_999]})
+
+      assert Matcher.involvement(kill, @tracked, @focus) == :not_involved
+    end
+  end
+
+  describe ":unknown verdict" do
+    # `:not_involved` is a positive finding, and `Router` acts on it by applying
+    # the excluded-system and wormhole-only filters. Reporting it here would
+    # mean a cache outage silently drops every k-space kill on the map.
+    test "an unavailable tracked set is unknown, not 'not involved'" do
+      kill = nested(%{"victim_char_id" => 4242})
+
+      assert Matcher.involvement(kill, :unavailable, @no_focus) == :unknown
+    end
+
+    test "a flat payload with no victim match is unknown and warns" do
+      kill = flat(%{"killmail_id" => 900_777})
+
+      log =
+        capture_log(fn ->
+          assert Matcher.involvement(kill, @tracked, @no_focus) == :unknown
+        end)
+
+      assert log =~ "900777"
+      assert log =~ "attacker data absent"
+      # At warning, not debug: this is the reason a kill lands in the system
+      # channel rather than the character channel.
+      assert log =~ "[warning]"
+    end
+
+    test "a flat payload is equally unknown under a corporation filter" do
+      kill = flat(%{"victim_corp_id" => 700_000})
+
+      capture_log(fn ->
+        assert Matcher.involvement(kill, @tracked, @focus) == :unknown
       end)
+    end
 
-    refute log =~ "attacker data absent"
-  end
+    # THE case that distinguishes absent from empty. Reading the attacker keys
+    # with a `|| []` default makes the previous tests pass and this one fail;
+    # this one exists so nobody "fixes" that by silencing the log unconditionally.
+    test "present-but-empty attacker lists are not a divergence" do
+      kill = nested(%{"attacker_char_ids" => [], "attacker_corp_ids" => []})
 
-  test "an empty focus list never matches" do
-    kill = nested(%{"victim_corp_id" => 500_001, "attacker_corp_ids" => [500_001]})
+      log =
+        capture_log(fn ->
+          assert Matcher.involvement(kill, @tracked, @no_focus) == :not_involved
+        end)
 
-    assert Matcher.involvement(kill, @tracked, []) == :not_involved
-  end
+      refute log =~ "attacker data absent"
+    end
 
-  # `victim_char_id` is a pass-through on the flat-payload branch (Task 5) and
-  # is NOT normalized by `collect_ids/2` — unlike the attacker id lists, it can
-  # arrive as a binary. The comparison site here must coerce it the same way
-  # `tracked_eve_ids/1` coerces `eve_id`, or a string-typed tracked victim
-  # silently fails to match.
-  test "a string-typed victim char id still produces a loss verdict" do
-    kill = flat(%{"victim_char_id" => "1001"})
+    # The warning fires per kill, so an unthrottled one would be the only thing
+    # in the log on a feed that only sends flat payloads.
+    test "the divergence warning is throttled to one line per interval" do
+      log =
+        capture_log(fn ->
+          assert Matcher.involvement(flat(%{"killmail_id" => 1}), @tracked, @no_focus) == :unknown
+          assert Matcher.involvement(flat(%{"killmail_id" => 2}), @tracked, @no_focus) == :unknown
+        end)
 
-    assert Matcher.involvement(kill, @tracked, @focus) == {:involved, :victim}
-  end
-
-  test "a malformed victim char id string does not match and does not crash" do
-    kill = flat(%{"victim_char_id" => "12345abc"})
-
-    # `parse_eve_id/1` logs a warning for the non-numeric id; suppress it here
-    # so this test doesn't print a stray log line on every green run.
-    capture_log(fn ->
-      assert Matcher.involvement(kill, @tracked, @focus) == :not_involved
-    end)
-  end
-
-  # `collect_ids/2` normalizes attacker ids to integers on the *nested*
-  # branch only (`add_attacker_identity_data/2`); the flat branch is a pure
-  # pass-through with no coercion. Nothing today enforces that a flat
-  # payload can't carry these keys as binaries, so the comparison site must
-  # coerce them too, or a string-typed tracked attacker silently misses.
-  test "a flat-shaped payload with string attacker ids still produces a kill verdict" do
-    kill = flat(%{"attacker_char_ids" => ["1002"], "attacker_corp_ids" => []})
-
-    assert Matcher.involvement(kill, @tracked, @focus) == {:involved, :attacker}
-  end
-
-  # NPC and structure kills legitimately have no character victim. Both
-  # attacker keys are absent on this fixture too, so this also fires the
-  # divergence log — wrapped to keep test output clean.
-  test "an absent victim char id does not match and does not crash" do
-    kill = flat(%{"victim_char_id" => nil, "victim_corp_id" => nil})
-
-    capture_log(fn ->
-      assert Matcher.involvement(kill, @tracked, @focus) == :not_involved
-    end)
-  end
-
-  # Half-present attacker data: one key present, the other absent. The `||`
-  # inside `attacker_match?/3` must not be reached by the absent-vs-empty
-  # gate re-triggering on the missing half.
-  test "one attacker key present and the other absent still matches on the present key" do
-    kill = flat(%{"attacker_char_ids" => [1002]})
-
-    assert Matcher.involvement(kill, @tracked, @focus) == {:involved, :attacker}
+      assert log =~ "attacker data absent"
+      refute log =~ "killmail 2:"
+    end
   end
 
   # `focus_corp_ids` is a caller contract, not runtime data — the guard makes

--- a/test/unit/external_events/discord/router_test.exs
+++ b/test/unit/external_events/discord/router_test.exs
@@ -135,6 +135,47 @@ defmodule WandererApp.ExternalEvents.Discord.RouterTest do
     assert id == system_wh.id
   end
 
+  # `:unknown` means involvement could not be determined — the tracked-set
+  # cache was unavailable, or the payload carried no attacker data. Rules 1 and
+  # 2 must not fire on it: they are filters that only a positive "this kill is
+  # not ours" earns. If these two tests go to `:drop`, a Cachex outage silently
+  # swallows every k-space kill on every map with the default `wh_only`, and the
+  # only evidence is one log line.
+  test "an unknown verdict bypasses the excluded-system filter", %{
+    notification: n,
+    system_wh: system_wh
+  } do
+    {:ok, n} =
+      MapDiscordNotification.update(n, %{wh_only: false, excluded_systems: [@ks_system]})
+
+    assert {:ok, %{id: id}} = Router.route(kill(@ks_system), with_webhooks(n), :unknown)
+    assert id == system_wh.id
+  end
+
+  test "an unknown verdict bypasses the wormhole-only filter", %{
+    notification: n,
+    system_wh: system_wh
+  } do
+    {:ok, n} = MapDiscordNotification.update(n, %{wh_only: true})
+
+    assert {:ok, %{id: id}} = Router.route(kill(@ks_system), with_webhooks(n), :unknown)
+    assert id == system_wh.id
+  end
+
+  # It bypasses the filters, but it is NOT involvement. An undetermined kill
+  # must not reach the character channel, which is commonly public and is
+  # supposed to mean "these are ours".
+  test "an unknown verdict goes to the system webhook even when a character one exists", %{
+    notification: n,
+    system_wh: system_wh
+  } do
+    _character_wh = add_character_webhook(n)
+    {:ok, n} = MapDiscordNotification.update(n, %{wh_only: false})
+
+    assert {:ok, %{id: id}} = Router.route(kill(@ks_system), with_webhooks(n), :unknown)
+    assert id == system_wh.id
+  end
+
   # DROP, NOT REROUTE. Turning this into `{:ok, system_wh}` would post kills
   # involving the user's own pilots into a channel they did not choose.
   test "a disabled character webhook drops rather than rerouting", %{notification: n} do

--- a/test/unit/external_events/discord_dispatcher_test.exs
+++ b/test/unit/external_events/discord_dispatcher_test.exs
@@ -270,7 +270,14 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcherTest do
     refute_delivery(w.id)
   end
 
+  # `track/2` with no ids is load-bearing, not decoration: the filters below
+  # only apply to a verdict of `:not_involved`, and that requires a tracked set
+  # we could actually read. Without the seed the map reads as `:unavailable`,
+  # the verdict is `:unknown`, and the kill is deliberately delivered — which
+  # would look like the filter is broken when it is the fixture that is.
   test "skips non-wormhole systems when wh_only is set", %{map: map, system: w} do
+    track(map.id, [])
+
     event = kill_event(Factory.build(:kill_event, %{solar_system_id: @ks_system}))
 
     DiscordDispatcher.dispatch_event(map.id, event)
@@ -291,6 +298,7 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcherTest do
   end
 
   test "skips excluded systems", %{map: map, notification: n, system: w} do
+    track(map.id, [])
     {:ok, _} = MapDiscordNotification.update(n, %{excluded_systems: [@wh_system]})
     DiscordDispatcher.invalidate_cache(map.id)
 
@@ -553,6 +561,74 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcherTest do
       # assertion, so `settle/1` alone is not enough — a third request could
       # still be in flight in an async task. Wait until BOTH workers are
       # genuinely idle, or the count passes for the wrong reason.
+      deadline = System.monotonic_time(:millisecond) + 2_000
+      assert await_worker_idle(system_wh.id, deadline) in [:idle, :no_worker]
+      assert await_worker_idle(character_wh.id, deadline) in [:idle, :no_worker]
+
+      assert length(HttpStub.requests()) == 2
+    end
+
+    # End-to-end proof of the corporation filter's REPLACEMENT semantic, which
+    # only shows up when all three pieces (Matcher, Router, dispatcher) agree.
+    # One batch, three kills, three different answers:
+    #
+    #   * a filtered corporation in an EXCLUDED system  -> character channel
+    #     (the carve-out follows the filter, not the tracked characters)
+    #   * a TRACKED character in an allowed system      -> system channel
+    #     (the filter took them out of the character channel)
+    #   * a TRACKED character in an EXCLUDED system     -> dropped
+    #     (no carve-out either, for the same reason)
+    #
+    # If the filter ever reverts to widening the tracked set, the last two land
+    # in the character channel and this test fails on both counts.
+    test "a corporation filter replaces tracked characters for character routing", %{
+      map: map,
+      notification: n,
+      system: system_wh
+    } do
+      character_wh = character_webhook(n)
+      track(map.id, [1001])
+
+      {:ok, _} =
+        MapDiscordNotification.update(n, %{
+          wh_only: false,
+          excluded_systems: [@ks_system],
+          focus_corp_ids: [500_001]
+        })
+
+      DiscordDispatcher.invalidate_cache(map.id)
+
+      filtered_corp =
+        killmail(710_001, %{"solar_system_id" => @ks_system, "victim_corp_id" => 500_001})
+
+      tracked_char =
+        killmail(710_002, %{"solar_system_id" => @wh_system, "victim_char_id" => 1001})
+
+      tracked_char_excluded =
+        killmail(710_003, %{"solar_system_id" => @ks_system, "victim_char_id" => 1001})
+
+      DiscordDispatcher.dispatch_event(
+        map.id,
+        kill_event(
+          Factory.build(:kill_event, %{
+            solar_system_id: @wh_system,
+            killmails: [filtered_corp, tracked_char, tracked_char_excluded]
+          })
+        )
+      )
+
+      settle(system_wh.id)
+      settle(character_wh.id)
+
+      requests = wait_for_requests(2)
+      by_url = Enum.group_by(requests, &elem(&1, 0), &elem(&1, 1))
+
+      assert [character_body] = by_url[@character_url]
+      assert [%{"footer" => %{"text" => "Killmail ID: 710001"}}] = character_body["embeds"]
+
+      assert [system_body] = by_url[@system_url]
+      assert [%{"footer" => %{"text" => "Killmail ID: 710002"}}] = system_body["embeds"]
+
       deadline = System.monotonic_time(:millisecond) + 2_000
       assert await_worker_idle(system_wh.id, deadline) in [:idle, :no_worker]
       assert await_worker_idle(character_wh.id, deadline) in [:idle, :no_worker]

--- a/test/wanderer_app/external_events/discord/matcher_test.exs
+++ b/test/wanderer_app/external_events/discord/matcher_test.exs
@@ -38,16 +38,20 @@ defmodule WandererApp.ExternalEvents.Discord.MatcherTest do
       assert MapSet.member?(Matcher.tracked_eve_ids(map.id), 2_117_994_022)
     end
 
-    test "returns an empty MapSet for a map that is not running" do
+    # NOT an empty MapSet. An empty set is a claim that nobody is tracked, and
+    # `involvement/3` acts on that claim: every kill becomes `:not_involved`,
+    # which is what enables the wormhole-only filter — so a map that is briefly
+    # not running would silently drop all of its k-space kills.
+    test "reports :unavailable for a map that is not running" do
       unknown_map_id = Ecto.UUID.generate()
 
-      assert Matcher.tracked_eve_ids(unknown_map_id) == MapSet.new()
+      assert Matcher.tracked_eve_ids(unknown_map_id) == :unavailable
     end
 
-    test "does not cache the empty result of a failed lookup" do
+    test "does not cache the result of a failed lookup" do
       unknown_map_id = Ecto.UUID.generate()
 
-      assert Matcher.tracked_eve_ids(unknown_map_id) == MapSet.new()
+      assert Matcher.tracked_eve_ids(unknown_map_id) == :unavailable
 
       assert {:ok, nil} =
                Cachex.get(:discord_notification_cache, "map:#{unknown_map_id}:tracked_eve_ids")


### PR DESCRIPTION
Follow-up to the routing review on the Discord kill notifications feature. Three findings, plus the docs and UI copy that go with them.

## 1. Undetermined involvement was indistinguishable from "not ours"

`Matcher.involvement/3` returned `:not_involved` both when it had checked and found nothing, and when it could not check at all. `Router` treats `:not_involved` as permission to apply `excluded_systems` and `wh_only` — so a Cachex outage, or a map that was briefly not running, silently dropped **every k-space kill on every map with the default `wh_only`**, with one debug line as the only evidence.

`tracked_eve_ids/1` now returns `:unavailable` instead of an empty `MapSet` (an empty set is a factual claim that nobody is tracked, and the router acts on it). `involvement/3` gained an `:unknown` verdict. `Router` lets only a positive `:not_involved` open the filters; `:unknown` bypasses them and goes to the **system** webhook — never the character one, which is supposed to mean "these are ours".

## 2. Flat payloads hit the same silent drop

A payload with no attacker keys at all — absence is this codebase's own "we don't know who attacked" signal, as distinct from an empty list meaning "we know, and it was nobody" — produced the same wrong `:not_involved`. Now `:unknown`, and the diagnostic went from `Logger.debug` to a throttled `Logger.warning`: it is the reason a kill lands in the system channel instead of the character one, so it should be visible without enabling debug logging.

## 3. The corporation filter widened the channel instead of narrowing it

`focus_corp_ids` was a union — map-tracked characters **or** filtered corporations. The intent is **replacement**: when set, the filter answers "who is the character channel for" on its own, so an admin can use it to take untracked pilots *out* of that channel. As a union it could only ever widen, which is the opposite of what it is for.

- Non-empty → involvement is decided purely by corporation membership (victim first, then attackers).
- Empty → map-tracked characters, i.e. exactly today's behaviour. **No migration, no config change, no attribute or schema change.**
- Either way, matching kills keep the carve-out and bypass both filters.

Relabelled *Focus corporations* → **Corporation filter**, with copy that states the replacement.

## Also in here

**Add-button alignment.** The remaining vertical offset was not in the notifications component: `CoreComponents.live_select/1` always rendered an empty daisyUI `.label` spacer row above the input, so the wrapper was taller than the input and `items-end` on the row aligned the button to the wrapper. Added an opt-out `label_row` attr defaulting to `true` (no existing call site moves) and switched the two notification forms to `items-start`.

**Factory fix.** The `:killmail` factory claimed to mirror `adapt_nested_format_kill/1` but omitted the attacker id lists, so every routing test was accidentally exercising the undetermined path — which is why two dispatcher tests passed while asserting the wrong thing. Fixed, with a note that the keys' absence is load-bearing for the tests that do want that path.

**Blog post** updated with the four-rule routing table, the undetermined case and why it bypasses rules 1–2, and the corporation-filter semantics.

## Verification

- `MIX_ENV=test mix compile` — clean
- `mix test test/unit/external_events/ test/wanderer_app/external_events/` — **237 tests, 0 failures**
- `mix format` — applied

New coverage: two `matcher_involvement_test.exs` tests assert a tracked victim and a tracked attacker are **not** matched while a filter is set (these are the ones that go red if the union ever comes back); three router tests pin `:unknown` against both filters and against the character webhook; one end-to-end dispatcher test routes a filtered-corp kill in an excluded system to the character channel while a tracked character's kill in the same excluded system is dropped.

**Not browser-verified** — the alignment fix was reasoned from the shared component's markup, no browser available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)