### PR TITLE
feat(web): add GET /health

### DIFF
--- a/lib/wanderer_app_web/controllers/health_controller.ex
+++ b/lib/wanderer_app_web/controllers/health_controller.ex
@@ -1,0 +1,48 @@
+defmodule WandererAppWeb.HealthController do
+  @moduledoc """
+  Process liveness, for orchestrator health checks.
+
+  Answers one question: is this instance serving? It must never gain an
+  authentication, rate-limiting, or feature-flag plug — see the `:health`
+  pipeline in the router.
+
+  Database reachability is reported in the body but deliberately does not change
+  the status code. An orchestrator restarts or replaces an instance that fails
+  its check, and a restart cannot repair an external Postgres outage — so
+  letting the database drive the status code turns a transient blip (a network
+  partition, pool exhaustion, a slow migration) into a restart loop on top of
+  the original problem. Reporting it in the body keeps the information available
+  to humans and dashboards without wiring it to a kill signal.
+  """
+  use WandererAppWeb, :controller
+
+  # Short on purpose. This endpoint is polled every few seconds; the Repo default
+  # of 15s would let a saturated database hold each request open long enough for
+  # polls to pile up on top of the problem.
+  @db_check_timeout_ms 2_000
+
+  def index(conn, _params) do
+    json(conn, %{
+      status: "ok",
+      version: to_string(WandererApp.Env.vsn()),
+      database: if(database_reachable?(), do: "ok", else: "unreachable")
+    })
+  end
+
+  defp database_reachable? do
+    case Ecto.Adapters.SQL.query(WandererApp.Repo, "SELECT 1", [], timeout: @db_check_timeout_ms) do
+      {:ok, _} -> true
+      _ -> false
+    end
+  rescue
+    # Most query-level failures come back as an error tuple and are handled
+    # above; this catches the ones that raise instead.
+    _ -> false
+  catch
+    # `rescue` does not cover exits. If the connection pool is not alive, the
+    # GenServer.call inside DBConnection exits with :noproc or :timeout, which
+    # would otherwise crash the request into a 500 — the exact status this
+    # endpoint exists to avoid returning for a database fault.
+    :exit, _ -> false
+  end
+end

--- a/lib/wanderer_app_web/router.ex
+++ b/lib/wanderer_app_web/router.ex
@@ -174,6 +174,15 @@ defmodule WandererAppWeb.Router do
     plug WandererAppWeb.Plugs.CheckApiDisabled
   end
 
+  # Deliberately minimal, and it must stay that way. A liveness check that can
+  # be switched off by configuration is worse than no check at all: the
+  # orchestrator reads the resulting non-200 as a dead process and restarts or
+  # replaces the container, so a product feature flag becomes an outage. No
+  # CheckApiDisabled, no auth, no rate limit.
+  pipeline :health do
+    plug :accepts, ["json"]
+  end
+
   # Versioned API pipeline with enhanced security and validation
   pipeline :api_versioned do
     plug WandererAppWeb.Plugs.ContentNegotiation, accepts: ["json"]
@@ -373,8 +382,14 @@ defmodule WandererAppWeb.Router do
   # Health Check Endpoints
   # Used for monitoring, load balancer health checks, and deployment validation
   #
-  scope "/api", WandererAppWeb do
-    pipe_through [:api]
+  # This scope's POSITION IN THE FILE IS LOAD-BEARING. It must stay above the
+  # `live "/:slug", MapLive, :index` wildcard further down. Phoenix matches
+  # routes in definition order, so below that line `/health` is swallowed by the
+  # wildcard and answers 302 to /welcome instead of 200.
+  scope "/", WandererAppWeb do
+    pipe_through [:health]
+
+    get "/health", HealthController, :index
   end
 
   # scope "/api/licenses", WandererAppWeb do

--- a/test/wanderer_app_web/controllers/health_controller_test.exs
+++ b/test/wanderer_app_web/controllers/health_controller_test.exs
@@ -1,0 +1,26 @@
+defmodule WandererAppWeb.HealthControllerTest do
+  use WandererAppWeb.ConnCase
+
+  import WandererApp.EnvHelper
+
+  test "GET /health returns 200 with status, version and database state", %{conn: conn} do
+    conn = get(conn, "/health")
+
+    assert %{"status" => "ok", "version" => version, "database" => database} =
+             json_response(conn, 200)
+
+    assert is_binary(version)
+    assert database == "ok"
+  end
+
+  # The reason this route does not live in the :api scope, which pipes through
+  # CheckApiDisabled. A 403 here reads to an orchestrator as a dead instance, so
+  # setting WANDERER_PUBLIC_API_DISABLED would restart a perfectly healthy
+  # container. This test is the guard.
+  test "GET /health still returns 200 when the public API is disabled", %{conn: conn} do
+    with_env_override(:public_api_disabled, true) do
+      conn = get(conn, "/health")
+      assert %{"status" => "ok"} = json_response(conn, 200)
+    end
+  end
+end


### PR DESCRIPTION
Fills in the health endpoint the router has been reserving: `lib/wanderer_app_web/router.ex` carries a `Health Check Endpoints — Used for monitoring, load balancer health checks, and deployment validation` comment above an empty scope, and there is no `HealthController` in the repo today.

`GET /health` returns 200 with the app version and database reachability:

```json
{"status": "ok", "version": "1.x.y", "database": "ok"}
```

## Two decisions worth a look

**It is not in the `:api` scope.** That pipeline runs `CheckApiDisabled`, which halts with 403 when `WANDERER_PUBLIC_API_DISABLED` is set — and an orchestrator reads 403 as a dead instance, so a product feature flag would start restarting healthy containers. The flag defaults to false, so that failure would have been latent until someone set it. The new `:health` pipeline is `:accepts` only, and there is a test asserting 200 while the public API is disabled.

**The database does not gate the status code.** A restart cannot repair an external Postgres outage, so wiring reachability to the status code turns a transient blip — network partition, pool exhaustion, a slow migration — into a restart loop on top of the original problem. Reachability is reported in the body for humans and dashboards instead. Two details follow from that: the check is bounded to 2s rather than the `Repo` default of 15s, since a saturated database would otherwise hold each poll open long enough for them to pile up; and it catches `:exit` as well as rescuing, because a dead connection pool exits rather than raises, which would crash the request into the 500 this endpoint exists to avoid returning.

## One placement note

The scope sits above the `live "/:slug", MapLive, :index` wildcard deliberately. Phoenix matches routes in definition order, so below that line `/health` is swallowed by the wildcard and answers 302 to `/welcome` instead of 200. There is a comment saying so.

## Testing

`mix test test/wanderer_app_web/controllers/health_controller_test.exs` — 2 tests, 0 failures.

## Context

Extracted from the Fly.io deployment work on `guarzo/zoo`, where this endpoint backs the platform health check. Nothing in the diff is Fly-specific — it is equally a Kubernetes liveness probe or a compose `healthcheck` — and it is deliberately self-contained so it can be reviewed on its own. The remaining Fly changes will follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)