### PR TITLE
fix: reach the route builder over IPv6

### DIFF
--- a/lib/wanderer_app/esi/api_client.ex
+++ b/lib/wanderer_app/esi/api_client.ex
@@ -71,6 +71,7 @@ defmodule WandererApp.Esi.ApiClient do
           }
         ]
         |> Keyword.merge(@timeout_opts)
+        |> Keyword.merge(WandererApp.RouteBuilderClient.connect_opts())
       )
 
   def get_routes_eve(hubs, origin, _params, _opts),

--- a/lib/wanderer_app/route_builder_client.ex
+++ b/lib/wanderer_app/route_builder_client.ex
@@ -6,6 +6,28 @@ defmodule WandererApp.RouteBuilderClient do
   require Logger
 
   @timeout_opts [pool_timeout: 5_000, receive_timeout: :timer.seconds(30)]
+
+  # Mint resolves IPv4-only unless told otherwise, but on Fly the route builder
+  # is reachable only over the IPv6 6PN network — `route-builder.internal` has
+  # no A record at all, so every request fails with :nxdomain. Callers see that
+  # as an ordinary route lookup failure, and the ESI fallback path then reports
+  # "no connection" for every hub, so nothing in the logs names DNS.
+  #
+  # `inet6: true` keeps Mint's `inet4: true` default, which means it tries IPv6
+  # first and falls back to IPv4. Deployments where the route builder is an
+  # IPv4 docker-compose service (CUSTOM_ROUTE_BASE_URL=http://eve-route-builder:2001)
+  # keep working, at the cost of one failed resolution per new connection.
+  # That fallback is why this is unconditional rather than an operator flag: a
+  # flag left unset on Fly fails silently, which is the bug being fixed here.
+  @connect_opts [connect_options: [transport_opts: [inet6: true]]]
+
+  @doc """
+  Req options every caller of the route builder service must pass.
+
+  Shared with `WandererApp.Esi.ApiClient`, which posts to `/route/multiple` on
+  the same service.
+  """
+  def connect_opts, do: @connect_opts
   @loot_dir Path.join(["repo", "data", "route_by_systems"])
   @available_routes_by ["blueLoot", "redLoot", "thera", "turnur", "so_cleaning", "trade_hubs"]
 
@@ -36,7 +58,7 @@ defmodule WandererApp.RouteBuilderClient do
       count: count || 1
     }
 
-    case Req.post(url, Keyword.merge([json: payload], @timeout_opts)) do
+    case Req.post(url, Keyword.merge([json: payload], @timeout_opts ++ @connect_opts)) do
       {:ok, %{status: status, body: body}} when status in [200, 201] ->
         {:ok, body}
 


### PR DESCRIPTION
Reaches the route builder over IPv6.

`WandererApp.RouteBuilderClient` and `WandererApp.Esi.ApiClient.get_routes_custom/3`
both POST to the route builder service. Mint resolves IPv4-only by default, and on
Fly that service is reachable only over the IPv6 6PN network — `route-builder.internal`
has no A record at all, so every request failed with `:nxdomain`.

Measured from the deployed machine:

```
:inet.getaddr(~c"route-builder.internal", :inet)  => {:error, :nxdomain}
:inet.getaddr(~c"route-builder.internal", :inet6) => {:ok, {...}}
:gen_tcp.connect(~c"route-builder.internal", 2001, [:inet6], 5000) => {:ok, port}
```

**Why it was invisible.** `get_all_routes/4` discards the error reason and falls back
to `Esi.ApiClient.get_routes_eve/4`, whose body is stubbed to return
`%{"success" => false}` for every hub. The UI showed "no connection" on every route
and nothing in the logs named DNS.

**Why it is unconditional rather than a flag.** `inet6: true` keeps Mint's `inet4: true`
default, so it tries IPv6 first and falls back to IPv4. docker-compose deployments
pointing `CUSTOM_ROUTE_BASE_URL` at an IPv4 service keep working, at the cost of one
failed resolution per new connection. A flag left unset on Fly fails silently — which
is the failure being fixed.

The option lives in one place, `RouteBuilderClient.connect_opts/0`, and `ApiClient`
merges it, so the two callers of the same service cannot drift apart.

## Context

This fix is currently deployed but existed only on a local branch — `guarzo/zoo` does
not have it, so a build from `zoo` today would regress route building. That gap is
what this PR closes.

## Verification

- `mix format --check-formatted` on both files — clean
- `MIX_ENV=test mix compile` — exit 0, no new warnings
- `mix test test/unit/esi test/unit/map_route_api_controller_test.exs` — 37 tests, 0 failures
- Live: route building confirmed working on the Fly deployment with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
