### PR TITLE
fix: stop rotating the unsplashed-holes badge

### DIFF
--- a/assets/js/hooks/Mapper/components/map/components/SolarSystemNode/SolarSystemNodeZoo.tsx
+++ b/assets/js/hooks/Mapper/components/map/components/SolarSystemNode/SolarSystemNodeZoo.tsx
@@ -116,10 +116,7 @@ export const SolarSystemNodeZoo = memo((props: NodeProps<MapSolarSystemType>) =>
           )}
 
           {unsplashedCount > 0 && (
-            <div
-              className={clsx(classes.Bookmark, MARKER_BOOKMARK_BG_STYLES.unSplashed)}
-              style={{ display: 'flex', transform: 'rotate(-90deg)' }}
-            >
+            <div className={clsx(classes.Bookmark, MARKER_BOOKMARK_BG_STYLES.unSplashed)} style={{ display: 'flex' }}>
               <GiConcentrationOrb
                 size={8}
                 color="#38bdf8"


### PR DESCRIPTION
## Problem

The unsplashed-holes indicator on map nodes renders vertically — the orb icon sits above the count in a tall, narrow pill instead of side by side.

## Cause

`SolarSystemNodeZoo.tsx` applies an inline `transform: rotate(-90deg)` to the badge, turning the whole thing a quarter turn.

The rotation was introduced in `defb2443` as `rotate(-90dg)`. `dg` is not a valid CSS angle unit, so the browser discarded the entire `transform` declaration and the badge rendered flat and horizontal. `e791d4e1` (2026-08-01) corrected the typo to `-90deg`, which activated a rotation that had never actually rendered — that's when the odd layout showed up.

This is fork-local; the file does not exist upstream.

## Fix

Drop the transform. The orb's `marginRight: 2px` and the count's `marginTop: 1px` are both tuned for horizontal flow, which indicates horizontal was the intended design all along.

## Verification

Not visually verified — the change is a pure inline-style deletion, but it has not been rendered. Validating locally before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)