### PR TITLE
feat(discord): add notable items section to kill embeds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,17 @@ export WANDERER_WEBHOOK_TIMEOUT_MS="15000"
 # export WANDERER_DISCORD_MAX_KILLMAIL_AGE_SECONDS="3600"
 # Connection pool size for Discord kill notification delivery (optional, default 10)
 # export WANDERER_DISCORD_POOL_SIZE="10"
+# Adds a "Notable Items" section listing the most valuable DROPPED loot on each
+# kill. Off by default: it costs an extra ESI killmail fetch per kill plus a
+# market lookup, on the dispatcher's critical path. (optional, default false)
+# export WANDERER_NOTABLE_ITEMS_ENABLED="false"
+# Only items worth strictly more than this are listed (optional, default 50000000)
+# export WANDERER_NOTABLE_ITEMS_THRESHOLD_ISK="50000000"
+# At most this many items per kill, highest value first (optional, default 5)
+# export WANDERER_NOTABLE_ITEMS_LIMIT="5"
+# How long enrichment may hold up one kill batch. Raising it delays kill
+# notifications for every map on the instance. (optional, default 1500)
+# export WANDERER_NOTABLE_ITEMS_TIMEOUT_MS="1500"
 
 # Promo codes for map subscriptions (optional)
 # Format: CODE:DISCOUNT_PERCENT,CODE2:DISCOUNT_PERCENT2

--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ Finch connection pool used for Discord delivery.
 `WANDERER_DISCORD_MAX_KILLMAIL_AGE_SECONDS` (default `3600`) drops killmails
 older than the given age, so an upstream replay does not post stale kills.
 
+`WANDERER_NOTABLE_ITEMS_ENABLED` (default `false`) adds a "Notable Items"
+section to each kill embed, listing the most valuable loot that *dropped*
+(destroyed modules are excluded). It is off by default because building it costs
+one extra ESI killmail fetch per kill plus a market price lookup, on the
+dispatcher's critical path. `WANDERER_NOTABLE_ITEMS_THRESHOLD_ISK` (default
+`50000000`) sets the minimum value an item must exceed to be listed,
+`WANDERER_NOTABLE_ITEMS_LIMIT` (default `5`) caps how many are listed per kill,
+and `WANDERER_NOTABLE_ITEMS_TIMEOUT_MS` (default `1500`) bounds how long
+enrichment may hold up a batch — raising it delays kill notifications for every
+map on the instance. Prices are Jita 4-4 quotes; abyssal modules are listed
+without a price, since market quotes for them are not meaningful. Any failure —
+timeout, ESI error, unavailable pricing — simply omits the section; the kill is
+still posted.
+
 The webhook URL is stored encrypted and is never displayed in full after it is
 saved — the settings tab shows only a masked hint. Pointing a destination at a
 different channel means entering the full URL again.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -502,7 +502,16 @@ config :wanderer_app, :external_events,
     config_dir |> get_int_from_path_or_env("WANDERER_WEBHOOK_TIMEOUT_MS", 15000),
   discord_max_killmail_age_seconds:
     config_dir
-    |> get_int_from_path_or_env("WANDERER_DISCORD_MAX_KILLMAIL_AGE_SECONDS", 3600)
+    |> get_int_from_path_or_env("WANDERER_DISCORD_MAX_KILLMAIL_AGE_SECONDS", 3600),
+  notable_items_enabled:
+    config_dir
+    |> get_var_from_path_or_env("WANDERER_NOTABLE_ITEMS_ENABLED", "false")
+    |> String.to_existing_atom(),
+  notable_items_threshold_isk:
+    config_dir |> get_int_from_path_or_env("WANDERER_NOTABLE_ITEMS_THRESHOLD_ISK", 50_000_000),
+  notable_items_limit: config_dir |> get_int_from_path_or_env("WANDERER_NOTABLE_ITEMS_LIMIT", 5),
+  notable_items_timeout_ms:
+    config_dir |> get_int_from_path_or_env("WANDERER_NOTABLE_ITEMS_TIMEOUT_MS", 1500)
 
 # Signature expiration — evaluated at boot so the deployment's env vars win over
 # whatever was set when the release was built. Defaults mirror config.exs.

--- a/lib/wanderer_app/application.ex
+++ b/lib/wanderer_app/application.ex
@@ -64,6 +64,18 @@ defmodule WandererApp.Application do
           ]
         }
       },
+      # Triff pool - isolated so a slow market API cannot exhaust the ESI or
+      # Discord pools. App-env only, matching the Discord pool: no env vars.
+      {
+        Finch,
+        name: WandererApp.Finch.Triff,
+        pools: %{
+          default: [
+            size: Application.get_env(:wanderer_app, :finch_triff_pool_size, 25),
+            count: Application.get_env(:wanderer_app, :finch_triff_pool_count, 2)
+          ]
+        }
+      },
       # Default pool - everything else (email, license manager, etc.)
       {
         Finch,

--- a/lib/wanderer_app/application.ex
+++ b/lib/wanderer_app/application.ex
@@ -65,7 +65,9 @@ defmodule WandererApp.Application do
         }
       },
       # Triff pool - isolated so a slow market API cannot exhaust the ESI or
-      # Discord pools. App-env only, matching the Discord pool: no env vars.
+      # Discord pools. Sized from app env with the same defaults as the webhooks
+      # pool; no dedicated env var, since the request rate is bounded by the
+      # dispatcher's enrichment budget.
       {
         Finch,
         name: WandererApp.Finch.Triff,

--- a/lib/wanderer_app/env.ex
+++ b/lib/wanderer_app/env.ex
@@ -134,6 +134,66 @@ defmodule WandererApp.Env do
     @default_discord_max_killmail_age_seconds
   end
 
+  @default_notable_items_threshold_isk 50_000_000
+  @default_notable_items_limit 5
+  @default_notable_items_timeout_ms 1_500
+
+  @doc """
+  Whether Discord kill embeds carry a **Notable Items** section.
+
+  Off by default: the section costs an ESI killmail fetch and a market lookup on
+  the dispatcher's critical path, so it is opt-in per deployment.
+  """
+  def notable_items_enabled?() do
+    Application.get_env(@app, :external_events, [])
+    |> Keyword.get(:notable_items_enabled, false)
+  end
+
+  @doc """
+  Minimum ISK value for a dropped item to be worth naming. Matches
+  wanderer-notifier's threshold.
+  """
+  def notable_items_threshold_isk() do
+    Application.get_env(@app, :external_events, [])
+    |> Keyword.get(:notable_items_threshold_isk, @default_notable_items_threshold_isk)
+    |> validate_positive_integer(
+      :notable_items_threshold_isk,
+      @default_notable_items_threshold_isk
+    )
+  end
+
+  @doc "Maximum items listed per kill. Matches wanderer-notifier's limit."
+  def notable_items_limit() do
+    Application.get_env(@app, :external_events, [])
+    |> Keyword.get(:notable_items_limit, @default_notable_items_limit)
+    |> validate_positive_integer(:notable_items_limit, @default_notable_items_limit)
+  end
+
+  @doc """
+  Hard ceiling on how long enrichment may block the singleton dispatcher.
+
+  This budget is load-bearing — see the concurrency notes in
+  `WandererApp.ExternalEvents.Discord.NotableItems`. Raising it stalls kill
+  notifications for every map on the instance.
+  """
+  def notable_items_timeout_ms() do
+    Application.get_env(@app, :external_events, [])
+    |> Keyword.get(:notable_items_timeout_ms, @default_notable_items_timeout_ms)
+    |> validate_positive_integer(:notable_items_timeout_ms, @default_notable_items_timeout_ms)
+  end
+
+  defp validate_positive_integer(value, _key, _default) when is_integer(value) and value > 0,
+    do: value
+
+  defp validate_positive_integer(value, key, default) do
+    Logger.warning(
+      "[Discord] #{key} must be a positive integer, " <>
+        "got #{inspect(value)}; falling back to #{default}"
+    )
+
+    default
+  end
+
   @decorate cacheable(
               cache: WandererApp.Cache,
               key: "map-connection-auto-expire-hours"

--- a/lib/wanderer_app/env.ex
+++ b/lib/wanderer_app/env.ex
@@ -120,18 +120,10 @@ defmodule WandererApp.Env do
   def discord_max_killmail_age_seconds() do
     Application.get_env(@app, :external_events, [])
     |> Keyword.get(:discord_max_killmail_age_seconds, @default_discord_max_killmail_age_seconds)
-    |> validate_max_killmail_age()
-  end
-
-  defp validate_max_killmail_age(seconds) when is_integer(seconds) and seconds > 0, do: seconds
-
-  defp validate_max_killmail_age(seconds) do
-    Logger.warning(
-      "[Discord] discord_max_killmail_age_seconds must be a positive integer, " <>
-        "got #{inspect(seconds)}; falling back to #{@default_discord_max_killmail_age_seconds}"
+    |> validate_positive_integer(
+      :discord_max_killmail_age_seconds,
+      @default_discord_max_killmail_age_seconds
     )
-
-    @default_discord_max_killmail_age_seconds
   end
 
   @default_notable_items_threshold_isk 50_000_000

--- a/lib/wanderer_app/external_events/discord/embed_formatter.ex
+++ b/lib/wanderer_app/external_events/discord/embed_formatter.ex
@@ -139,7 +139,7 @@ defmodule WandererApp.ExternalEvents.Discord.EmbedFormatter do
       "title" => truncate(title(kill, system_name), @max_title_length),
       "url" => zkill_url(kill["killmail_id"]),
       "color" => color(verdict, kill["total_value"]),
-      "description" => truncate(description(kill), @max_description_length),
+      "description" => full_description(kill),
       "fields" => fields(kill)
     }
     |> maybe_put("author", author(kill, verdict))
@@ -209,6 +209,68 @@ defmodule WandererApp.ExternalEvents.Discord.EmbedFormatter do
     |> Enum.join()
     |> Kernel.<>(".")
   end
+
+  # The notable-items section is PRE-BUDGETED rather than left to `truncate/2`.
+  # `truncate/2` cuts at an arbitrary grapheme, which on a bullet list emits a
+  # half-written item name or a bare "• ". So the base description is truncated
+  # first, and only whole item lines that still fit are appended. If not even
+  # one fits, the header is omitted too — never a heading with nothing under it.
+  #
+  # A dropped line is silent: the ISK threshold already makes this a top-N, not
+  # an inventory. The `truncate/2` call stays because it still guards the base.
+  defp full_description(kill) do
+    base = truncate(description(kill), @max_description_length)
+    base <> notable_items_section(kill["notable_items"], String.length(base))
+  end
+
+  @notable_items_header "\n\n**Notable Items:**\n"
+
+  defp notable_items_section(items, used) when is_list(items) do
+    budget = @max_description_length - used - String.length(@notable_items_header)
+
+    case items |> Enum.flat_map(&item_line/1) |> take_fitting(budget) do
+      [] -> ""
+      lines -> @notable_items_header <> Enum.join(lines, "\n")
+    end
+  end
+
+  defp notable_items_section(_items, _used), do: ""
+
+  defp take_fitting(lines, budget) do
+    {kept, _used} =
+      Enum.reduce_while(lines, {[], 0}, fn line, {kept, used} ->
+        # The +1 is the newline joining this line to the previous one.
+        needed = String.length(line) + if kept == [], do: 0, else: 1
+
+        if used + needed <= budget,
+          do: {:cont, {[line | kept], used + needed}},
+          else: {:halt, {kept, used}}
+      end)
+
+    Enum.reverse(kept)
+  end
+
+  # Abyssal modules carry no price: their market values are unreliable enough
+  # that quoting one would be worse than saying nothing, matching
+  # wanderer-notifier.
+  defp item_line(%{name: name, quantity: quantity} = item)
+       when is_binary(name) and is_integer(quantity) and quantity > 0 do
+    count = if quantity > 1, do: " x#{quantity}", else: ""
+
+    price =
+      if Map.get(item, :abyssal?) do
+        ""
+      else
+        case format_isk(Map.get(item, :value)) do
+          nil -> ""
+          isk -> " (~#{isk})"
+        end
+      end
+
+    ["• #{name}#{count}#{price}"]
+  end
+
+  defp item_line(_item), do: []
 
   defp victim_clause(kill) do
     pilot =

--- a/lib/wanderer_app/external_events/discord/notable_items.ex
+++ b/lib/wanderer_app/external_events/discord/notable_items.ex
@@ -1,0 +1,217 @@
+defmodule WandererApp.ExternalEvents.Discord.NotableItems do
+  @moduledoc """
+  Resolves the notable dropped loot for a batch of killmails, for the
+  **Notable Items** section of the Discord kill embed.
+
+  ## Why this needs network calls at all
+
+  Kills reach us over the wanderer-kills websocket, whose payload carries no
+  item data — its `Killmail` JSON encoder emits victim, attackers, system, and
+  zkb metadata only. So the items have to be fetched from ESI using the
+  killmail hash that *is* in the payload (`zkb.hash`), exactly as
+  wanderer-notifier does.
+
+  ## Pipeline
+
+  1. `zkb.hash` → `get_killmail/2` on ESI.
+  2. Flatten `victim.items` **recursively**. A container entry carries its own
+     nested `items` list; wanderer-notifier reads the list flat and therefore
+     silently omits loot inside a cargo container. Flattening is a deliberate
+     improvement over that behaviour, not parity with it.
+  3. Keep only entries with a `quantity_dropped` key — destroyed items no
+     longer exist. Note that dropped-vs-destroyed is the *presence of the key*,
+     not a value.
+  4. Sum quantities per `item_type_id`: the same module fitted to several slots
+     appears as several entries with distinct `flag`s.
+  5. Price through `WandererApp.Market.Triff`, one batched request for the whole
+     candidate set.
+  6. Filter above the ISK threshold, sort descending, take the limit.
+  7. **Only then** resolve type names, for the handful of survivors. Names are a
+     per-type ESI call, so pricing first keeps the common case at zero lookups.
+
+  ## Fail-open
+
+  Every failure path — missing hash, ESI error, market error, unresolvable name
+  — omits that kill or that item and returns. Nothing raises and nothing
+  returns `{:error, _}`. A missing section is an acceptable outcome; a missing
+  kill notification is not.
+
+  ## Test seam
+
+  ESI is resolved through `Application.get_env(:wanderer_app, :esi_client, ...)`
+  rather than called directly, mirroring `Discord.HttpClient`. Every other ESI
+  caller in the app still calls `WandererApp.Esi` directly; introducing the seam
+  app-wide is out of scope for this feature, so a reader will find two idioms.
+  """
+
+  require Logger
+
+  alias WandererApp.Market.Triff
+
+  @type item :: %{
+          name: String.t(),
+          quantity: pos_integer(),
+          value: float(),
+          abyssal?: boolean()
+        }
+
+  @doc """
+  Returns `%{killmail_id => [item]}` for the kills that have notable loot.
+
+  Kills with no notable loot are **absent from the map**, not present with an
+  empty list.
+  """
+  @callback enrich([map()]) :: %{optional(term()) => [item()]}
+
+  @doc "Returns the configured enricher, so the dispatcher can inject a stub."
+  def impl, do: Application.get_env(:wanderer_app, :notable_items_enricher, __MODULE__)
+
+  @spec enrich([map()]) :: %{optional(term()) => [item()]}
+  def enrich([]), do: %{}
+
+  def enrich(kills) do
+    dropped =
+      Enum.reduce(kills, %{}, fn kill, acc ->
+        case dropped_quantities(kill) do
+          {killmail_id, quantities} when map_size(quantities) > 0 ->
+            Map.put(acc, killmail_id, quantities)
+
+          _ ->
+            acc
+        end
+      end)
+
+    if map_size(dropped) == 0, do: %{}, else: price_and_select(dropped)
+  end
+
+  # -- step 1-4: dropped quantities per kill ---------------------------------
+
+  defp dropped_quantities(kill) do
+    with killmail_id when not is_nil(killmail_id) <- kill["killmail_id"],
+         hash when is_binary(hash) <- hash(kill),
+         {:ok, killmail} <- safe(fn -> esi_client().get_killmail(killmail_id, hash) end, :error) do
+      {killmail_id, sum_dropped(killmail)}
+    else
+      _ -> :skip
+    end
+  end
+
+  # Defensive: `MessageHandler.add_core_kill_data/3` retains the whole `zkb`
+  # map, but the flat-format path may not, and a kill without a hash is simply
+  # one we cannot enrich.
+  defp hash(%{"zkb" => %{"hash" => hash}}) when is_binary(hash), do: hash
+  defp hash(_kill), do: nil
+
+  defp sum_dropped(%{"victim" => %{"items" => items}}) when is_list(items) do
+    items
+    |> flatten_items()
+    |> Enum.reduce(%{}, &add_dropped/2)
+  end
+
+  defp sum_dropped(_killmail), do: %{}
+
+  # A container is itself dropped loot, so it is kept alongside its contents.
+  defp flatten_items(items) when is_list(items) do
+    Enum.flat_map(items, fn
+      %{"items" => nested} = item when is_list(nested) -> [item | flatten_items(nested)]
+      item -> [item]
+    end)
+  end
+
+  defp flatten_items(_items), do: []
+
+  defp add_dropped(%{"item_type_id" => type_id, "quantity_dropped" => quantity}, acc)
+       when is_integer(type_id) and is_integer(quantity) and quantity > 0,
+       do: Map.update(acc, type_id, quantity, &(&1 + quantity))
+
+  defp add_dropped(_item, acc), do: acc
+
+  # -- step 5-7: price, select, name -----------------------------------------
+
+  defp price_and_select(dropped) do
+    type_ids = dropped |> Map.values() |> Enum.flat_map(&Map.keys/1) |> Enum.uniq()
+
+    case safe(fn -> Triff.quote_types(type_ids) end, :error) do
+      {:ok, prices} -> select_and_name(dropped, prices)
+      _ -> %{}
+    end
+  end
+
+  defp select_and_name(dropped, prices) do
+    threshold = WandererApp.Env.notable_items_threshold_isk()
+    limit = WandererApp.Env.notable_items_limit()
+
+    selected =
+      dropped
+      |> Enum.map(fn {killmail_id, quantities} ->
+        {killmail_id, select(quantities, prices, threshold, limit)}
+      end)
+      |> Enum.reject(fn {_killmail_id, selected} -> selected == [] end)
+
+    names = resolve_names(selected)
+
+    selected
+    |> Enum.map(fn {killmail_id, selected} -> {killmail_id, to_items(selected, names)} end)
+    |> Enum.reject(fn {_killmail_id, items} -> items == [] end)
+    |> Map.new()
+  end
+
+  defp select(quantities, prices, threshold, limit) do
+    quantities
+    |> Enum.flat_map(fn {type_id, quantity} ->
+      case Map.get(prices, type_id) do
+        nil -> []
+        unit_price -> [{type_id, quantity, unit_price * quantity}]
+      end
+    end)
+    |> Enum.filter(fn {_type_id, _quantity, value} -> value > threshold end)
+    |> Enum.sort_by(fn {_type_id, _quantity, value} -> value end, :desc)
+    |> Enum.take(limit)
+  end
+
+  defp resolve_names(selected) do
+    selected
+    |> Enum.flat_map(fn {_killmail_id, items} ->
+      Enum.map(items, fn {type_id, _quantity, _value} -> type_id end)
+    end)
+    |> Enum.uniq()
+    |> Enum.reduce(%{}, fn type_id, acc ->
+      case safe(fn -> esi_client().get_type_info(type_id) end, :error) do
+        {:ok, %{"name" => name}} when is_binary(name) -> Map.put(acc, type_id, name)
+        _ -> acc
+      end
+    end)
+  end
+
+  # An item whose name would not resolve is dropped: there is nothing to render.
+  defp to_items(selected, names) do
+    Enum.flat_map(selected, fn {type_id, quantity, value} ->
+      case Map.get(names, type_id) do
+        nil -> []
+        name -> [%{name: name, quantity: quantity, value: value, abyssal?: abyssal?(name)}]
+      end
+    end)
+  end
+
+  defp abyssal?(name), do: name |> String.downcase() |> String.starts_with?("abyssal")
+
+  # -- plumbing --------------------------------------------------------------
+
+  defp esi_client, do: Application.get_env(:wanderer_app, :esi_client, WandererApp.Esi)
+
+  # Fail-open belt-and-braces. The dispatcher runs this module under
+  # `async_nolink` so a crash would not take it down, but an exception here
+  # would still cost the whole batch its section — including the kills that had
+  # already resolved fine.
+  defp safe(fun, fallback) do
+    fun.()
+  rescue
+    error ->
+      Logger.warning("[NotableItems] #{Exception.message(error)}")
+      fallback
+  catch
+    :exit, reason ->
+      Logger.warning("[NotableItems] exited: #{inspect(reason)}")
+      fallback
+  end
+end

--- a/lib/wanderer_app/external_events/discord_dispatcher.ex
+++ b/lib/wanderer_app/external_events/discord_dispatcher.ex
@@ -50,7 +50,15 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
 
   alias WandererApp.Api.{MapDiscordNotification, MapDiscordWebhook}
   alias WandererApp.Env
-  alias WandererApp.ExternalEvents.Discord.{EmbedFormatter, Matcher, Router, SystemName}
+
+  alias WandererApp.ExternalEvents.Discord.{
+    EmbedFormatter,
+    Matcher,
+    NotableItems,
+    Router,
+    SystemName
+  }
+
   alias WandererApp.ExternalEvents.Discord.WorkerSupervisor
 
   @cache :discord_notification_cache
@@ -58,6 +66,15 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
   # Comfortably longer than any plausible upstream replay window, matching the
   # 24h TTLs already used for kill caches.
   @dedup_ttl :timer.hours(24)
+
+  # Notable-items enrichment failure cooldown. The counter lives in the shared
+  # api cache and carries the cooldown as its TTL, so it both counts and expires.
+  # Threshold and window are deliberate guesses: telemetry on
+  # `[:wanderer_app, :discord, :notable_items]` is what will tune them.
+  @notable_items_cache :api_cache
+  @notable_items_failure_key "discord-notable-items-failures"
+  @notable_items_failure_threshold 3
+  @notable_items_cooldown_ms :timer.seconds(60)
 
   def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
 
@@ -224,6 +241,7 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
       # per-kill carve-outs for kills involving this map's own pilots.
       fresh
       |> partition(map_id, notification)
+      |> enrich_notable_items()
       |> Enum.each(fn {webhook, entries} ->
         deliver_partition(map_id, system_id, webhook, entries)
       end)
@@ -257,6 +275,187 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
     end)
     # Reduce prepends; restore the batch's original order per destination.
     |> Map.new(fn {webhook, entries} -> {webhook, Enum.reverse(entries)} end)
+  end
+
+  # -- notable items ---------------------------------------------------------
+  #
+  # Enrichment happens HERE — after routing and after the per-destination cap —
+  # for two reasons. Enriching before `partition/3` spends ESI and market calls
+  # on kills the router then drops. Enriching a whole partition spends the
+  # budget on kills past `max_kills_per_event/0`, which are never rendered, and
+  # starves the ones that are.
+  #
+  # It runs inline, so it BLOCKS THE SINGLETON DISPATCHER for up to
+  # `Env.notable_items_timeout_ms/0`. That budget is load-bearing: every map's
+  # kill batches funnel through this one process. Do not remove or raise it
+  # without revisiting the decision — an unbounded enrichment here stalls kill
+  # notifications instance-wide.
+  #
+  # The budget bounds ONE batch, not the mailbox. During a sustained ESI or
+  # market outage every batch would pay it in full and the dispatcher would fall
+  # arbitrarily far behind, so the failure cooldown below is part of the feature
+  # rather than a follow-up: after @notable_items_failure_threshold consecutive
+  # failures, enrichment is skipped outright for the cooldown window.
+  defp enrich_notable_items(partitions) do
+    cond do
+      not Env.notable_items_enabled?() ->
+        emit_notable_items(0, 0, 0, :disabled)
+        partitions
+
+      notable_items_cooldown_active?() ->
+        emit_notable_items(0, 0, 0, :skipped_cooldown)
+        partitions
+
+      true ->
+        run_enrichment(partitions, notable_items_candidates(partitions))
+    end
+  end
+
+  defp run_enrichment(partitions, []) do
+    emit_notable_items(0, 0, 0, :ok)
+    partitions
+  end
+
+  defp run_enrichment(partitions, candidates) do
+    started = System.monotonic_time()
+
+    case start_enrichment(candidates) do
+      nil ->
+        # No task supervisor: nothing was attempted, so this is not a failure to
+        # count against the cooldown. Distinct from `:timeout` so the telemetry
+        # does not read as a slow enricher when it is a missing supervisor.
+        emit_notable_items(0, length(candidates), 0, :unavailable)
+        partitions
+
+      task ->
+        # The documented `yield || shutdown` idiom. `Task.yield/2` returns
+        # `{:exit, reason}` INLINE when the task crashes, so all three outcomes
+        # are handled here and none of them reaches `handle_info/2`.
+        result =
+          Task.yield(task, Env.notable_items_timeout_ms()) ||
+            Task.shutdown(task, :brutal_kill)
+
+        handle_enrichment(partitions, candidates, result, System.monotonic_time() - started)
+    end
+  end
+
+  defp handle_enrichment(partitions, candidates, result, duration) do
+    case result do
+      {:ok, by_kill} when is_map(by_kill) ->
+        reset_notable_items_failures()
+        emit_notable_items(duration, length(candidates), item_count(by_kill), :ok)
+        merge_notable_items(partitions, by_kill)
+
+      {:ok, _unexpected} ->
+        reset_notable_items_failures()
+        emit_notable_items(duration, length(candidates), 0, :ok)
+        partitions
+
+      {:exit, reason} ->
+        note_notable_items_failure("enricher crashed: #{inspect(reason)}")
+        emit_notable_items(duration, length(candidates), 0, :crash)
+        partitions
+
+      _ ->
+        note_notable_items_failure("enricher timed out")
+        emit_notable_items(duration, length(candidates), 0, :timeout)
+        partitions
+    end
+  end
+
+  # `async_nolink`, never `Task.async`: a linked task would take this singleton
+  # down with it on an enrichment exception — the exact opposite of fail-open.
+  # `Discord.TaskSupervisor` is started by `WorkerSupervisor`, which only runs
+  # when webhooks are globally enabled; `do_dispatch/2` gates on that before
+  # reaching here, so this is safe. Do not move enrichment above that gate.
+  defp start_enrichment(candidates) do
+    enricher = NotableItems.impl()
+
+    Task.Supervisor.async_nolink(
+      WandererApp.ExternalEvents.Discord.TaskSupervisor,
+      fn -> enricher.enrich(candidates) end
+    )
+  rescue
+    # The supervisor is not up. Fail open like every other enrichment failure.
+    _ -> nil
+  catch
+    :exit, _ -> nil
+  end
+
+  # Only the kills that will actually be rendered, deduplicated. `Router.route/3`
+  # returns exactly one destination per kill so a kill cannot currently appear in
+  # two partitions; the dedup is cheap insurance against that property changing.
+  defp notable_items_candidates(partitions) do
+    partitions
+    |> Enum.flat_map(fn {_webhook, entries} ->
+      entries
+      |> Enum.take(EmbedFormatter.max_kills_per_event())
+      |> Enum.map(fn {kill, _verdict} -> kill end)
+    end)
+    |> Enum.uniq_by(& &1["killmail_id"])
+  end
+
+  defp merge_notable_items(partitions, by_kill) when map_size(by_kill) == 0, do: partitions
+
+  defp merge_notable_items(partitions, by_kill) do
+    Map.new(partitions, fn {webhook, entries} ->
+      entries =
+        Enum.map(entries, fn {kill, verdict} ->
+          case Map.get(by_kill, kill["killmail_id"]) do
+            nil -> {kill, verdict}
+            items -> {Map.put(kill, "notable_items", items), verdict}
+          end
+        end)
+
+      {webhook, entries}
+    end)
+  end
+
+  defp item_count(by_kill),
+    do: by_kill |> Map.values() |> Enum.map(&length/1) |> Enum.sum()
+
+  defp notable_items_cooldown_active? do
+    case Cachex.get(@notable_items_cache, @notable_items_failure_key) do
+      {:ok, count} when is_integer(count) -> count >= @notable_items_failure_threshold
+      _ -> false
+    end
+  end
+
+  # The counter carries the cooldown TTL, so reaching the threshold suppresses
+  # enrichment until the entry expires and a fresh attempt is made.
+  defp note_notable_items_failure(reason) do
+    count =
+      case Cachex.get(@notable_items_cache, @notable_items_failure_key) do
+        {:ok, n} when is_integer(n) -> n + 1
+        _ -> 1
+      end
+
+    Cachex.put(@notable_items_cache, @notable_items_failure_key, count,
+      ttl: @notable_items_cooldown_ms
+    )
+
+    Logger.warning(
+      "[Discord] notable items #{reason} (#{count} consecutive); " <>
+        "batch delivered without the section"
+    )
+  rescue
+    # The cache is not started in every context; a bookkeeping failure must not
+    # cost the batch.
+    _ -> :ok
+  end
+
+  defp reset_notable_items_failures do
+    Cachex.del(@notable_items_cache, @notable_items_failure_key)
+  rescue
+    _ -> :ok
+  end
+
+  defp emit_notable_items(duration, kill_count, item_count, outcome) do
+    :telemetry.execute(
+      [:wanderer_app, :discord, :notable_items],
+      %{duration: duration, kill_count: kill_count, item_count: item_count},
+      %{outcome: outcome}
+    )
   end
 
   # The role reaching `SystemName.display_name/3` is a LITERAL atom matched out

--- a/lib/wanderer_app/market/triff.ex
+++ b/lib/wanderer_app/market/triff.ex
@@ -1,0 +1,200 @@
+defmodule WandererApp.Market.Triff do
+  @moduledoc """
+  Bulk item pricing via [triff.tools](https://triff.tools).
+
+  Used by the Discord notable-items enricher to decide which dropped loot is
+  worth naming. triff needs no API token, which is why this feature is not
+  disabled-by-default the way wanderer-notifier's Janice-backed equivalent is.
+
+  ## Scope and mode
+
+  Prices are quoted against **Jita 4-4** (`station_id=60003760`), fixed. It is
+  the tightest market in EVE and what players mentally price loot against. The
+  `station_id` (or `region_id`) parameter is **mandatory** — without it the API
+  answers `400 {"error":"station_id or region_id required"}`.
+
+  The selected price is the 5th-percentile sell order, falling back to the best
+  sell order when `p05` is null. Thin markets have too few orders to support a
+  percentile; a null `best` has nothing to fall back to, so that type is omitted
+  from the result map rather than coerced to zero.
+
+  ## Caching
+
+  Three distinct entries in `:api_cache`, all short-lived because prices move:
+
+  * a resolved price per type id (30 min);
+  * a `:no_quote` sentinel per type id (10 min) for types with no usable order
+    on either side. Without an explicit sentinel these would be re-requested on
+    every kill that drops them, forever — precisely the permanently-unpriced
+    long tail;
+  * one whole-request failure marker (60 s), so a hard-down triff costs one
+    round trip per minute rather than one per batch.
+  """
+
+  require Logger
+
+  alias WandererApp.Market.Triff.HttpClient
+
+  @quote_url "https://triff.tools/api/market/quote"
+  @jita_4_4_station_id 60_003_760
+
+  # Matches authGD's QUOTE_CHUNK. Larger chunks risk a URL length rejection.
+  @chunk_size 900
+
+  @price_ttl :timer.minutes(30)
+  @no_quote_ttl :timer.minutes(10)
+  @failure_ttl :timer.seconds(60)
+
+  # The priciest item in EVE is on the order of 1e12 ISK, so anything past this
+  # is a malformed response, not a real quote. Mirrors authGD's sideSchema.
+  @max_price 1.0e15
+
+  @failure_key "triff-request-failure"
+
+  @type prices :: %{integer() => float()}
+
+  @doc """
+  Quotes the given type ids.
+
+  Returns `{:ok, prices}` where `prices` maps type id to unit price in ISK.
+  Types with no usable quote are **absent from the map** — callers must not
+  treat a missing key as zero.
+
+  Returns `{:error, reason}` if any request in the batch fails, or if a recent
+  request already failed and the cooldown is still active.
+  """
+  @spec quote_types([integer()]) :: {:ok, prices()} | {:error, term()}
+  def quote_types(type_ids) do
+    ids = type_ids |> Enum.filter(&is_integer/1) |> Enum.uniq()
+    {cached, missing} = split_cached(ids)
+
+    cond do
+      missing == [] ->
+        {:ok, cached}
+
+      recently_failed?() ->
+        {:error, :recent_failure}
+
+      true ->
+        fetch_missing(missing, cached)
+    end
+  end
+
+  defp fetch_missing(missing, cached) do
+    missing
+    |> Enum.chunk_every(@chunk_size)
+    |> Enum.reduce_while({:ok, cached}, fn chunk, {:ok, acc} ->
+      case fetch_chunk(chunk) do
+        {:ok, priced} -> {:cont, {:ok, Map.merge(acc, priced)}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, prices} ->
+        {:ok, prices}
+
+      {:error, reason} ->
+        mark_failure(reason)
+        {:error, reason}
+    end
+  end
+
+  defp fetch_chunk(ids) do
+    with {:ok, 200, body} <- HttpClient.get(url(ids), [{"accept", "application/json"}]),
+         {:ok, priced} <- parse(body) do
+      cache_results(ids, priced)
+      {:ok, Map.take(priced, ids)}
+    else
+      {:ok, status, _body} -> {:error, {:http_status, status}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp url(ids) do
+    query =
+      URI.encode_query(
+        type_ids: Enum.join(ids, ","),
+        include_aggregates: "true",
+        include_orders: "false",
+        station_id: @jita_4_4_station_id
+      )
+
+    @quote_url <> "?" <> query
+  end
+
+  defp parse(body) do
+    case Jason.decode(body) do
+      {:ok, %{"types" => types}} when is_list(types) ->
+        {:ok, Enum.reduce(types, %{}, &collect_price/2)}
+
+      {:ok, _other} ->
+        {:error, :malformed_response}
+
+      {:error, reason} ->
+        {:error, {:invalid_json, reason}}
+    end
+  end
+
+  defp collect_price(%{"type_id" => id} = type, acc) when is_integer(id) do
+    case select_price(Map.get(type, "sell")) do
+      nil -> acc
+      price -> Map.put(acc, id, price)
+    end
+  end
+
+  defp collect_price(_type, acc), do: acc
+
+  # p05 first, best as the fallback. An invalid p05 is treated like a null one:
+  # either way we have no usable percentile and the best order is the next-best
+  # answer.
+  defp select_price(%{} = sell) do
+    valid_price(Map.get(sell, "p05")) || valid_price(Map.get(sell, "best"))
+  end
+
+  defp select_price(_), do: nil
+
+  # `Jason` cannot produce NaN or Infinity — they are not valid JSON — so the
+  # range check is the whole non-finite guard.
+  defp valid_price(n) when is_number(n) and n > 0 and n <= @max_price, do: n * 1.0
+  defp valid_price(_), do: nil
+
+  defp split_cached(ids) do
+    {found, missing} =
+      Enum.reduce(ids, {%{}, []}, fn id, {found, missing} ->
+        case Cachex.get(:api_cache, cache_key(id)) do
+          {:ok, price} when is_float(price) -> {Map.put(found, id, price), missing}
+          # A known-unpriced type: neither a hit to return nor a miss to re-request.
+          {:ok, :no_quote} -> {found, missing}
+          _ -> {found, [id | missing]}
+        end
+      end)
+
+    {found, Enum.reverse(missing)}
+  end
+
+  # Every requested id gets an entry, including ids the response omitted
+  # entirely — otherwise the unpriced long tail is re-requested forever.
+  defp cache_results(requested_ids, priced) do
+    Enum.each(requested_ids, fn id ->
+      case Map.get(priced, id) do
+        nil -> Cachex.put(:api_cache, cache_key(id), :no_quote, ttl: @no_quote_ttl)
+        price -> Cachex.put(:api_cache, cache_key(id), price, ttl: @price_ttl)
+      end
+    end)
+  end
+
+  defp cache_key(id), do: "triff-price-#{id}"
+
+  defp recently_failed? do
+    match?({:ok, true}, Cachex.get(:api_cache, @failure_key))
+  end
+
+  defp mark_failure(reason) do
+    Logger.warning(
+      "[Triff] quote request failed (#{inspect(reason)}); " <>
+        "suppressing requests for #{div(@failure_ttl, 1000)}s"
+    )
+
+    Cachex.put(:api_cache, @failure_key, true, ttl: @failure_ttl)
+  end
+end

--- a/lib/wanderer_app/market/triff/http_client.ex
+++ b/lib/wanderer_app/market/triff/http_client.ex
@@ -1,0 +1,50 @@
+defmodule WandererApp.Market.Triff.HttpClient do
+  @moduledoc """
+  Seam over HTTP calls to triff.tools, so market pricing can be tested without a
+  live endpoint. The real implementation uses an isolated Finch pool.
+
+  Mirrors `WandererApp.ExternalEvents.Discord.HttpClient`.
+  """
+
+  @callback get(url :: String.t(), headers :: list()) ::
+              {:ok, status :: integer(), body :: binary()} | {:error, term()}
+
+  @doc "Returns the configured implementation module."
+  def impl do
+    Application.get_env(
+      :wanderer_app,
+      :triff_http_client,
+      WandererApp.Market.Triff.HttpClient.Live
+    )
+  end
+
+  @doc "Issues a GET, delegating to the configured implementation."
+  def get(url, headers \\ []), do: impl().get(url, headers)
+
+  defmodule Live do
+    @moduledoc """
+    Real HTTP delivery via the isolated triff Finch pool.
+
+    Named `Live` rather than `Finch` so the nested module does not shadow the
+    Finch library inside its own body.
+    """
+    @behaviour WandererApp.Market.Triff.HttpClient
+
+    # A backstop, not the real deadline. In the dispatcher path the enrichment
+    # task is brutally killed at `notable_items_timeout_ms` (1.5s by default),
+    # well before this fires; this only bounds a caller running outside that
+    # budget, so a hung socket cannot hold a pool connection indefinitely.
+    @timeout 5_000
+
+    @impl true
+    def get(url, headers) do
+      :get
+      |> Finch.build(url, headers)
+      |> Finch.request(WandererApp.Finch.Triff, receive_timeout: @timeout)
+      |> case do
+        {:ok, %Finch.Response{status: status, body: body}} -> {:ok, status, body}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+end

--- a/test/support/mock_definitions.ex
+++ b/test/support/mock_definitions.ex
@@ -131,6 +131,13 @@ if Mix.env() == :test do
     @callback get_corporation_info(binary(), keyword()) :: {:ok, map()} | {:error, any()}
     @callback get_alliance_info(binary()) :: {:ok, map()} | {:error, any()}
     @callback get_alliance_info(binary(), keyword()) :: {:ok, map()} | {:error, any()}
+    @callback get_killmail(binary() | integer(), binary()) :: {:ok, map()} | {:error, any()}
+
+    @callback get_killmail(binary() | integer(), binary(), keyword()) ::
+                {:ok, map()} | {:error, any()}
+
+    @callback get_type_info(binary() | integer()) :: {:ok, map()} | {:error, any()}
+    @callback get_type_info(binary() | integer(), keyword()) :: {:ok, map()} | {:error, any()}
   end
 
   # Define all the mocks

--- a/test/support/triff_http_stub.ex
+++ b/test/support/triff_http_stub.ex
@@ -1,0 +1,57 @@
+defmodule WandererApp.Market.Triff.HttpStub do
+  @moduledoc """
+  Test double for triff.tools HTTP calls.
+
+  State lives in ONE named Agent shared by every test, so any test using this
+  stub must be `async: false`. Call `start/0` in setup (it resets the state if
+  the Agent is already up), `set_responses/1` to script replies, and
+  `requests/0` to assert on what was requested.
+
+  Mirrors `WandererApp.ExternalEvents.Discord.HttpStub`.
+  """
+  @behaviour WandererApp.Market.Triff.HttpClient
+
+  @agent __MODULE__.Agent
+
+  def start do
+    # `Agent.start`, not `start_link`: linking would tie the shared Agent to
+    # whichever test process happened to call `start/0` first, so it would die
+    # with that test, and an enrichment task still in flight would then hit a
+    # dead Agent and exit `:noproc` instead of getting the scripted response.
+    case Agent.start(fn -> new_state() end, name: @agent) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> reset() && {:ok, pid}
+      {:error, reason} -> raise "could not start #{inspect(@agent)}: #{inspect(reason)}"
+    end
+  end
+
+  def reset, do: Agent.update(@agent, fn _ -> new_state() end) == :ok
+
+  defp new_state, do: %{responses: [], requests: []}
+
+  @doc """
+  Queues responses, consumed in order. Each is `{:ok, status, body}` or
+  `{:error, term}`. A body given as a map is JSON-encoded for you. When the
+  queue runs dry the stub returns an empty `types` list rather than raising, so
+  a test only has to script the calls it cares about.
+  """
+  def set_responses(responses), do: Agent.update(@agent, &%{&1 | responses: responses})
+
+  @doc "Returns the requested urls, in the order they were sent."
+  def requests, do: Agent.get(@agent, & &1.requests) |> Enum.reverse()
+
+  @impl true
+  def get(url, _headers) do
+    Agent.get_and_update(@agent, fn state ->
+      state = %{state | requests: [url | state.requests]}
+
+      case state.responses do
+        [] -> {{:ok, 200, ~s({"types":[]})}, state}
+        [resp | rest] -> {encode(resp), %{state | responses: rest}}
+      end
+    end)
+  end
+
+  defp encode({:ok, status, body}) when is_map(body), do: {:ok, status, Jason.encode!(body)}
+  defp encode(resp), do: resp
+end

--- a/test/unit/external_events/discord/embed_formatter_test.exs
+++ b/test/unit/external_events/discord/embed_formatter_test.exs
@@ -587,4 +587,163 @@ defmodule WandererApp.ExternalEvents.Discord.EmbedFormatterTest do
       end)
     end
   end
+
+  describe "notable items" do
+    defp with_items(items),
+      do: Factory.build(:killmail) |> Map.put("notable_items", items)
+
+    defp describe_kill(kill), do: EmbedFormatter.format_kill(kill, @bystander, "J123456")
+
+    defp item(name, opts \\ []) do
+      %{
+        name: name,
+        quantity: Keyword.get(opts, :quantity, 1),
+        value: Keyword.get(opts, :value, 100_000_000.0),
+        abyssal?: Keyword.get(opts, :abyssal?, false)
+      }
+    end
+
+    test "no section when the key is absent" do
+      description = Factory.build(:killmail) |> describe_kill() |> Map.get("description")
+      refute description =~ "Notable Items"
+    end
+
+    test "no section when the list is empty" do
+      refute describe_kill(with_items([]))["description"] =~ "Notable Items"
+    end
+
+    test "no section when the value is not a list" do
+      refute describe_kill(with_items(nil))["description"] =~ "Notable Items"
+      refute describe_kill(with_items("nope"))["description"] =~ "Notable Items"
+    end
+
+    test "a single item renders without a quantity" do
+      description = describe_kill(with_items([item("Damage Control II")]))["description"]
+
+      assert description =~ "\n\n**Notable Items:**\n"
+      assert description =~ "• Damage Control II (~100.0M ISK)"
+      refute description =~ "x1"
+    end
+
+    test "a stacked item renders its quantity" do
+      description =
+        describe_kill(with_items([item("Nanite Repair Paste", quantity: 300)]))["description"]
+
+      assert description =~ "• Nanite Repair Paste x300 (~100.0M ISK)"
+    end
+
+    test "an abyssal item renders no price" do
+      description =
+        describe_kill(with_items([item("Abyssal Warp Scrambler", abyssal?: true)]))["description"]
+
+      assert description =~ "• Abyssal Warp Scrambler"
+      refute description =~ "ISK)"
+    end
+
+    test "an abyssal item still renders its quantity" do
+      description =
+        describe_kill(with_items([item("Abyssal Damage Control", quantity: 2, abyssal?: true)]))[
+          "description"
+        ]
+
+      assert description =~ "• Abyssal Damage Control x2"
+      refute description =~ "ISK)"
+    end
+
+    test "items render one per line, in the order given" do
+      description =
+        describe_kill(with_items([item("First"), item("Second"), item("Third")]))["description"]
+
+      assert [_prose, "• First (~100.0M ISK)", "• Second (~100.0M ISK)", "• Third (~100.0M ISK)"] =
+               String.split(description, "\n", trim: true) |> Enum.take(-4)
+    end
+
+    test "a malformed item is skipped rather than rendered" do
+      description = describe_kill(with_items([%{name: "Real"}, item("Good")]))["description"]
+
+      assert description =~ "• Good"
+      refute description =~ "• Real"
+    end
+
+    # -- budgeting ------------------------------------------------------------
+
+    # Builds a killmail whose base description (before any section) is exactly
+    # `target` graphemes, by padding the victim name — it appears once in the
+    # description, so length grows with it one for one.
+    defp kill_with_base_length(target) do
+      probe = Factory.build(:killmail) |> Map.put("victim_char_name", "X")
+      base = String.length(describe_kill(probe)["description"])
+      Map.put(probe, "victim_char_name", String.duplicate("X", target - base + 1))
+    end
+
+    test "the base description alone is still truncated to the Discord limit" do
+      description = describe_kill(kill_with_base_length(5000))["description"]
+      assert String.length(description) == 4096
+    end
+
+    test "a full section never pushes the description past the limit" do
+      items = for n <- 1..5, do: item("Item #{n}")
+
+      description =
+        kill_with_base_length(4000)
+        |> Map.put("notable_items", items)
+        |> describe_kill()
+        |> Map.get("description")
+
+      assert String.length(description) <= 4096
+    end
+
+    test "only whole lines that fit are kept; the rest are dropped silently" do
+      line = "• Item 1 (~100.0M ISK)"
+      header = "\n\n**Notable Items:**\n"
+      items = for n <- 1..5, do: item("Item #{n}")
+
+      # Room for the header and exactly one line, and nothing more.
+      base = 4096 - String.length(header) - String.length(line)
+
+      description =
+        kill_with_base_length(base)
+        |> Map.put("notable_items", items)
+        |> describe_kill()
+        |> Map.get("description")
+
+      assert String.ends_with?(description, header <> line)
+      refute description =~ "Item 2"
+      assert String.length(description) == 4096
+    end
+
+    test "the header is omitted entirely when not even one line fits" do
+      items = for n <- 1..5, do: item("Item #{n}")
+
+      description =
+        kill_with_base_length(4090)
+        |> Map.put("notable_items", items)
+        |> describe_kill()
+        |> Map.get("description")
+
+      refute description =~ "Notable Items"
+      refute description =~ "•"
+    end
+
+    test "a long section splits a batch into more messages" do
+      items = for n <- 1..5, do: item(String.duplicate("N", 200) <> " #{n}")
+
+      entries =
+        for _n <- 1..10 do
+          {Factory.build(:killmail) |> Map.put("notable_items", items), @bystander}
+        end
+
+      without =
+        EmbedFormatter.format_batch(
+          Enum.map(entries, fn {k, v} -> {Map.delete(k, "notable_items"), v} end),
+          "J123456"
+        )
+
+      with_sections = EmbedFormatter.format_batch(entries, "J123456")
+
+      assert length(without) == 1
+      assert length(with_sections) > 1
+      assert Enum.all?(with_sections, &(embed_text_total(&1["embeds"]) <= 6000))
+    end
+  end
 end

--- a/test/unit/external_events/discord/notable_items_test.exs
+++ b/test/unit/external_events/discord/notable_items_test.exs
@@ -1,0 +1,264 @@
+defmodule WandererApp.ExternalEvents.Discord.NotableItemsTest do
+  # `async: false`: the triff stub keeps state in one named Agent, the module
+  # caches into the shared `:api_cache`, and both seams are application env.
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias WandererApp.ExternalEvents.Discord.NotableItems
+  alias WandererApp.Market.Triff.HttpStub
+
+  @hash "abc123hash"
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  setup do
+    HttpStub.start()
+    HttpStub.reset()
+    Cachex.clear(:api_cache)
+
+    Application.put_env(:wanderer_app, :triff_http_client, HttpStub)
+    Application.put_env(:wanderer_app, :esi_client, WandererApp.Esi.Mock)
+
+    on_exit(fn ->
+      Application.delete_env(:wanderer_app, :triff_http_client)
+      Application.delete_env(:wanderer_app, :esi_client)
+      Cachex.clear(:api_cache)
+    end)
+
+    :ok
+  end
+
+  # -- fixtures ---------------------------------------------------------------
+
+  defp kill(killmail_id, opts \\ []) do
+    zkb = Keyword.get(opts, :zkb, %{"hash" => @hash})
+    %{"killmail_id" => killmail_id, "zkb" => zkb}
+  end
+
+  defp killmail(items), do: %{"victim" => %{"items" => items}}
+
+  defp dropped(type_id, quantity, extra \\ %{}),
+    do:
+      Map.merge(
+        %{"item_type_id" => type_id, "quantity_dropped" => quantity, "flag" => 5},
+        extra
+      )
+
+  defp destroyed(type_id, quantity),
+    do: %{"item_type_id" => type_id, "quantity_destroyed" => quantity, "flag" => 27}
+
+  # Scripts one triff response pricing each `{type_id, unit_price}` pair.
+  defp prices(pairs) do
+    types =
+      Enum.map(pairs, fn {type_id, price} ->
+        %{"type_id" => type_id, "sell" => %{"p05" => price, "best" => nil}}
+      end)
+
+    HttpStub.set_responses([{:ok, 200, %{"types" => types}}])
+  end
+
+  defp stub_killmail(killmails) do
+    stub(WandererApp.Esi.Mock, :get_killmail, fn killmail_id, _hash ->
+      case Map.fetch(killmails, killmail_id) do
+        {:ok, {:error, reason}} -> {:error, reason}
+        {:ok, body} -> {:ok, body}
+        :error -> {:error, :not_found}
+      end
+    end)
+  end
+
+  defp stub_names(names) do
+    stub(WandererApp.Esi.Mock, :get_type_info, fn type_id ->
+      case Map.fetch(names, type_id) do
+        {:ok, :error} -> {:error, :not_found}
+        {:ok, name} -> {:ok, %{"name" => name}}
+        :error -> {:error, :not_found}
+      end
+    end)
+  end
+
+  # -- tests ------------------------------------------------------------------
+
+  describe "enrich/1" do
+    test "returns an empty map for no kills" do
+      assert NotableItems.enrich([]) == %{}
+    end
+
+    test "names loot above the threshold" do
+      stub_killmail(%{1 => killmail([dropped(1319, 1)])})
+      prices([{1319, 100_000_000}])
+      stub_names(%{1319 => "Damage Control II"})
+
+      assert %{1 => [item]} = NotableItems.enrich([kill(1)])
+
+      assert item == %{
+               name: "Damage Control II",
+               quantity: 1,
+               value: 100_000_000.0,
+               abyssal?: false
+             }
+    end
+
+    test "excludes destroyed items" do
+      stub_killmail(%{1 => killmail([destroyed(1319, 1)])})
+      stub_names(%{1319 => "Damage Control II"})
+
+      assert NotableItems.enrich([kill(1)]) == %{}
+      # Nothing dropped, so no pricing request was needed at all.
+      assert HttpStub.requests() == []
+    end
+
+    test "flattens items nested inside a container" do
+      container = dropped(3468, 1, %{"items" => [dropped(1319, 1)]})
+      stub_killmail(%{1 => killmail([container])})
+      prices([{1319, 100_000_000}, {3468, 1_000}])
+      stub_names(%{1319 => "Damage Control II", 3468 => "Small Standard Container"})
+
+      assert %{1 => [%{name: "Damage Control II"}]} = NotableItems.enrich([kill(1)])
+    end
+
+    test "sums quantities of the same type across slots" do
+      stub_killmail(%{1 => killmail([dropped(1319, 1), dropped(1319, 2, %{"flag" => 13})])})
+      prices([{1319, 20_000_000}])
+      stub_names(%{1319 => "Damage Control II"})
+
+      assert %{1 => [%{quantity: 3, value: 60_000_000.0}]} = NotableItems.enrich([kill(1)])
+    end
+  end
+
+  describe "threshold and limit" do
+    test "excludes an item worth exactly the threshold" do
+      stub_killmail(%{1 => killmail([dropped(1319, 1)])})
+      prices([{1319, 50_000_000}])
+      stub_names(%{1319 => "Damage Control II"})
+
+      assert NotableItems.enrich([kill(1)]) == %{}
+    end
+
+    test "includes an item worth one ISK more than the threshold" do
+      stub_killmail(%{1 => killmail([dropped(1319, 1)])})
+      prices([{1319, 50_000_001}])
+      stub_names(%{1319 => "Damage Control II"})
+
+      assert %{1 => [%{name: "Damage Control II"}]} = NotableItems.enrich([kill(1)])
+    end
+
+    test "takes the highest-valued items in descending order, capped at the limit" do
+      items = for type_id <- 1..7, do: dropped(type_id, 1)
+      stub_killmail(%{1 => killmail(items)})
+      prices(for type_id <- 1..7, do: {type_id, 100_000_000 * type_id})
+      stub_names(Map.new(1..7, fn type_id -> {type_id, "Item #{type_id}"} end))
+
+      assert %{1 => selected} = NotableItems.enrich([kill(1)])
+
+      assert Enum.map(selected, & &1.name) == [
+               "Item 7",
+               "Item 6",
+               "Item 5",
+               "Item 4",
+               "Item 3"
+             ]
+    end
+  end
+
+  describe "abyssal items" do
+    test "flags a name beginning with abyssal, case-insensitively" do
+      stub_killmail(%{1 => killmail([dropped(1319, 1), dropped(2048, 1)])})
+      prices([{1319, 100_000_000}, {2048, 200_000_000}])
+      stub_names(%{1319 => "Damage Control II", 2048 => "abyssal Warp Scrambler"})
+
+      assert %{1 => [abyssal, regular]} = NotableItems.enrich([kill(1)])
+      assert abyssal.abyssal?
+      refute regular.abyssal?
+    end
+  end
+
+  describe "multiple kills" do
+    test "enriches each kill independently and omits those with nothing notable" do
+      stub_killmail(%{
+        1 => killmail([dropped(1319, 1)]),
+        2 => killmail([dropped(2048, 1)])
+      })
+
+      prices([{1319, 100_000_000}, {2048, 1_000}])
+      stub_names(%{1319 => "Damage Control II", 2048 => "Civilian Gatling Autocannon"})
+
+      result = NotableItems.enrich([kill(1), kill(2)])
+
+      assert Map.keys(result) == [1]
+      # One batched pricing request covers both kills.
+      assert length(HttpStub.requests()) == 1
+    end
+  end
+
+  describe "fail-open" do
+    test "skips a kill with no zkb hash" do
+      stub_killmail(%{1 => killmail([dropped(1319, 1)])})
+
+      assert NotableItems.enrich([kill(1, zkb: %{})]) == %{}
+      assert NotableItems.enrich([kill(1, zkb: nil)]) == %{}
+    end
+
+    test "skips a kill whose ESI fetch fails" do
+      stub_killmail(%{1 => {:error, :timeout}})
+
+      assert NotableItems.enrich([kill(1)]) == %{}
+    end
+
+    test "skips a kill whose ESI fetch raises" do
+      stub(WandererApp.Esi.Mock, :get_killmail, fn _id, _hash -> raise "boom" end)
+
+      assert NotableItems.enrich([kill(1)]) == %{}
+    end
+
+    test "returns nothing when pricing fails" do
+      stub_killmail(%{1 => killmail([dropped(1319, 1)])})
+      HttpStub.set_responses([{:error, :timeout}])
+
+      assert NotableItems.enrich([kill(1)]) == %{}
+    end
+
+    test "omits an item whose name cannot be resolved" do
+      stub_killmail(%{1 => killmail([dropped(1319, 1), dropped(2048, 1)])})
+      prices([{1319, 100_000_000}, {2048, 200_000_000}])
+      stub_names(%{1319 => "Damage Control II", 2048 => :error})
+
+      assert %{1 => [%{name: "Damage Control II"}]} = NotableItems.enrich([kill(1)])
+    end
+
+    test "omits a kill whose only notable item cannot be named" do
+      stub_killmail(%{1 => killmail([dropped(1319, 1)])})
+      prices([{1319, 100_000_000}])
+      stub_names(%{1319 => :error})
+
+      assert NotableItems.enrich([kill(1)]) == %{}
+    end
+
+    test "omits an item that triff could not price" do
+      stub_killmail(%{1 => killmail([dropped(1319, 1)])})
+      prices([])
+      stub_names(%{1319 => "Damage Control II"})
+
+      assert NotableItems.enrich([kill(1)]) == %{}
+    end
+
+    test "tolerates a killmail with no victim items" do
+      stub_killmail(%{1 => %{"victim" => %{}}})
+
+      assert NotableItems.enrich([kill(1)]) == %{}
+    end
+  end
+
+  describe "impl/0" do
+    test "defaults to this module and honours the override" do
+      assert NotableItems.impl() == NotableItems
+
+      Application.put_env(:wanderer_app, :notable_items_enricher, __MODULE__)
+      on_exit(fn -> Application.delete_env(:wanderer_app, :notable_items_enricher) end)
+
+      assert NotableItems.impl() == __MODULE__
+    end
+  end
+end

--- a/test/unit/external_events/discord_dispatcher_test.exs
+++ b/test/unit/external_events/discord_dispatcher_test.exs
@@ -1,3 +1,26 @@
+# A stand-in for the real enricher. NOT Mox: the enricher runs inside a task
+# spawned off `Discord.TaskSupervisor`, and a Mox expectation set in the test
+# process is not visible from an unrelated process without global mode — which
+# would in turn conflict with the timeout case, where the "enricher" never
+# returns at all.
+defmodule WandererApp.ExternalEvents.DiscordDispatcherTest.Enricher do
+  @behaviour WandererApp.ExternalEvents.Discord.NotableItems
+
+  @impl true
+  def enrich(kills) do
+    case Process.whereis(:notable_items_observer) do
+      nil -> :ok
+      pid -> send(pid, {:enrich_called, kills})
+    end
+
+    case Application.get_env(:wanderer_app, :test_notable_items_mode, %{}) do
+      :timeout -> Process.sleep(:infinity)
+      :crash -> raise "enricher boom"
+      by_kill when is_map(by_kill) -> by_kill
+    end
+  end
+end
+
 defmodule WandererApp.ExternalEvents.DiscordDispatcherTest do
   # `async: false` is mandatory: `HttpStub` keeps its state in a single named
   # Agent, and this file also mutates application env.
@@ -13,7 +36,13 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcherTest do
     WorkerSupervisor
   }
 
+  alias WandererApp.ExternalEvents.DiscordDispatcherTest.Enricher
   alias WandererAppWeb.Factory
+
+  # Must match `DiscordDispatcher`'s own key: the cooldown tests clear it
+  # between runs, and a private counter left behind would silently disable
+  # enrichment for every later test in this file.
+  @failure_key "discord-notable-items-failures"
 
   # A real wormhole system id (J-space) and a real known-space id (Jita).
   @wh_system 31_000_005
@@ -1177,6 +1206,205 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcherTest do
       assert warning_count == 1
     end
   end
+
+  describe "notable items" do
+    setup do
+      Process.register(self(), :notable_items_observer)
+      Cachex.del(:api_cache, @failure_key)
+
+      Application.put_env(:wanderer_app, :notable_items_enricher, Enricher)
+      Application.put_env(:wanderer_app, :test_notable_items_mode, %{})
+
+      on_exit(fn ->
+        Application.delete_env(:wanderer_app, :notable_items_enricher)
+        Application.delete_env(:wanderer_app, :test_notable_items_mode)
+        Cachex.del(:api_cache, @failure_key)
+      end)
+
+      :ok
+    end
+
+    test "does not enrich when the feature is disabled", %{map: map, system: w} do
+      # No `enable_notable_items/1` — the default is off, which is the shipping
+      # configuration. This test is what makes "off means zero added latency"
+      # an assertion rather than a claim.
+      dispatch(map, [fresh_kill(9_201)])
+      settle(w.id)
+
+      refute_received {:enrich_called, _}
+      assert [{_url, body}] = wait_for_requests(1)
+      refute description(body) =~ "Notable Items"
+    end
+
+    test "renders the section for an enriched kill", %{map: map, system: w} do
+      enable_notable_items()
+      returns(%{9_202 => [notable("Damage Control II", 1, 100_000_000.0)]})
+
+      dispatch(map, [fresh_kill(9_202)])
+      settle(w.id)
+
+      assert [{_url, body}] = wait_for_requests(1)
+      assert description(body) =~ "**Notable Items:**"
+      assert description(body) =~ "• Damage Control II (~100.0M ISK)"
+    end
+
+    test "leaves un-enriched kills in the same batch alone", %{map: map, system: w} do
+      enable_notable_items()
+      returns(%{9_203 => [notable("Damage Control II", 1, 100_000_000.0)]})
+
+      dispatch(map, [fresh_kill(9_203), fresh_kill(9_204)])
+      settle(w.id)
+
+      assert [{_url, body}] = wait_for_requests(1)
+      assert [enriched, plain] = body["embeds"]
+      assert enriched["description"] =~ "Notable Items"
+      refute plain["description"] =~ "Notable Items"
+    end
+
+    test "only offers kills that will actually be rendered", %{map: map, system: w} do
+      # The cap is per destination and applied by the formatter. Enriching past
+      # it spends ESI and market calls on kills nobody will ever see.
+      enable_notable_items()
+      over_cap = EmbedFormatter.max_kills_per_event() + 5
+      kills = for id <- 1..over_cap, do: fresh_kill(9_300 + id)
+
+      dispatch(map, kills)
+      settle(w.id)
+
+      assert_received {:enrich_called, candidates}
+      assert length(candidates) == EmbedFormatter.max_kills_per_event()
+    end
+
+    test "delivers without the section when the enricher times out", %{map: map, system: w} do
+      enable_notable_items(notable_items_timeout_ms: 50)
+      returns(:timeout)
+
+      dispatch(map, [fresh_kill(9_205)])
+      settle(w.id)
+
+      assert [{_url, body}] = wait_for_requests(1)
+      refute description(body) =~ "Notable Items"
+    end
+
+    test "delivers without the section when the enricher crashes", %{map: map, system: w} do
+      # The crash must not reach the dispatcher: `async_nolink` plus the
+      # `{:exit, reason}` branch of `Task.yield/2`. If this ever regresses the
+      # singleton dies and every map stops receiving kill notifications.
+      enable_notable_items()
+      returns(:crash)
+
+      capture_log(fn -> dispatch(map, [fresh_kill(9_206)]) end)
+
+      assert Process.alive?(Process.whereis(DiscordDispatcher))
+      assert [{_url, body}] = wait_for_requests(1)
+      refute description(body) =~ "Notable Items"
+    end
+
+    test "stops enriching after repeated failures", %{map: map, system: w} do
+      enable_notable_items()
+      returns(:crash)
+
+      capture_log(fn ->
+        for id <- 1..3 do
+          dispatch(map, [fresh_kill(9_400 + id)])
+          assert_received {:enrich_called, _}
+        end
+      end)
+
+      # Threshold reached: the fourth batch skips enrichment outright rather
+      # than paying the budget again during a sustained outage.
+      dispatch(map, [fresh_kill(9_410)])
+      refute_received {:enrich_called, _}
+
+      settle(w.id)
+      assert length(wait_for_requests(4)) == 4
+    end
+
+    test "a success clears the failure counter", %{map: map, system: w} do
+      enable_notable_items()
+      returns(:crash)
+
+      capture_log(fn ->
+        for id <- 1..2 do
+          dispatch(map, [fresh_kill(9_500 + id)])
+          assert_received {:enrich_called, _}
+        end
+      end)
+
+      returns(%{})
+      dispatch(map, [fresh_kill(9_510)])
+      assert_received {:enrich_called, _}
+
+      # Without the reset, two more failures would trip the cooldown.
+      returns(:crash)
+
+      capture_log(fn ->
+        for id <- 1..2 do
+          dispatch(map, [fresh_kill(9_520 + id)])
+          assert_received {:enrich_called, _}
+        end
+      end)
+
+      settle(w.id)
+    end
+
+    test "emits telemetry for each outcome", %{map: map, system: w} do
+      handler = "notable-items-test-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler,
+        [:wanderer_app, :discord, :notable_items],
+        fn _event, measurements, metadata, _ ->
+          send(test_pid, {:telemetry, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      dispatch(map, [fresh_kill(9_601)])
+      assert_received {:telemetry, _, %{outcome: :disabled}}
+
+      enable_notable_items()
+      returns(%{9_602 => [notable("Damage Control II", 1, 100_000_000.0)]})
+      dispatch(map, [fresh_kill(9_602)])
+
+      assert_received {:telemetry, measurements, %{outcome: :ok}}
+      assert measurements.kill_count == 1
+      assert measurements.item_count == 1
+
+      settle(w.id)
+    end
+  end
+
+  # -- notable items helpers --------------------------------------------------
+
+  defp enable_notable_items(extra \\ []) do
+    original = Application.get_env(:wanderer_app, :external_events, [])
+
+    updated =
+      original
+      |> Keyword.put(:notable_items_enabled, true)
+      |> Keyword.merge(extra)
+
+    Application.put_env(:wanderer_app, :external_events, updated)
+    on_exit(fn -> Application.put_env(:wanderer_app, :external_events, original) end)
+  end
+
+  defp returns(mode), do: Application.put_env(:wanderer_app, :test_notable_items_mode, mode)
+
+  defp notable(name, quantity, value),
+    do: %{name: name, quantity: quantity, value: value, abyssal?: false}
+
+  defp fresh_kill(id), do: kill(id, DateTime.utc_now() |> DateTime.to_iso8601())
+
+  defp dispatch(map, kills) do
+    DiscordDispatcher.dispatch_event(map.id, kill_event(@wh_system, kills))
+    :sys.get_state(DiscordDispatcher)
+  end
+
+  defp description(body), do: body["embeds"] |> hd() |> Map.get("description")
 
   # Minimal killmail and event builders matching what `extract_kills/1` expects.
   defp kill(id, kill_time) do

--- a/test/unit/market/triff_test.exs
+++ b/test/unit/market/triff_test.exs
@@ -1,0 +1,216 @@
+defmodule WandererApp.Market.TriffTest do
+  # `async: false`: the stub keeps state in one named Agent and the module
+  # caches into the shared `:api_cache`.
+  use ExUnit.Case, async: false
+
+  alias WandererApp.Market.Triff
+  alias WandererApp.Market.Triff.HttpStub
+
+  setup do
+    HttpStub.start()
+    HttpStub.reset()
+    Cachex.clear(:api_cache)
+
+    previous = Application.get_env(:wanderer_app, :triff_http_client)
+    Application.put_env(:wanderer_app, :triff_http_client, HttpStub)
+
+    on_exit(fn ->
+      if previous do
+        Application.put_env(:wanderer_app, :triff_http_client, previous)
+      else
+        Application.delete_env(:wanderer_app, :triff_http_client)
+      end
+
+      Cachex.clear(:api_cache)
+    end)
+
+    :ok
+  end
+
+  defp types(entries), do: %{"types" => entries}
+
+  defp sell(type_id, p05, best),
+    do: %{"type_id" => type_id, "sell" => %{"p05" => p05, "best" => best}}
+
+  describe "quote_types/1" do
+    test "returns an empty map without a request when given no ids" do
+      assert {:ok, %{}} == Triff.quote_types([])
+      assert HttpStub.requests() == []
+    end
+
+    test "prefers the p05 sell price" do
+      HttpStub.set_responses([{:ok, 200, types([sell(1319, 316_539.07, 313_800)])}])
+
+      assert {:ok, %{1319 => 316_539.07}} = Triff.quote_types([1319])
+    end
+
+    test "falls back to the best sell price when p05 is null" do
+      HttpStub.set_responses([{:ok, 200, types([sell(1319, nil, 313_800)])}])
+
+      assert {:ok, %{1319 => 313_800.0}} = Triff.quote_types([1319])
+    end
+
+    test "omits a type whose sell side is entirely null rather than pricing it at zero" do
+      HttpStub.set_responses([{:ok, 200, types([sell(44_992, nil, nil)])}])
+
+      assert {:ok, prices} = Triff.quote_types([44_992])
+      refute Map.has_key?(prices, 44_992)
+    end
+
+    test "rejects negative, zero, and absurd prices" do
+      HttpStub.set_responses([
+        {:ok, 200,
+         types([
+           sell(1, -5, nil),
+           sell(2, 0, nil),
+           sell(3, 1.0e16, nil),
+           sell(4, "not a number", nil)
+         ])}
+      ])
+
+      assert {:ok, prices} = Triff.quote_types([1, 2, 3, 4])
+      assert prices == %{}
+    end
+
+    test "falls back to best when p05 is present but invalid" do
+      HttpStub.set_responses([{:ok, 200, types([sell(1319, -5, 313_800)])}])
+
+      assert {:ok, %{1319 => 313_800.0}} = Triff.quote_types([1319])
+    end
+
+    test "does not return types that were not asked for" do
+      HttpStub.set_responses([{:ok, 200, types([sell(1319, 100.0, nil), sell(9999, 200.0, nil)])}])
+
+      assert {:ok, %{1319 => 100.0}} == Triff.quote_types([1319])
+    end
+
+    test "sends the mandatory station_id and aggregate parameters" do
+      HttpStub.set_responses([{:ok, 200, types([])}])
+      Triff.quote_types([1319])
+
+      assert [url] = HttpStub.requests()
+      assert url =~ "station_id=60003760"
+      assert url =~ "include_aggregates=true"
+      assert url =~ "include_orders=false"
+      assert url =~ "type_ids=1319"
+    end
+  end
+
+  describe "chunking" do
+    test "splits at 900 ids per request" do
+      ids = Enum.to_list(1..901)
+
+      HttpStub.set_responses([
+        {:ok, 200, types([sell(1, 10.0, nil)])},
+        {:ok, 200, types([sell(901, 20.0, nil)])}
+      ])
+
+      assert {:ok, prices} = Triff.quote_types(ids)
+      assert prices == %{1 => 10.0, 901 => 20.0}
+      assert length(HttpStub.requests()) == 2
+    end
+
+    test "keeps a single request at exactly 900 ids" do
+      HttpStub.set_responses([{:ok, 200, types([])}])
+
+      assert {:ok, _} = Triff.quote_types(Enum.to_list(1..900))
+      assert length(HttpStub.requests()) == 1
+    end
+
+    test "deduplicates ids before chunking" do
+      HttpStub.set_responses([{:ok, 200, types([sell(1319, 100.0, nil)])}])
+
+      assert {:ok, %{1319 => 100.0}} == Triff.quote_types([1319, 1319, 1319])
+      assert length(HttpStub.requests()) == 1
+    end
+  end
+
+  describe "failures" do
+    test "returns an error on a non-200 status" do
+      HttpStub.set_responses([{:ok, 400, ~s({"error":"station_id or region_id required"})}])
+
+      assert {:error, {:http_status, 400}} = Triff.quote_types([1319])
+    end
+
+    test "returns an error on a malformed body" do
+      HttpStub.set_responses([{:ok, 200, ~s({"unexpected":true})}])
+
+      assert {:error, :malformed_response} = Triff.quote_types([1319])
+    end
+
+    test "returns an error on undecodable JSON" do
+      HttpStub.set_responses([{:ok, 200, "<html>502</html>"}])
+
+      assert {:error, {:invalid_json, _}} = Triff.quote_types([1319])
+    end
+
+    test "returns an error on a transport failure" do
+      HttpStub.set_responses([{:error, :timeout}])
+
+      assert {:error, :timeout} = Triff.quote_types([1319])
+    end
+
+    test "a failure suppresses further requests for the cooldown window" do
+      HttpStub.set_responses([{:error, :timeout}])
+
+      assert {:error, :timeout} = Triff.quote_types([1319])
+      assert {:error, :recent_failure} = Triff.quote_types([2048])
+
+      # Only the first call reached the network.
+      assert length(HttpStub.requests()) == 1
+    end
+
+    test "the cooldown does not block a fully cached request" do
+      HttpStub.set_responses([
+        {:ok, 200, types([sell(1319, 100.0, nil)])},
+        {:error, :timeout}
+      ])
+
+      assert {:ok, %{1319 => 100.0}} == Triff.quote_types([1319])
+      assert {:error, :timeout} = Triff.quote_types([2048])
+
+      # 1319 is cached, so this needs no request and is unaffected by the cooldown.
+      assert {:ok, %{1319 => 100.0}} == Triff.quote_types([1319])
+    end
+  end
+
+  describe "caching" do
+    test "a cached price avoids a second request" do
+      HttpStub.set_responses([{:ok, 200, types([sell(1319, 100.0, nil)])}])
+
+      assert {:ok, %{1319 => 100.0}} == Triff.quote_types([1319])
+      assert {:ok, %{1319 => 100.0}} == Triff.quote_types([1319])
+      assert length(HttpStub.requests()) == 1
+    end
+
+    test "an unpriced type is remembered so it is not re-requested" do
+      HttpStub.set_responses([{:ok, 200, types([sell(44_992, nil, nil)])}])
+
+      assert {:ok, %{}} == Triff.quote_types([44_992])
+      assert {:ok, %{}} == Triff.quote_types([44_992])
+      assert length(HttpStub.requests()) == 1
+    end
+
+    test "a type absent from the response is remembered as unpriced" do
+      HttpStub.set_responses([{:ok, 200, types([])}])
+
+      assert {:ok, %{}} == Triff.quote_types([44_992])
+      assert {:ok, %{}} == Triff.quote_types([44_992])
+      assert length(HttpStub.requests()) == 1
+    end
+
+    test "only uncached ids are requested" do
+      HttpStub.set_responses([
+        {:ok, 200, types([sell(1319, 100.0, nil)])},
+        {:ok, 200, types([sell(2048, 200.0, nil)])}
+      ])
+
+      assert {:ok, %{1319 => 100.0}} == Triff.quote_types([1319])
+      assert {:ok, %{1319 => 100.0, 2048 => 200.0}} == Triff.quote_types([1319, 2048])
+
+      assert [_first, second] = HttpStub.requests()
+      assert second =~ "type_ids=2048"
+      refute second =~ "1319"
+    end
+  end
+end


### PR DESCRIPTION
Kill embeds now list the most valuable loot that **dropped**, matching the section wanderer-notifier posts. Off by default.

## How it works

Kills arrive over the wanderer-kills websocket with no item data, so the enricher refetches each killmail from ESI using `zkb.hash`, keeps entries carrying a `quantity_dropped` key (dropped-vs-destroyed is key *presence*, not a value), sums quantities per type id, prices the whole candidate set in one triff.tools request quoted at Jita 4-4, filters above the ISK threshold, sorts descending, takes the limit, and only then resolves type names — so the common case costs zero name lookups.

Enrichment runs after routing and after the per-destination kill cap, so no work is done for kills that will not be rendered.

## Concurrency and fail-open

The enricher runs in a task off `Discord.TaskSupervisor` via `async_nolink` — never `Task.async`, which would take the singleton dispatcher down with it on an exception. The dispatcher does `Task.yield(task, notable_items_timeout_ms()) || Task.shutdown(task, :brutal_kill)`; `Task.yield/2` returns `{:exit, reason}` inline, so a crash never reaches `handle_info/2`.

Three consecutive failures suppress enrichment for 60s. The timeout bounds one batch, not the mailbox — without the cooldown, a permanently slow ESI would cost 1.5s on every batch forever. The counter lives in `:api_cache` and its TTL *is* the cooldown window.

Every failure path — missing hash, ESI error, market error, unresolvable name, timeout, crash, task supervisor down — omits the section and still posts the kill.

## Configuration

| Env var | Default | |
|---|---|---|
| `WANDERER_NOTABLE_ITEMS_ENABLED` | `false` | costs an ESI fetch per kill plus a market lookup on the dispatcher's critical path |
| `WANDERER_NOTABLE_ITEMS_THRESHOLD_ISK` | `50000000` | item must be worth strictly more |
| `WANDERER_NOTABLE_ITEMS_LIMIT` | `5` | items per kill |
| `WANDERER_NOTABLE_ITEMS_TIMEOUT_MS` | `1500` | raising it delays kill notifications for every map on the instance |

Telemetry: `[:wanderer_app, :discord, :notable_items]` with `duration`/`kill_count`/`item_count` and `outcome: :ok | :disabled | :timeout | :crash | :unavailable | :skipped_cooldown`.

## Deliberate divergence from wanderer-notifier

Container contents are flattened **recursively**. wanderer-notifier reads `victim.items` flat and therefore silently omits loot inside a cargo container.

## Pricing

`WandererApp.Market.Triff` — no API token needed, which is why this is not token-gated the way the notifier's Janice-backed equivalent is. Prices are the 5th-percentile sell order, falling back to the best sell order. Three cache entries in `:api_cache`: a price per type (30 min), a `:no_quote` sentinel (10 min) so the permanently-unpriced long tail is not re-requested forever, and a request-failure marker (60s). Its own isolated Finch pool, so a slow market API cannot exhaust the ESI or Discord pools.

## Rendering

The section is pre-budgeted against Discord's 4096-char description limit rather than left to `truncate/2`, which would cut mid-bullet and emit a half-written item name or a bare `•`. The base description is truncated first and only whole item lines that still fit are appended; if not even one fits, the header is omitted too. Abyssal modules are listed without a price.

## Verification

- `mix compile --warnings-as-errors`, `mix format --check-formatted` — clean
- `mix credo --strict` — zero findings in new/changed files
- `mix dialyzer` — zero findings in new/changed files (the one `embed_formatter.ex:155` warning is pre-existing, confirmed against baseline)
- `mix test test/unit/external_events/ test/unit/market/` — **238 tests, 0 failures** (re-run after rebase onto `guarzo/zoo`)
- Full `mix test` — 13 failures, all pre-existing and environment/ordering-related (`AuthControllerTest`, `MapDuplicationAPIControllerSuccessTest`, `MapScopesTest`, `CommonAPIControllerTest`); identical at baseline

**Not verified:** no call against the live triff.tools endpoint or real ESI. The response shape comes from authGD's client and is exercised only through a stub — if triff's `sell.p05`/`sell.best` field names differ, every type would be silently unpriced and the section would never appear.

## Reviewer focus

1. `discord_dispatcher.ex` `enrich_notable_items/1` → `handle_enrichment/4` — the only place the singleton blocks on network work.
2. `NotableItems.enrich/1` ordering (price before names) and the fail-open coverage of `safe/2`.
3. `Triff.select_price/1` / `valid_price/1` — the response-shape assumption above.
4. `EmbedFormatter.take_fitting/2` — character accounting against the 4096 limit.

## Known follow-up

ESI killmail fetches are sequential inside the 1.5s budget — up to 30 per batch. On a cold ESI cache a full batch may exceed it, and three such batches trip the cooldown. Fail-open means kills still post; `outcome: :timeout` telemetry is what would confirm it in production, and the fix is an `async_stream` with bounded concurrency inside the enricher task.
