### PR TITLE
ci: run the test suite on guarzo/zoo pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: 🧪 Test Suite
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [guarzo/zoo, main, develop]
   push:
-    branches: [main, develop]
+    branches: [guarzo/zoo, main, develop]
 
 permissions:
   contents: read


### PR DESCRIPTION
`.github/workflows/test.yml` is the only workflow with a `pull_request` trigger, and its branch filter still read `[main, develop]`. Since the fork's default branch moved to `guarzo/zoo`, every PR has matched no trigger and run zero checks — no red X, just an empty checks list.

Changing the default branch does not rewrite `on.<event>.branches`. GitHub resolves the default branch implicitly only for `schedule` and `workflow_dispatch`.

## Change

```yaml
on:
  pull_request:
    branches: [guarzo/zoo, main, develop]
  push:
    branches: [guarzo/zoo, main, develop]
```

`main` and `develop` stay in the list so this hunk doesn't conflict on upstream merges. They cost nothing while unused.

## Not changed

The push-triggered workflows still don't fire from this fork, deliberately:

- `build.yml` / `build-develop.yml` publish to `wandererltd/community-edition`
- `advanced-test.yml` deploys the fly app named in `fly.toml`

Those are upstream's registry and app. Retargeting them is a separate change, not a branch name added to a filter.

`flaky-test-detection.yml` is cron + `workflow_dispatch` only and is unaffected.

## Verification

Parsed all six workflow files with a YAML loader and printed each resolved `on:` block — confirmed `test.yml` is the sole `pull_request` trigger and has no other branch-conditional `if:` gates. The PR-comment steps gate on `github.event_name == 'pull_request'` and are unaffected.

The checks on this PR are the real test: `pull_request` workflows are evaluated from the merge ref, so the suite should run here. If it doesn't appear, merging still activates it for subsequent PRs.
