### PR TITLE
perf(discord): concurrent notable-items enrichment and partial price retention

### DIFF
--- a/lib/wanderer_app/external_events/discord/embed_formatter.ex
+++ b/lib/wanderer_app/external_events/discord/embed_formatter.ex
@@ -250,18 +250,22 @@ defmodule WandererApp.ExternalEvents.Discord.EmbedFormatter do
     Enum.reverse(kept)
   end
 
+  # Matches the full `NotableItems.item()` shape rather than reading `:value`
+  # and `:abyssal?` defensively: every key is required by that type, so an item
+  # missing one is malformed and is dropped rather than rendered half-formed.
+  #
   # Abyssal modules carry no price: their market values are unreliable enough
   # that quoting one would be worse than saying nothing, matching
   # wanderer-notifier.
-  defp item_line(%{name: name, quantity: quantity} = item)
+  defp item_line(%{name: name, quantity: quantity, value: value, abyssal?: abyssal?})
        when is_binary(name) and is_integer(quantity) and quantity > 0 do
     count = if quantity > 1, do: " x#{quantity}", else: ""
 
     price =
-      if Map.get(item, :abyssal?) do
+      if abyssal? do
         ""
       else
-        case format_isk(Map.get(item, :value)) do
+        case format_isk(value) do
           nil -> ""
           isk -> " (~#{isk})"
         end

--- a/lib/wanderer_app/external_events/discord/notable_items.ex
+++ b/lib/wanderer_app/external_events/discord/notable_items.ex
@@ -71,18 +71,44 @@ defmodule WandererApp.ExternalEvents.Discord.NotableItems do
 
   def enrich(kills) do
     dropped =
-      Enum.reduce(kills, %{}, fn kill, acc ->
-        case dropped_quantities(kill) do
-          {killmail_id, quantities} when map_size(quantities) > 0 ->
-            Map.put(acc, killmail_id, quantities)
+      kills
+      |> esi_stream(&safe_dropped_quantities/1)
+      |> Enum.reduce(%{}, fn
+        {:ok, {killmail_id, quantities}}, acc when map_size(quantities) > 0 ->
+          Map.put(acc, killmail_id, quantities)
 
-          _ ->
-            acc
-        end
+        _result, acc ->
+          acc
       end)
 
     if map_size(dropped) == 0, do: %{}, else: price_and_select(dropped)
   end
+
+  # One ESI round trip per kill, and a batch is up to
+  # `EmbedFormatter.max_kills_per_event()` kills, so doing this sequentially
+  # spent the whole enrichment budget on latency: 30 cold fetches at ~100ms
+  # each cannot fit in 1.5s no matter how fast ESI is. Concurrency is capped so
+  # a busy batch cannot flood the ESI pool on the dispatcher's behalf.
+  #
+  # `on_timeout: :kill_task` rather than letting the stream raise: a single slow
+  # lookup costs its own item, not the batch. The per-item timeout is the whole
+  # enrichment budget because the dispatcher kills this task at that point
+  # anyway — it is a ceiling, not a schedule.
+  @esi_concurrency 8
+
+  defp esi_stream(enumerable, fun) do
+    Task.async_stream(enumerable, fun,
+      max_concurrency: @esi_concurrency,
+      timeout: WandererApp.Env.notable_items_timeout_ms(),
+      on_timeout: :kill_task,
+      ordered: false
+    )
+  end
+
+  # Wrapped so a raise anywhere in the per-kill path costs that kill only. An
+  # unrescued exception in a stream child brings down the whole stream, which
+  # would discard the kills that had already resolved.
+  defp safe_dropped_quantities(kill), do: safe(fn -> dropped_quantities(kill) end, :skip)
 
   # -- step 1-4: dropped quantities per kill ---------------------------------
 
@@ -175,12 +201,18 @@ defmodule WandererApp.ExternalEvents.Discord.NotableItems do
       Enum.map(items, fn {type_id, _quantity, _value} -> type_id end)
     end)
     |> Enum.uniq()
-    |> Enum.reduce(%{}, fn type_id, acc ->
-      case safe(fn -> esi_client().get_type_info(type_id) end, :error) do
-        {:ok, %{"name" => name}} when is_binary(name) -> Map.put(acc, type_id, name)
-        _ -> acc
-      end
+    |> esi_stream(&resolve_name/1)
+    |> Enum.reduce(%{}, fn
+      {:ok, {type_id, name}}, acc -> Map.put(acc, type_id, name)
+      _result, acc -> acc
     end)
+  end
+
+  defp resolve_name(type_id) do
+    case safe(fn -> esi_client().get_type_info(type_id) end, :error) do
+      {:ok, %{"name" => name}} when is_binary(name) -> {type_id, name}
+      _ -> :unresolved
+    end
   end
 
   # An item whose name would not resolve is dropped: there is nothing to render.

--- a/lib/wanderer_app/market/triff.ex
+++ b/lib/wanderer_app/market/triff.ex
@@ -60,8 +60,11 @@ defmodule WandererApp.Market.Triff do
   Types with no usable quote are **absent from the map** — callers must not
   treat a missing key as zero.
 
-  Returns `{:error, reason}` if any request in the batch fails, or if a recent
-  request already failed and the cooldown is still active.
+  Returns `{:error, reason}` if the very first request in the batch fails, or if
+  a recent request already failed and the cooldown is still active. A batch that
+  spans several chunks and fails partway returns `{:ok, partial}` with whatever
+  was priced before the failure — an under-reported section beats no section,
+  and unpriced types are already an expected outcome.
   """
   @spec quote_types([integer()]) :: {:ok, prices()} | {:error, term()}
   def quote_types(type_ids) do
@@ -80,22 +83,38 @@ defmodule WandererApp.Market.Triff do
     end
   end
 
+  # Halts on the first failing chunk — a failure usually means triff is down, so
+  # issuing the remaining chunks would just add round trips to a dead endpoint.
+  # But the chunks that already answered are kept and returned: their prices are
+  # real, and discarding them would cost the whole batch its section over a
+  # partial outage. The failure is still marked, so the cooldown engages either
+  # way.
   defp fetch_missing(missing, cached) do
     missing
     |> Enum.chunk_every(@chunk_size)
-    |> Enum.reduce_while({:ok, cached}, fn chunk, {:ok, acc} ->
+    |> Enum.reduce_while({cached, 0, nil}, fn chunk, {acc, ok_count, _reason} ->
       case fetch_chunk(chunk) do
-        {:ok, priced} -> {:cont, {:ok, Map.merge(acc, priced)}}
-        {:error, reason} -> {:halt, {:error, reason}}
+        {:ok, priced} -> {:cont, {Map.merge(acc, priced), ok_count + 1, nil}}
+        {:error, reason} -> {:halt, {acc, ok_count, reason}}
       end
     end)
     |> case do
-      {:ok, prices} ->
+      {prices, _ok_count, nil} ->
         {:ok, prices}
 
-      {:error, reason} ->
+      {_prices, 0, reason} ->
         mark_failure(reason)
         {:error, reason}
+
+      {prices, ok_count, reason} ->
+        mark_failure(reason)
+
+        Logger.warning(
+          "[Triff] returning #{map_size(prices)} prices from #{ok_count} " <>
+            "chunk(s) after a later chunk failed"
+        )
+
+        {:ok, prices}
     end
   end
 

--- a/test/unit/external_events/discord/embed_formatter_test.exs
+++ b/test/unit/external_events/discord/embed_formatter_test.exs
@@ -665,6 +665,18 @@ defmodule WandererApp.ExternalEvents.Discord.EmbedFormatterTest do
       refute description =~ "• Real"
     end
 
+    # `NotableItems.item()` declares all four keys, so an item missing one did
+    # not come from the enricher and cannot be trusted to render.
+    test "an item missing a key the type requires is skipped" do
+      for missing <- [:name, :quantity, :value, :abyssal?] do
+        malformed = item("Partial") |> Map.delete(missing)
+        description = describe_kill(with_items([malformed, item("Good")]))["description"]
+
+        assert description =~ "• Good", "expected the well-formed item with #{missing} missing"
+        refute description =~ "• Partial"
+      end
+    end
+
     # -- budgeting ------------------------------------------------------------
 
     # Builds a killmail whose base description (before any section) is exactly

--- a/test/unit/external_events/discord/notable_items_test.exs
+++ b/test/unit/external_events/discord/notable_items_test.exs
@@ -191,6 +191,34 @@ defmodule WandererApp.ExternalEvents.Discord.NotableItemsTest do
       # One batched pricing request covers both kills.
       assert length(HttpStub.requests()) == 1
     end
+
+    # The kills are fetched concurrently, so an exception in one runs in its own
+    # stream child. Without the per-kill rescue that child would take the whole
+    # stream down and the healthy kills would be lost with it.
+    test "one kill raising does not cost the others their section" do
+      stub(WandererApp.Esi.Mock, :get_killmail, fn
+        1, _hash -> raise "boom"
+        2, _hash -> {:ok, killmail([dropped(1319, 1)])}
+      end)
+
+      prices([{1319, 100_000_000}])
+      stub_names(%{1319 => "Damage Control II"})
+
+      assert %{2 => [%{name: "Damage Control II"}]} =
+               NotableItems.enrich([kill(1), kill(2)])
+    end
+
+    test "enriches a full batch of kills" do
+      killmails = Map.new(1..30, fn id -> {id, killmail([dropped(1319, 1)])} end)
+      stub_killmail(killmails)
+      prices([{1319, 100_000_000}])
+      stub_names(%{1319 => "Damage Control II"})
+
+      result = NotableItems.enrich(Enum.map(1..30, &kill/1))
+
+      assert map_size(result) == 30
+      assert length(HttpStub.requests()) == 1
+    end
   end
 
   describe "fail-open" do

--- a/test/unit/market/triff_test.exs
+++ b/test/unit/market/triff_test.exs
@@ -123,6 +123,23 @@ defmodule WandererApp.Market.TriffTest do
       assert {:ok, %{1319 => 100.0}} == Triff.quote_types([1319, 1319, 1319])
       assert length(HttpStub.requests()) == 1
     end
+
+    test "keeps the prices from earlier chunks when a later chunk fails" do
+      HttpStub.set_responses([
+        {:ok, 200, types([sell(1, 10.0, nil)])},
+        {:error, :timeout}
+      ])
+
+      assert {:ok, %{1 => 10.0}} == Triff.quote_types(Enum.to_list(1..901))
+    end
+
+    test "stops requesting after the first failing chunk" do
+      HttpStub.set_responses([{:error, :timeout}])
+
+      assert {:error, :timeout} = Triff.quote_types(Enum.to_list(1..1801))
+      # Three chunks were due; the first failure ends the batch.
+      assert length(HttpStub.requests()) == 1
+    end
   end
 
   describe "failures" do


### PR DESCRIPTION
Four follow-ups from the polish pass on #116.

## What changed

- **Concurrent killmail fetches.** `NotableItems.enrich/1` fans out over a bounded `Task.async_stream` (`@esi_concurrency 8`) instead of walking the batch serially. A batch is up to `EmbedFormatter.max_kills_per_event()` kills and each costs one ESI round trip, so 30 cold fetches at ~100ms could never fit the 1.5s enrichment budget sequentially. `on_timeout: :kill_task` means one slow lookup costs its own item, not the batch; the per-kill path is wrapped so a raise costs that kill only (an unrescued exception in a stream child would otherwise discard the kills that had already resolved).
- **Concurrent type-name resolution**, through the same bounded stream, for the same reason.
- **Partial price retention.** `Triff.fetch_missing/2` still halts on the first failing chunk — a failure usually means triff is down — but now returns the prices earlier chunks already produced rather than throwing them away. The failure is still marked, so the cooldown engages either way. An under-reported section beats no section, and unpriced types are already an expected outcome.
- **Strict `item_line/1`.** It now matches the full `NotableItems.item()` shape rather than reading `:value` and `:abyssal?` defensively. Every key is required by that type, so an item missing one is malformed and is dropped instead of rendered half-formed.

## Tests

Five new tests: per-kill raise isolation, a full 30-kill batch (asserts one batched pricing request), partial-chunk price retention, halt-after-first-failing-chunk, and `item_line/1` strictness across each missing key.

## Verification

- `mix test test/unit/external_events/ test/unit/market/` → **243 tests, 0 failures**
- `mix format --check-formatted` → clean
- `mix compile --warnings-as-errors --force` → clean
- `mix credo --strict` on the three changed lib files → no issues
- Each new test checked for non-vacuity by reverting its lib change and confirming it goes red.

This branch is based on plain `guarzo/zoo`, so the 12 pre-existing suite failures (`MapDuplicationAPIControllerSuccessTest`, `AuthControllerTest`) still apply until #118 lands — hence verification against the targeted suites rather than the full run.