### PR TITLE
chore(fly): enable notable-item enrichment on the Fly deployment

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -49,6 +49,15 @@ swap_size_mb = 512
   # forever. Its companions WANDERER_KILLS_SERVICE_ENABLED and
   # WANDERER_KILLS_BASE_URL are secrets instead: they embed the kills app name.
   WANDERER_KILLS_IPV6 = 'true'
+  # Enriches Discord killmail embeds with notable dropped items
+  # (external_events/discord_dispatcher.ex:301); default is "false". Must be
+  # exactly 'true' or 'false' — runtime.exs:508 pipes this through
+  # String.to_existing_atom/1, so '1' or 'yes' raises at boot and takes the
+  # machine down rather than falling back to the default. Read only at boot,
+  # so a deploy/restart is required. The tuning companions
+  # WANDERER_NOTABLE_ITEMS_{THRESHOLD_ISK,LIMIT,TIMEOUT_MS} stay at their
+  # defaults (50_000_000 / 5 / 1500) until set here.
+  WANDERER_NOTABLE_ITEMS_ENABLED = 'true'
   # PROMEX_DISABLED defaults to 'true' (config/runtime.exs), so there is no
   # [[metrics]] block here on purpose. Flipping it to 'false' requires adding
   # one — METRICS_PORT defaults to 4021 and nothing exposes it.


### PR DESCRIPTION
Sets `WANDERER_NOTABLE_ITEMS_ENABLED = 'true'` in the `[env]` block of `fly.toml`.

## What this turns on

The flag gates notable dropped-item enrichment on Discord killmail embeds — `lib/wanderer_app/external_events/discord_dispatcher.ex:301` bails out early when it is off. The default is `"false"` (`config/runtime.exs:506-509`), so this was previously disabled on the Fly deployment.

## Why `[env]` and not `fly secrets`

`fly.toml` reserves secrets for values that are per-deployment or embed another app's name (`PHX_HOST`, `WEB_APP_URL`, `WANDERER_KILLS_BASE_URL`). This is a plain non-secret feature flag, so it belongs in the committed config where it stays visible and versioned.

## Notes for whoever deploys

- `config/runtime.exs:508` pipes the value through `String.to_existing_atom/1`. Only `'true'` and `'false'` are safe — `'1'`, `'yes'`, or `'TRUE'` raise `ArgumentError` at boot and take the machine down rather than falling back to the default. The comment in the diff records this.
- Read at boot only, so it takes effect on the next deploy/restart.
- The tuning companions stay at their defaults unless also set: `WANDERER_NOTABLE_ITEMS_THRESHOLD_ISK` (50,000,000), `_LIMIT` (5), `_TIMEOUT_MS` (1500).
- Only has visible effect where Discord webhook dispatch is already enabled.

## Verification

`fly.toml` parses cleanly (`tomllib`) and the resulting `[env]` table contains the new key. No application code changed, so no test run was warranted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled notable-item enrichment for Discord killmail embeds, providing additional item details in supported notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->