### PR TITLE
fix(discord): resolve missing corporation tickers from ESI for kill embeds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,9 +39,14 @@ export WANDERER_WEBHOOK_TIMEOUT_MS="15000"
 # notifications for every map on the instance. (optional, default 1500)
 # export WANDERER_NOTABLE_ITEMS_TIMEOUT_MS="1500"
 
-# How long corporation-ticker lookups may hold up one kill batch. Ticker
-# enrichment is always on; this only bounds its cost. (optional, default 1500)
+# How long corporation-ticker lookups may hold up one kill batch.
+# (optional, default 1500)
 # export WANDERER_CORP_TICKERS_TIMEOUT_MS="1500"
+
+# Incident switch for corporation-ticker lookups. On by default: turning it off
+# means kill embeds lose the (TICKER) after each pilot name.
+# (optional, default true)
+# export WANDERER_CORP_TICKERS_ENABLED="true"
 
 # Promo codes for map subscriptions (optional)
 # Format: CODE:DISCOUNT_PERCENT,CODE2:DISCOUNT_PERCENT2

--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,10 @@ export WANDERER_WEBHOOK_TIMEOUT_MS="15000"
 # notifications for every map on the instance. (optional, default 1500)
 # export WANDERER_NOTABLE_ITEMS_TIMEOUT_MS="1500"
 
+# How long corporation-ticker lookups may hold up one kill batch. Ticker
+# enrichment is always on; this only bounds its cost. (optional, default 1500)
+# export WANDERER_CORP_TICKERS_TIMEOUT_MS="1500"
+
 # Promo codes for map subscriptions (optional)
 # Format: CODE:DISCOUNT_PERCENT,CODE2:DISCOUNT_PERCENT2
 # Codes are case-insensitive, discounts stack with period discounts

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ without a price, since market quotes for them are not meaningful. Any failure �
 timeout, ESI error, unavailable pricing — simply omits the section; the kill is
 still posted.
 
+Corporation tickers are filled in from ESI when a killmail reaches the
+dispatcher without them, so the `(TICKER)` after each pilot name is not lost to
+an upstream payload that arrived unenriched. This is always on: it is one
+lookup per corporation, cached for an hour, and only for the kills actually
+being posted. `WANDERER_CORP_TICKERS_TIMEOUT_MS` (default `1500`) bounds how
+long those lookups may hold up a batch. A failure omits the ticker; the kill is
+still posted.
+
 The webhook URL is stored encrypted and is never displayed in full after it is
 saved — the settings tab shows only a masked hint. Pointing a destination at a
 different channel means entering the full URL again.

--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ dispatcher without them, so the `(TICKER)` after each pilot name is not lost to
 an upstream payload that arrived unenriched. This is always on: it is one
 lookup per corporation, cached for an hour, and only for the kills actually
 being posted. `WANDERER_CORP_TICKERS_TIMEOUT_MS` (default `1500`) bounds how
-long those lookups may hold up a batch. A failure omits the ticker; the kill is
-still posted.
+long those lookups may hold up a batch, and `WANDERER_CORP_TICKERS_ENABLED`
+(default `true`) is an incident switch for stopping the lookups without a
+deploy — turning it off means embeds lose the ticker again. A failure omits the
+ticker; the kill is still posted.
 
 The webhook URL is stored encrypted and is never displayed in full after it is
 saved — the settings tab shows only a masked hint. Pointing a destination at a

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ still posted.
 
 Corporation tickers are filled in from ESI when a killmail reaches the
 dispatcher without them, so the `(TICKER)` after each pilot name is not lost to
-an upstream payload that arrived unenriched. This is always on: it is one
+an upstream payload that arrived unenriched. This is on by default: it is one
 lookup per corporation, cached for an hour, and only for the kills actually
 being posted. `WANDERER_CORP_TICKERS_TIMEOUT_MS` (default `1500`) bounds how
 long those lookups may hold up a batch, and `WANDERER_CORP_TICKERS_ENABLED`

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -512,6 +512,10 @@ config :wanderer_app, :external_events,
   notable_items_limit: config_dir |> get_int_from_path_or_env("WANDERER_NOTABLE_ITEMS_LIMIT", 5),
   notable_items_timeout_ms:
     config_dir |> get_int_from_path_or_env("WANDERER_NOTABLE_ITEMS_TIMEOUT_MS", 1500),
+  corp_tickers_enabled:
+    config_dir
+    |> get_var_from_path_or_env("WANDERER_CORP_TICKERS_ENABLED", "true")
+    |> String.to_existing_atom(),
   corp_tickers_timeout_ms:
     config_dir |> get_int_from_path_or_env("WANDERER_CORP_TICKERS_TIMEOUT_MS", 1500)
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -511,7 +511,9 @@ config :wanderer_app, :external_events,
     config_dir |> get_int_from_path_or_env("WANDERER_NOTABLE_ITEMS_THRESHOLD_ISK", 50_000_000),
   notable_items_limit: config_dir |> get_int_from_path_or_env("WANDERER_NOTABLE_ITEMS_LIMIT", 5),
   notable_items_timeout_ms:
-    config_dir |> get_int_from_path_or_env("WANDERER_NOTABLE_ITEMS_TIMEOUT_MS", 1500)
+    config_dir |> get_int_from_path_or_env("WANDERER_NOTABLE_ITEMS_TIMEOUT_MS", 1500),
+  corp_tickers_timeout_ms:
+    config_dir |> get_int_from_path_or_env("WANDERER_CORP_TICKERS_TIMEOUT_MS", 1500)
 
 # Signature expiration — evaluated at boot so the deployment's env vars win over
 # whatever was set when the release was built. Defaults mirror config.exs.

--- a/config/test.exs
+++ b/config/test.exs
@@ -34,7 +34,9 @@ config :wanderer_app,
   websocket_client_module: Test.WebSocketClientMock,
   sse: [enabled: false],
   external_events: [webhooks_enabled: false],
-  discord_http_client: WandererApp.ExternalEvents.Discord.HttpStub
+  discord_http_client: WandererApp.ExternalEvents.Discord.HttpStub,
+  # No test may reach real ESI. Enrichment tests override this per test.
+  esi_client: WandererApp.Esi.OfflineStub
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.

--- a/lib/wanderer_app/env.ex
+++ b/lib/wanderer_app/env.ex
@@ -174,6 +174,23 @@ defmodule WandererApp.Env do
     |> validate_positive_integer(:notable_items_timeout_ms, @default_notable_items_timeout_ms)
   end
 
+  @default_corp_tickers_timeout_ms 1_500
+
+  @doc """
+  Hard ceiling on how long corporation-ticker resolution may block the singleton
+  dispatcher, in the same sense as `notable_items_timeout_ms/0`.
+
+  Separate from that budget rather than shared with it because the two do very
+  different amounts of work: ticker lookups are per-corporation and cached for
+  an hour, so the steady state is a cache read, while notable items pay an ESI
+  killmail fetch per kill every time.
+  """
+  def corp_tickers_timeout_ms() do
+    Application.get_env(@app, :external_events, [])
+    |> Keyword.get(:corp_tickers_timeout_ms, @default_corp_tickers_timeout_ms)
+    |> validate_positive_integer(:corp_tickers_timeout_ms, @default_corp_tickers_timeout_ms)
+  end
+
   defp validate_positive_integer(value, _key, _default) when is_integer(value) and value > 0,
     do: value
 

--- a/lib/wanderer_app/env.ex
+++ b/lib/wanderer_app/env.ex
@@ -177,6 +177,21 @@ defmodule WandererApp.Env do
   @default_corp_tickers_timeout_ms 1_500
 
   @doc """
+  Whether the Discord dispatcher fills in corporation tickers a killmail arrived
+  without.
+
+  On by default, unlike `notable_items_enabled?/0`: an off switch here means
+  embeds silently lose the `(TICKER)` after each pilot name, which is a bug, not
+  a preference. It exists as a switch only so an operator can stop the ESI
+  lookups during an incident without waiting for a deploy — the enrichment
+  already costs nothing on batches whose payload carried its tickers.
+  """
+  def corp_tickers_enabled?() do
+    Application.get_env(@app, :external_events, [])
+    |> Keyword.get(:corp_tickers_enabled, true)
+  end
+
+  @doc """
   Hard ceiling on how long corporation-ticker resolution may block the singleton
   dispatcher, in the same sense as `notable_items_timeout_ms/0`.
 

--- a/lib/wanderer_app/external_events/discord/corp_tickers.ex
+++ b/lib/wanderer_app/external_events/discord/corp_tickers.ex
@@ -84,7 +84,7 @@ defmodule WandererApp.ExternalEvents.Discord.CorpTickers do
         corp_ids
         |> Task.async_stream(&resolve/1,
           max_concurrency: @esi_concurrency,
-          timeout: WandererApp.Env.corp_tickers_timeout_ms(),
+          timeout: element_timeout_ms(),
           on_timeout: :kill_task,
           ordered: false
         )
@@ -142,6 +142,18 @@ defmodule WandererApp.ExternalEvents.Discord.CorpTickers do
       _ ->
         :unresolved
     end
+  end
+
+  # Strictly smaller than the budget the dispatcher gives the whole enrichment,
+  # and that gap is the point. Both deadlines start at roughly the same moment,
+  # so a per-element timeout equal to the whole budget means the dispatcher
+  # shuts this task down before `on_timeout: :kill_task` can drop the slow
+  # corporation — the corporations that already resolved die with it. Half the
+  # budget leaves room for the stream to finish and hand back what it got.
+  defp element_timeout_ms do
+    WandererApp.Env.corp_tickers_timeout_ms()
+    |> div(2)
+    |> max(1)
   end
 
   defp normalize(id) when is_integer(id), do: Integer.to_string(id)

--- a/lib/wanderer_app/external_events/discord/corp_tickers.ex
+++ b/lib/wanderer_app/external_events/discord/corp_tickers.ex
@@ -1,0 +1,175 @@
+defmodule WandererApp.ExternalEvents.Discord.CorpTickers do
+  @moduledoc """
+  Resolves the corporation tickers a kill embed renders, for kills whose
+  websocket payload arrived without them.
+
+  ## Why this is needed
+
+  `EmbedFormatter` renders `(TICKER)` after the victim and the final blow, and
+  drops the whole parenthetical when the ticker is nil
+  (`embed_formatter.ex:364`). `MessageHandler.get_corp_ticker/1` reads the
+  ticker straight out of the wanderer-kills payload and never falls back, so a
+  payload that omits it produces a notification with no corporation at all —
+  the reported symptom. Every wanderer-kills serializer rejects nil fields
+  before encoding, which makes "upstream had not enriched this kill yet"
+  indistinguishable from "this corporation has no ticker".
+
+  The corporation **ids** do not have that problem: they come off the raw ESI
+  killmail, so `victim_corp_id` / `final_blow_corp_id` are present even when the
+  tickers are not. This module turns those ids into tickers.
+
+  wanderer-notifier never hit this because it never trusted the payload — it
+  resolved the ticker from `corporation_id` through cache→ESI on every kill
+  (`killmail_formatter.ex:389-418`).
+
+  ## Scope
+
+  Discord path only, and only for the two fields the embed actually renders.
+  `top_damage_corp_ticker` is carried in the payload but never rendered, so it
+  is not resolved. Enriching in `MessageHandler` instead would also fix the
+  kills widget, but would put an ESI lookup on every kill in every subscribed
+  system rather than on the handful that become notifications.
+
+  Lookups go through `WandererApp.Esi.get_corporation_info/1`, which is
+  Nebulex-cached with a 1h TTL (`esi/api_client.ex:151`), so a busy chain
+  resolves each corporation once an hour, not once a kill.
+
+  ## Fail-open
+
+  A corporation that will not resolve is simply left absent, and the embed
+  renders as it does today — pilot name with no parenthetical. A missing ticker
+  is an acceptable outcome; a missing kill notification is not. Rendering
+  wanderer-notifier's literal `"????"` placeholder was considered and rejected:
+  omitting reads as "no corp shown", `"????"` reads as "corp is called ????".
+  """
+
+  require Logger
+
+  # The pairs the embed renders. Order is irrelevant; membership is not — adding
+  # a field here without a matching `corporation_link/2` call in the formatter
+  # buys ESI calls for something nobody sees.
+  @fields [
+    {"victim_corp_id", "victim_corp_ticker"},
+    {"final_blow_corp_id", "final_blow_corp_ticker"}
+  ]
+
+  # Matches `NotableItems`: bounded so one batch cannot flood the ESI pool on
+  # the dispatcher's behalf. Cache hits do not consume a slot for long.
+  @esi_concurrency 8
+
+  @typedoc "Corporation id, normalized to a string — payload ids are not consistently typed."
+  @type corp_id :: String.t()
+
+  @doc """
+  Returns `%{corp_id => ticker}` for the corporations these kills need and did
+  not carry.
+
+  Corporations that fail to resolve are **absent from the map**. Keys are
+  stringified ids; use `apply_tickers/2` rather than reading the map directly.
+  """
+  @callback enrich([map()]) :: %{optional(corp_id()) => String.t()}
+
+  @doc "Returns the configured enricher, so the dispatcher can inject a stub."
+  def impl, do: Application.get_env(:wanderer_app, :corp_tickers_enricher, __MODULE__)
+
+  @spec enrich([map()]) :: %{optional(corp_id()) => String.t()}
+  def enrich([]), do: %{}
+
+  def enrich(kills) do
+    case missing_corp_ids(kills) do
+      [] ->
+        %{}
+
+      corp_ids ->
+        corp_ids
+        |> Task.async_stream(&resolve/1,
+          max_concurrency: @esi_concurrency,
+          timeout: WandererApp.Env.corp_tickers_timeout_ms(),
+          on_timeout: :kill_task,
+          ordered: false
+        )
+        |> Enum.reduce(%{}, fn
+          {:ok, {corp_id, ticker}}, acc -> Map.put(acc, corp_id, ticker)
+          _result, acc -> acc
+        end)
+    end
+  end
+
+  @doc """
+  Fills in whichever of the rendered ticker fields this kill is missing.
+
+  Never overwrites a ticker the payload already carried: upstream saw the
+  killmail, we only saw the corporation.
+  """
+  @spec apply_tickers(map(), %{optional(corp_id()) => String.t()}) :: map()
+  def apply_tickers(kill, tickers) when map_size(tickers) == 0, do: kill
+
+  def apply_tickers(kill, tickers) do
+    Enum.reduce(@fields, kill, fn {id_key, ticker_key}, acc ->
+      with nil <- present(acc[ticker_key]),
+           id when not is_nil(id) <- normalize(acc[id_key]),
+           ticker when is_binary(ticker) <- Map.get(tickers, id) do
+        Map.put(acc, ticker_key, ticker)
+      else
+        _ -> acc
+      end
+    end)
+  end
+
+  @doc "The corporation ids these kills need looked up. Public for the dispatcher's telemetry."
+  @spec missing_corp_ids([map()]) :: [corp_id()]
+  def missing_corp_ids(kills) do
+    kills
+    |> Enum.flat_map(fn kill ->
+      Enum.flat_map(@fields, fn {id_key, ticker_key} ->
+        case {present(kill[ticker_key]), normalize(kill[id_key])} do
+          {nil, id} when not is_nil(id) -> [id]
+          _ -> []
+        end
+      end)
+    end)
+    |> Enum.uniq()
+  end
+
+  defp resolve(corp_id) do
+    case safe(fn -> esi_client().get_corporation_info(corp_id) end) do
+      {:ok, %{"ticker" => ticker}} when is_binary(ticker) ->
+        case present(ticker) do
+          nil -> :unresolved
+          ticker -> {corp_id, ticker}
+        end
+
+      _ ->
+        :unresolved
+    end
+  end
+
+  defp normalize(id) when is_integer(id), do: Integer.to_string(id)
+  defp normalize(id) when is_binary(id), do: present(id)
+  defp normalize(_id), do: nil
+
+  defp present(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp present(_value), do: nil
+
+  defp esi_client, do: Application.get_env(:wanderer_app, :esi_client, WandererApp.Esi)
+
+  # An exception in an `async_stream` child brings down the whole stream, which
+  # would discard the corporations that had already resolved.
+  defp safe(fun) do
+    fun.()
+  rescue
+    error ->
+      Logger.warning("[CorpTickers] #{Exception.message(error)}")
+      :error
+  catch
+    :exit, reason ->
+      Logger.warning("[CorpTickers] exited: #{inspect(reason)}")
+      :error
+  end
+end

--- a/lib/wanderer_app/external_events/discord/corp_tickers.ex
+++ b/lib/wanderer_app/external_events/discord/corp_tickers.ex
@@ -132,7 +132,7 @@ defmodule WandererApp.ExternalEvents.Discord.CorpTickers do
   end
 
   defp resolve(corp_id) do
-    case safe(fn -> esi_client().get_corporation_info(corp_id) end) do
+    case safe(corp_id, fn -> esi_client().get_corporation_info(corp_id) end) do
       {:ok, %{"ticker" => ticker}} when is_binary(ticker) ->
         case present(ticker) do
           nil -> :unresolved
@@ -161,15 +161,19 @@ defmodule WandererApp.ExternalEvents.Discord.CorpTickers do
 
   # An exception in an `async_stream` child brings down the whole stream, which
   # would discard the corporations that had already resolved.
-  defp safe(fun) do
+  #
+  # The corporation id is carried into the message because the concurrency means
+  # a systemic failure produces several identical lines at once, with nothing
+  # else to tell them apart by.
+  defp safe(corp_id, fun) do
     fun.()
   rescue
     error ->
-      Logger.warning("[CorpTickers] #{Exception.message(error)}")
+      Logger.warning("[CorpTickers] corporation #{corp_id}: #{Exception.message(error)}")
       :error
   catch
     :exit, reason ->
-      Logger.warning("[CorpTickers] exited: #{inspect(reason)}")
+      Logger.warning("[CorpTickers] corporation #{corp_id} exited: #{inspect(reason)}")
       :error
   end
 end

--- a/lib/wanderer_app/external_events/discord_dispatcher.ex
+++ b/lib/wanderer_app/external_events/discord_dispatcher.ex
@@ -68,14 +68,15 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
   # 24h TTLs already used for kill caches.
   @dedup_ttl :timer.hours(24)
 
-  # Notable-items enrichment failure cooldown. The counter lives in the shared
-  # api cache and carries the cooldown as its TTL, so it both counts and expires.
-  # Threshold and window are deliberate guesses: telemetry on
-  # `[:wanderer_app, :discord, :notable_items]` is what will tune them.
-  @notable_items_cache :api_cache
+  # Enrichment failure cooldown, shared by both enrichment steps. The counter
+  # lives in the shared api cache and carries the cooldown as its TTL, so it both
+  # counts and expires. Threshold and window are deliberate guesses: telemetry on
+  # `[:wanderer_app, :discord, :notable_items]` and
+  # `[:wanderer_app, :discord, :corp_tickers]` is what will tune them.
+  @enrichment_cache :api_cache
   @notable_items_failure_key "discord-notable-items-failures"
-  @notable_items_failure_threshold 3
-  @notable_items_cooldown_ms :timer.seconds(60)
+  @enrichment_failure_threshold 3
+  @enrichment_cooldown_ms :timer.seconds(60)
 
   # Corporation-ticker enrichment shares that bookkeeping, under its own key so
   # an ESI outage that stops ticker lookups does not also suppress notable items
@@ -301,7 +302,7 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
   # The budget bounds ONE batch, not the mailbox. During a sustained ESI or
   # market outage every batch would pay it in full and the dispatcher would fall
   # arbitrarily far behind, so the failure cooldown below is part of the feature
-  # rather than a follow-up: after @notable_items_failure_threshold consecutive
+  # rather than a follow-up: after @enrichment_failure_threshold consecutive
   # failures, enrichment is skipped outright for the cooldown window.
   defp enrich_notable_items(partitions) do
     cond do
@@ -381,13 +382,21 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
     start_task(fn -> enricher.enrich(candidates) end)
   end
 
+  # Returns nil when the task could not be started at all, which in practice
+  # means the Discord task supervisor is not running. Logged rather than
+  # swallowed: it silently disables *both* enrichments, and unlike the other
+  # failure paths it is a supervision-tree problem, not an ESI one.
   defp start_task(fun) do
     Task.Supervisor.async_nolink(WandererApp.ExternalEvents.Discord.TaskSupervisor, fun)
   rescue
     # The supervisor is not up. Fail open like every other enrichment failure.
-    _ -> nil
+    error ->
+      Logger.warning("[Discord] enrichment task not started: #{Exception.message(error)}")
+      nil
   catch
-    :exit, _ -> nil
+    :exit, reason ->
+      Logger.warning("[Discord] enrichment task not started, exited: #{inspect(reason)}")
+      nil
   end
 
   # Only the kills that will actually be rendered, deduplicated. `Router.route/3`
@@ -425,8 +434,8 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
   defp notable_items_cooldown_active?, do: cooldown_active?(@notable_items_failure_key)
 
   defp cooldown_active?(key) do
-    case Cachex.get(@notable_items_cache, key) do
-      {:ok, count} when is_integer(count) -> count >= @notable_items_failure_threshold
+    case Cachex.get(@enrichment_cache, key) do
+      {:ok, count} when is_integer(count) -> count >= @enrichment_failure_threshold
       _ -> false
     end
   end
@@ -442,12 +451,12 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
 
   defp note_failure(key, message_fun) do
     count =
-      case Cachex.get(@notable_items_cache, key) do
+      case Cachex.get(@enrichment_cache, key) do
         {:ok, n} when is_integer(n) -> n + 1
         _ -> 1
       end
 
-    Cachex.put(@notable_items_cache, key, count, ttl: @notable_items_cooldown_ms)
+    Cachex.put(@enrichment_cache, key, count, ttl: @enrichment_cooldown_ms)
 
     Logger.warning(message_fun.(count))
   rescue
@@ -459,7 +468,7 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
   defp reset_notable_items_failures, do: reset_failures(@notable_items_failure_key)
 
   defp reset_failures(key) do
-    Cachex.del(@notable_items_cache, key)
+    Cachex.del(@enrichment_cache, key)
   rescue
     _ -> :ok
   end
@@ -527,14 +536,29 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
 
   defp handle_corp_tickers(partitions, wanted, result, duration) do
     case result do
+      # Work was owed and none of it came back. Unlike notable items — where an
+      # empty result legitimately means "this kill dropped nothing notable" —
+      # every id here was asked for because a ticker is missing, so resolving
+      # none of them means ESI answered nothing. Counting it is what lets the
+      # cooldown stop us paying the full round trip on every subsequent batch,
+      # and what makes an ESI outage visible instead of silently reappearing as
+      # the exact bug this enrichment exists to fix.
+      {:ok, tickers} when is_map(tickers) and map_size(tickers) == 0 ->
+        note_corp_tickers_failure("resolved none of #{wanted} corporations")
+        emit_corp_tickers(duration, wanted, 0, :unresolved)
+        partitions
+
       {:ok, tickers} when is_map(tickers) ->
         reset_failures(@corp_tickers_failure_key)
         emit_corp_tickers(duration, wanted, map_size(tickers), :ok)
         merge_corp_tickers(partitions, tickers)
 
-      {:ok, _unexpected} ->
-        reset_failures(@corp_tickers_failure_key)
-        emit_corp_tickers(duration, wanted, 0, :ok)
+      # Only reachable through a misconfigured `:corp_tickers_enricher`. Treated
+      # as a failure rather than an empty result so it cannot masquerade as a
+      # healthy batch forever.
+      {:ok, unexpected} ->
+        note_corp_tickers_failure("enricher returned #{inspect(unexpected)}, expected a map")
+        emit_corp_tickers(duration, wanted, 0, :invalid)
         partitions
 
       {:exit, reason} ->

--- a/lib/wanderer_app/external_events/discord_dispatcher.ex
+++ b/lib/wanderer_app/external_events/discord_dispatcher.ex
@@ -246,6 +246,14 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
       # System-level filtering used to happen here for the whole batch. It now
       # lives in `Router.route/3`, because `excluded_systems` and `wh_only` have
       # per-kill carve-outs for kills involving this map's own pilots.
+      # Both enrichment steps block this singleton, and they run in sequence,
+      # so the worst-case hold on a batch is the SUM of their budgets — 3s with
+      # both at the default 1500ms, not 1500ms. That is accepted rather than
+      # shared: notable items is opt-in, so the default ceiling stays at one
+      # budget, and a deployment that opts in has already accepted paying for
+      # ESI killmail fetches on this path. Adding a third enrichment here, or
+      # turning notable items on by default, is the point at which the two
+      # should be bounded by one shared deadline instead.
       fresh
       |> partition(map_id, notification)
       |> enrich_notable_items()
@@ -310,7 +318,7 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
         emit_notable_items(0, 0, 0, :disabled)
         partitions
 
-      notable_items_cooldown_active?() ->
+      cooldown_active?(@notable_items_failure_key) ->
         emit_notable_items(0, 0, 0, :skipped_cooldown)
         partitions
 
@@ -350,12 +358,12 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
   defp handle_enrichment(partitions, candidates, result, duration) do
     case result do
       {:ok, by_kill} when is_map(by_kill) ->
-        reset_notable_items_failures()
+        reset_failures(@notable_items_failure_key)
         emit_notable_items(duration, length(candidates), item_count(by_kill), :ok)
         merge_notable_items(partitions, by_kill)
 
       {:ok, _unexpected} ->
-        reset_notable_items_failures()
+        reset_failures(@notable_items_failure_key)
         emit_notable_items(duration, length(candidates), 0, :ok)
         partitions
 
@@ -431,8 +439,6 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
   defp item_count(by_kill),
     do: by_kill |> Map.values() |> Enum.map(&length/1) |> Enum.sum()
 
-  defp notable_items_cooldown_active?, do: cooldown_active?(@notable_items_failure_key)
-
   defp cooldown_active?(key) do
     case Cachex.get(@enrichment_cache, key) do
       {:ok, count} when is_integer(count) -> count >= @enrichment_failure_threshold
@@ -464,8 +470,6 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
     # cost the batch.
     _ -> :ok
   end
-
-  defp reset_notable_items_failures, do: reset_failures(@notable_items_failure_key)
 
   defp reset_failures(key) do
     Cachex.del(@enrichment_cache, key)
@@ -589,7 +593,14 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
   # did resolve render correctly — so it neither trips the cooldown nor counts as
   # a failure. It is still worth a line: sustained partial resolution means an
   # ESI problem that no other signal here reports, since the outcome stays `:ok`.
-  defp log_partial_corp_tickers(wanted, resolved) when resolved < wanted do
+  #
+  # Only when the *majority* went unresolved, though. A corporation ESI does not
+  # know, or whose record carries no ticker, never resolves and is re-requested
+  # by every batch containing that kill, since nothing is ever written back to
+  # the payload. Warning on any shortfall would turn one such corporation into a
+  # permanent warning stream describing a fixed data condition rather than the
+  # degradation this is meant to catch.
+  defp log_partial_corp_tickers(wanted, resolved) when resolved * 2 < wanted do
     Logger.warning(
       "[Discord] corp tickers resolved #{resolved} of #{wanted} corporations; " <>
         "the rest post without their ticker"

--- a/lib/wanderer_app/external_events/discord_dispatcher.ex
+++ b/lib/wanderer_app/external_events/discord_dispatcher.ex
@@ -494,11 +494,22 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
   # a missing optional section. See `Discord.CorpTickers` for why the payload
   # cannot be trusted here.
   defp enrich_corp_tickers(partitions) do
-    if cooldown_active?(@corp_tickers_failure_key) do
-      emit_corp_tickers(0, 0, 0, :skipped_cooldown)
-      partitions
-    else
-      run_corp_tickers(partitions, render_candidates(partitions))
+    cond do
+      not Env.corp_tickers_enabled?() ->
+        emit_corp_tickers(0, 0, 0, :disabled)
+        partitions
+
+      cooldown_active?(@corp_tickers_failure_key) ->
+        emit_corp_tickers(0, 0, 0, :skipped_cooldown)
+        partitions
+
+      true ->
+        # `render_candidates/1` deliberately runs once per enrichment rather
+        # than once per batch. Hoisting it would mean handing the second
+        # enricher a list built before the first one ran, which is correct only
+        # while no enricher reads another's output — an unwritten invariant
+        # worth more than the microseconds a second pass over ten maps costs.
+        run_corp_tickers(partitions, render_candidates(partitions))
     end
   end
 
@@ -550,6 +561,7 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
 
       {:ok, tickers} when is_map(tickers) ->
         reset_failures(@corp_tickers_failure_key)
+        log_partial_corp_tickers(wanted, map_size(tickers))
         emit_corp_tickers(duration, wanted, map_size(tickers), :ok)
         merge_corp_tickers(partitions, tickers)
 
@@ -572,6 +584,19 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
         partitions
     end
   end
+
+  # A batch that resolves *some* of what it asked for is a success — the kills it
+  # did resolve render correctly — so it neither trips the cooldown nor counts as
+  # a failure. It is still worth a line: sustained partial resolution means an
+  # ESI problem that no other signal here reports, since the outcome stays `:ok`.
+  defp log_partial_corp_tickers(wanted, resolved) when resolved < wanted do
+    Logger.warning(
+      "[Discord] corp tickers resolved #{resolved} of #{wanted} corporations; " <>
+        "the rest post without their ticker"
+    )
+  end
+
+  defp log_partial_corp_tickers(_wanted, _resolved), do: :ok
 
   defp merge_corp_tickers(partitions, tickers) when map_size(tickers) == 0, do: partitions
 

--- a/lib/wanderer_app/external_events/discord_dispatcher.ex
+++ b/lib/wanderer_app/external_events/discord_dispatcher.ex
@@ -52,6 +52,7 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
   alias WandererApp.Env
 
   alias WandererApp.ExternalEvents.Discord.{
+    CorpTickers,
     EmbedFormatter,
     Matcher,
     NotableItems,
@@ -75,6 +76,11 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
   @notable_items_failure_key "discord-notable-items-failures"
   @notable_items_failure_threshold 3
   @notable_items_cooldown_ms :timer.seconds(60)
+
+  # Corporation-ticker enrichment shares that bookkeeping, under its own key so
+  # an ESI outage that stops ticker lookups does not also suppress notable items
+  # (or the reverse).
+  @corp_tickers_failure_key "discord-corp-tickers-failures"
 
   def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
 
@@ -242,6 +248,7 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
       fresh
       |> partition(map_id, notification)
       |> enrich_notable_items()
+      |> enrich_corp_tickers()
       |> Enum.each(fn {webhook, entries} ->
         deliver_partition(map_id, system_id, webhook, entries)
       end)
@@ -307,7 +314,7 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
         partitions
 
       true ->
-        run_enrichment(partitions, notable_items_candidates(partitions))
+        run_enrichment(partitions, render_candidates(partitions))
     end
   end
 
@@ -371,10 +378,11 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
   defp start_enrichment(candidates) do
     enricher = NotableItems.impl()
 
-    Task.Supervisor.async_nolink(
-      WandererApp.ExternalEvents.Discord.TaskSupervisor,
-      fn -> enricher.enrich(candidates) end
-    )
+    start_task(fn -> enricher.enrich(candidates) end)
+  end
+
+  defp start_task(fun) do
+    Task.Supervisor.async_nolink(WandererApp.ExternalEvents.Discord.TaskSupervisor, fun)
   rescue
     # The supervisor is not up. Fail open like every other enrichment failure.
     _ -> nil
@@ -385,7 +393,7 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
   # Only the kills that will actually be rendered, deduplicated. `Router.route/3`
   # returns exactly one destination per kill so a kill cannot currently appear in
   # two partitions; the dedup is cheap insurance against that property changing.
-  defp notable_items_candidates(partitions) do
+  defp render_candidates(partitions) do
     partitions
     |> Enum.flat_map(fn {_webhook, entries} ->
       entries
@@ -414,8 +422,10 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
   defp item_count(by_kill),
     do: by_kill |> Map.values() |> Enum.map(&length/1) |> Enum.sum()
 
-  defp notable_items_cooldown_active? do
-    case Cachex.get(@notable_items_cache, @notable_items_failure_key) do
+  defp notable_items_cooldown_active?, do: cooldown_active?(@notable_items_failure_key)
+
+  defp cooldown_active?(key) do
+    case Cachex.get(@notable_items_cache, key) do
       {:ok, count} when is_integer(count) -> count >= @notable_items_failure_threshold
       _ -> false
     end
@@ -424,28 +434,32 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
   # The counter carries the cooldown TTL, so reaching the threshold suppresses
   # enrichment until the entry expires and a fresh attempt is made.
   defp note_notable_items_failure(reason) do
+    note_failure(@notable_items_failure_key, fn count ->
+      "[Discord] notable items #{reason} (#{count} consecutive); " <>
+        "batch delivered without the section"
+    end)
+  end
+
+  defp note_failure(key, message_fun) do
     count =
-      case Cachex.get(@notable_items_cache, @notable_items_failure_key) do
+      case Cachex.get(@notable_items_cache, key) do
         {:ok, n} when is_integer(n) -> n + 1
         _ -> 1
       end
 
-    Cachex.put(@notable_items_cache, @notable_items_failure_key, count,
-      ttl: @notable_items_cooldown_ms
-    )
+    Cachex.put(@notable_items_cache, key, count, ttl: @notable_items_cooldown_ms)
 
-    Logger.warning(
-      "[Discord] notable items #{reason} (#{count} consecutive); " <>
-        "batch delivered without the section"
-    )
+    Logger.warning(message_fun.(count))
   rescue
     # The cache is not started in every context; a bookkeeping failure must not
     # cost the batch.
     _ -> :ok
   end
 
-  defp reset_notable_items_failures do
-    Cachex.del(@notable_items_cache, @notable_items_failure_key)
+  defp reset_notable_items_failures, do: reset_failures(@notable_items_failure_key)
+
+  defp reset_failures(key) do
+    Cachex.del(@notable_items_cache, key)
   rescue
     _ -> :ok
   end
@@ -454,6 +468,109 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcher do
     :telemetry.execute(
       [:wanderer_app, :discord, :notable_items],
       %{duration: duration, kill_count: kill_count, item_count: item_count},
+      %{outcome: outcome}
+    )
+  end
+
+  # -- corporation tickers ---------------------------------------------------
+  #
+  # Same placement, budget and fail-open rules as notable items above: after
+  # routing and the per-destination cap, blocking for at most
+  # `Env.corp_tickers_timeout_ms/0`, and every failure path returns the
+  # partitions untouched so the batch still posts.
+  #
+  # Unlike notable items this is NOT opt-in. The embed already claims to show
+  # corporations; a payload that arrives without a ticker silently deletes the
+  # whole parenthetical, which reads as "this pilot has no corp" rather than as
+  # a missing optional section. See `Discord.CorpTickers` for why the payload
+  # cannot be trusted here.
+  defp enrich_corp_tickers(partitions) do
+    if cooldown_active?(@corp_tickers_failure_key) do
+      emit_corp_tickers(0, 0, 0, :skipped_cooldown)
+      partitions
+    else
+      run_corp_tickers(partitions, render_candidates(partitions))
+    end
+  end
+
+  defp run_corp_tickers(partitions, []) do
+    emit_corp_tickers(0, 0, 0, :ok)
+    partitions
+  end
+
+  defp run_corp_tickers(partitions, candidates) do
+    # Counted here rather than inside the task so the telemetry still reports
+    # how much work was owed when the task times out or crashes.
+    wanted = length(CorpTickers.missing_corp_ids(candidates))
+
+    if wanted == 0 do
+      emit_corp_tickers(0, 0, 0, :ok)
+      partitions
+    else
+      started = System.monotonic_time()
+      enricher = CorpTickers.impl()
+
+      case start_task(fn -> enricher.enrich(candidates) end) do
+        nil ->
+          emit_corp_tickers(0, wanted, 0, :unavailable)
+          partitions
+
+        task ->
+          result =
+            Task.yield(task, Env.corp_tickers_timeout_ms()) ||
+              Task.shutdown(task, :brutal_kill)
+
+          handle_corp_tickers(partitions, wanted, result, System.monotonic_time() - started)
+      end
+    end
+  end
+
+  defp handle_corp_tickers(partitions, wanted, result, duration) do
+    case result do
+      {:ok, tickers} when is_map(tickers) ->
+        reset_failures(@corp_tickers_failure_key)
+        emit_corp_tickers(duration, wanted, map_size(tickers), :ok)
+        merge_corp_tickers(partitions, tickers)
+
+      {:ok, _unexpected} ->
+        reset_failures(@corp_tickers_failure_key)
+        emit_corp_tickers(duration, wanted, 0, :ok)
+        partitions
+
+      {:exit, reason} ->
+        note_corp_tickers_failure("enricher crashed: #{inspect(reason)}")
+        emit_corp_tickers(duration, wanted, 0, :crash)
+        partitions
+
+      _ ->
+        note_corp_tickers_failure("enricher timed out")
+        emit_corp_tickers(duration, wanted, 0, :timeout)
+        partitions
+    end
+  end
+
+  defp merge_corp_tickers(partitions, tickers) when map_size(tickers) == 0, do: partitions
+
+  defp merge_corp_tickers(partitions, tickers) do
+    Map.new(partitions, fn {webhook, entries} ->
+      {webhook,
+       Enum.map(entries, fn {kill, verdict} ->
+         {CorpTickers.apply_tickers(kill, tickers), verdict}
+       end)}
+    end)
+  end
+
+  defp note_corp_tickers_failure(reason) do
+    note_failure(@corp_tickers_failure_key, fn count ->
+      "[Discord] corp tickers #{reason} (#{count} consecutive); " <>
+        "batch delivered without corporation tickers"
+    end)
+  end
+
+  defp emit_corp_tickers(duration, corp_count, resolved_count, outcome) do
+    :telemetry.execute(
+      [:wanderer_app, :discord, :corp_tickers],
+      %{duration: duration, corp_count: corp_count, resolved_count: resolved_count},
       %{outcome: outcome}
     )
   end

--- a/test/support/esi_offline_stub.ex
+++ b/test/support/esi_offline_stub.ex
@@ -1,0 +1,23 @@
+defmodule WandererApp.Esi.OfflineStub do
+  @moduledoc """
+  Default ESI seam for the test suite: answers every lookup with an error.
+
+  Set as `:esi_client` in `config/test.exs` so no test reaches the real ESI over
+  the network by accident. The seam is read by the Discord enrichers
+  (`Discord.NotableItems`, `Discord.CorpTickers`), both of which fail open, so
+  an offline answer simply means "not enriched" — which is what an unconfigured
+  test wants.
+
+  Tests that care about enrichment override `:esi_client` with
+  `WandererApp.Esi.Mock` and script the calls they expect.
+
+  Deliberately silent: the enrichers only log when a lookup *raises*, so the
+  default path here adds no noise to unrelated tests.
+  """
+
+  def get_character_info(_id, _opts \\ []), do: {:error, :esi_disabled_in_test}
+  def get_corporation_info(_id, _opts \\ []), do: {:error, :esi_disabled_in_test}
+  def get_alliance_info(_id, _opts \\ []), do: {:error, :esi_disabled_in_test}
+  def get_killmail(_id, _hash, _opts \\ []), do: {:error, :esi_disabled_in_test}
+  def get_type_info(_id, _opts \\ []), do: {:error, :esi_disabled_in_test}
+end

--- a/test/unit/external_events/discord/corp_tickers_test.exs
+++ b/test/unit/external_events/discord/corp_tickers_test.exs
@@ -1,0 +1,175 @@
+defmodule WandererApp.ExternalEvents.Discord.CorpTickersTest do
+  # `async: false`: the ESI seam is application env and the lookups run in
+  # `Task.async_stream` children, so Mox has to be in global mode.
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias WandererApp.ExternalEvents.Discord.CorpTickers
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  setup do
+    # Restored, not deleted, on exit: `config/test.exs` points this seam at
+    # `Esi.OfflineStub`, and deleting it would leave later tests pointed at real
+    # ESI.
+    original_esi = Application.get_env(:wanderer_app, :esi_client)
+    Application.put_env(:wanderer_app, :esi_client, WandererApp.Esi.Mock)
+    on_exit(fn -> Application.put_env(:wanderer_app, :esi_client, original_esi) end)
+    :ok
+  end
+
+  # Scripts `%{corp_id => ticker | :error}` keyed by the id as the module will
+  # pass it, i.e. stringified.
+  defp stub_corps(corps) do
+    stub(WandererApp.Esi.Mock, :get_corporation_info, fn corp_id ->
+      case Map.fetch(corps, to_string(corp_id)) do
+        {:ok, :error} -> {:error, :not_found}
+        {:ok, ticker} -> {:ok, %{"name" => "Corp #{corp_id}", "ticker" => ticker}}
+        :error -> {:error, :not_found}
+      end
+    end)
+  end
+
+  defp kill(fields), do: Map.merge(%{"killmail_id" => 1}, fields)
+
+  describe "missing_corp_ids/1" do
+    test "returns the ids of both rendered fields when the tickers are absent" do
+      kills = [kill(%{"victim_corp_id" => 98_721_938, "final_blow_corp_id" => 98_832_599})]
+
+      assert CorpTickers.missing_corp_ids(kills) == ["98721938", "98832599"]
+    end
+
+    test "skips fields whose ticker the payload already carried" do
+      kills = [
+        kill(%{
+          "victim_corp_id" => 98_721_938,
+          "victim_corp_ticker" => ".STEX",
+          "final_blow_corp_id" => 98_832_599
+        })
+      ]
+
+      assert CorpTickers.missing_corp_ids(kills) == ["98832599"]
+    end
+
+    test "treats a blank ticker as missing" do
+      kills = [kill(%{"victim_corp_id" => 1, "victim_corp_ticker" => "   "})]
+
+      assert CorpTickers.missing_corp_ids(kills) == ["1"]
+    end
+
+    test "ignores fields with no corporation id — there is nothing to look up" do
+      assert CorpTickers.missing_corp_ids([kill(%{"victim_char_name" => "Pilot"})]) == []
+    end
+
+    test "deduplicates a corporation appearing on several kills and in both roles" do
+      kills = [
+        kill(%{"victim_corp_id" => 42, "final_blow_corp_id" => 42}),
+        kill(%{"victim_corp_id" => "42"})
+      ]
+
+      assert CorpTickers.missing_corp_ids(kills) == ["42"]
+    end
+
+    test "does not resolve top damage — the embed never renders its corporation" do
+      assert CorpTickers.missing_corp_ids([kill(%{"top_damage_corp_id" => 42})]) == []
+    end
+  end
+
+  describe "enrich/1" do
+    test "returns a ticker per resolvable corporation" do
+      stub_corps(%{"1" => "AAA", "2" => "BBB"})
+
+      kills = [kill(%{"victim_corp_id" => 1, "final_blow_corp_id" => 2})]
+
+      assert CorpTickers.enrich(kills) == %{"1" => "AAA", "2" => "BBB"}
+    end
+
+    test "makes no ESI call when nothing is missing" do
+      # No stub at all: an unexpected call fails the test rather than reaching
+      # the network.
+      kills = [kill(%{"victim_corp_id" => 1, "victim_corp_ticker" => "AAA"})]
+
+      assert CorpTickers.enrich(kills) == %{}
+    end
+
+    test "returns an empty map for an empty batch" do
+      assert CorpTickers.enrich([]) == %{}
+    end
+
+    test "looks a shared corporation up once" do
+      test_pid = self()
+
+      stub(WandererApp.Esi.Mock, :get_corporation_info, fn corp_id ->
+        send(test_pid, {:esi_called, corp_id})
+        {:ok, %{"ticker" => "AAA"}}
+      end)
+
+      kills = [
+        kill(%{"killmail_id" => 1, "victim_corp_id" => 42}),
+        kill(%{"killmail_id" => 2, "victim_corp_id" => 42, "final_blow_corp_id" => 42})
+      ]
+
+      assert CorpTickers.enrich(kills) == %{"42" => "AAA"}
+      assert_received {:esi_called, "42"}
+      refute_received {:esi_called, _}
+    end
+
+    test "omits a corporation ESI will not resolve, keeping the rest" do
+      stub_corps(%{"1" => "AAA", "2" => :error})
+
+      kills = [kill(%{"victim_corp_id" => 1, "final_blow_corp_id" => 2})]
+
+      assert CorpTickers.enrich(kills) == %{"1" => "AAA"}
+    end
+
+    test "omits a corporation whose record carries no usable ticker" do
+      stub(WandererApp.Esi.Mock, :get_corporation_info, fn _corp_id ->
+        {:ok, %{"name" => "Ticker-less Corp"}}
+      end)
+
+      assert CorpTickers.enrich([kill(%{"victim_corp_id" => 1})]) == %{}
+    end
+
+    test "survives a raising lookup — one bad corporation must not cost the batch" do
+      stub(WandererApp.Esi.Mock, :get_corporation_info, fn corp_id ->
+        if to_string(corp_id) == "2", do: raise("esi boom")
+        {:ok, %{"ticker" => "AAA"}}
+      end)
+
+      kills = [kill(%{"victim_corp_id" => 1, "final_blow_corp_id" => 2})]
+
+      assert CorpTickers.enrich(kills) == %{"1" => "AAA"}
+    end
+  end
+
+  describe "apply_tickers/2" do
+    test "fills both rendered fields" do
+      kill = kill(%{"victim_corp_id" => 1, "final_blow_corp_id" => 2})
+
+      assert %{"victim_corp_ticker" => "AAA", "final_blow_corp_ticker" => "BBB"} =
+               CorpTickers.apply_tickers(kill, %{"1" => "AAA", "2" => "BBB"})
+    end
+
+    test "never overwrites a ticker the payload carried" do
+      kill = kill(%{"victim_corp_id" => 1, "victim_corp_ticker" => "PAYLOAD"})
+
+      assert %{"victim_corp_ticker" => "PAYLOAD"} =
+               CorpTickers.apply_tickers(kill, %{"1" => "ESI"})
+    end
+
+    test "matches a string id against the same corporation as an integer one" do
+      kill = kill(%{"victim_corp_id" => "1"})
+
+      assert %{"victim_corp_ticker" => "AAA"} = CorpTickers.apply_tickers(kill, %{"1" => "AAA"})
+    end
+
+    test "leaves the kill untouched when the corporation did not resolve" do
+      kill = kill(%{"victim_corp_id" => 1})
+
+      assert CorpTickers.apply_tickers(kill, %{"2" => "BBB"}) == kill
+      assert CorpTickers.apply_tickers(kill, %{}) == kill
+    end
+  end
+end

--- a/test/unit/external_events/discord/corp_tickers_test.exs
+++ b/test/unit/external_events/discord/corp_tickers_test.exs
@@ -34,6 +34,18 @@ defmodule WandererApp.ExternalEvents.Discord.CorpTickersTest do
 
   defp kill(fields), do: Map.merge(%{"killmail_id" => 1}, fields)
 
+  defp corp_tickers_timeout(ms) do
+    original = Application.get_env(:wanderer_app, :external_events, [])
+
+    Application.put_env(
+      :wanderer_app,
+      :external_events,
+      Keyword.put(original, :corp_tickers_timeout_ms, ms)
+    )
+
+    on_exit(fn -> Application.put_env(:wanderer_app, :external_events, original) end)
+  end
+
   describe "missing_corp_ids/1" do
     test "returns the ids of both rendered fields when the tickers are absent" do
       kills = [kill(%{"victim_corp_id" => 98_721_938, "final_blow_corp_id" => 98_832_599})]
@@ -130,6 +142,22 @@ defmodule WandererApp.ExternalEvents.Discord.CorpTickersTest do
       end)
 
       assert CorpTickers.enrich([kill(%{"victim_corp_id" => 1})]) == %{}
+    end
+
+    test "keeps the corporations that resolved when one lookup outlives its slice" do
+      # The per-element timeout is half the enrichment budget precisely so this
+      # can happen: the slow corporation is dropped and the stream still returns
+      # the fast one, rather than the dispatcher killing the whole task.
+      corp_tickers_timeout(200)
+
+      stub(WandererApp.Esi.Mock, :get_corporation_info, fn corp_id ->
+        if to_string(corp_id) == "2", do: Process.sleep(180)
+        {:ok, %{"ticker" => "AAA"}}
+      end)
+
+      kills = [kill(%{"victim_corp_id" => 1, "final_blow_corp_id" => 2})]
+
+      assert CorpTickers.enrich(kills) == %{"1" => "AAA"}
     end
 
     test "survives a raising lookup — one bad corporation must not cost the batch" do

--- a/test/unit/external_events/discord/notable_items_test.exs
+++ b/test/unit/external_events/discord/notable_items_test.exs
@@ -19,11 +19,15 @@ defmodule WandererApp.ExternalEvents.Discord.NotableItemsTest do
     Cachex.clear(:api_cache)
 
     Application.put_env(:wanderer_app, :triff_http_client, HttpStub)
+    # Restored, not deleted, on exit: `config/test.exs` points this seam at
+    # `Esi.OfflineStub`, and deleting it would leave later tests pointed at real
+    # ESI.
+    original_esi = Application.get_env(:wanderer_app, :esi_client)
     Application.put_env(:wanderer_app, :esi_client, WandererApp.Esi.Mock)
 
     on_exit(fn ->
       Application.delete_env(:wanderer_app, :triff_http_client)
-      Application.delete_env(:wanderer_app, :esi_client)
+      Application.put_env(:wanderer_app, :esi_client, original_esi)
       Cachex.clear(:api_cache)
     end)
 

--- a/test/unit/external_events/discord_dispatcher_test.exs
+++ b/test/unit/external_events/discord_dispatcher_test.exs
@@ -1507,6 +1507,45 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcherTest do
       assert length(wait_for_requests(4)) == 4
     end
 
+    test "warns only when most of the batch went unresolved", %{map: map, system: w} do
+      # Three corporations owed across the batch. One permanently ticker-less
+      # corporation among them must not warn — otherwise every batch carrying
+      # that kill logs a fixed data condition as if it were ESI degradation.
+      batch = [
+        corp_kill(9_770,
+          victim_corp_id: 98_721_938,
+          final_blow_corp_id: 98_832_599,
+          extra: %{"final_blow_char_name" => "MiniNinja37"}
+        ),
+        corp_kill(9_771, victim_corp_id: 98_900_001)
+      ]
+
+      returns_tickers(%{"98721938" => ".STEX", "98832599" => "SKRPR"})
+      quiet = capture_log(fn -> dispatch(map, batch) end)
+      refute quiet =~ "corp tickers resolved"
+
+      # Two of three missing is degradation, and does warn.
+      returns_tickers(%{"98721938" => ".STEX"})
+
+      noisy =
+        capture_log(fn ->
+          dispatch(map, [
+            corp_kill(9_772,
+              victim_corp_id: 98_721_938,
+              final_blow_corp_id: 98_832_599,
+              extra: %{"final_blow_char_name" => "MiniNinja37"}
+            ),
+            corp_kill(9_773, victim_corp_id: 98_900_001)
+          ])
+        end)
+
+      assert noisy =~ "corp tickers resolved 1 of 3 corporations"
+
+      # One message per dispatched batch — both kills render into it.
+      settle(w.id)
+      assert length(wait_for_requests(2)) == 2
+    end
+
     test "does not resolve at all when the incident switch is off", %{map: map, system: w} do
       original = Application.get_env(:wanderer_app, :external_events, [])
 

--- a/test/unit/external_events/discord_dispatcher_test.exs
+++ b/test/unit/external_events/discord_dispatcher_test.exs
@@ -1507,6 +1507,27 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcherTest do
       assert length(wait_for_requests(4)) == 4
     end
 
+    test "does not resolve at all when the incident switch is off", %{map: map, system: w} do
+      original = Application.get_env(:wanderer_app, :external_events, [])
+
+      Application.put_env(
+        :wanderer_app,
+        :external_events,
+        Keyword.put(original, :corp_tickers_enabled, false)
+      )
+
+      on_exit(fn -> Application.put_env(:wanderer_app, :external_events, original) end)
+
+      returns_tickers(%{"98721938" => ".STEX"})
+
+      dispatch(map, [corp_kill(9_760, victim_corp_id: 98_721_938)])
+      refute_received {:tickers_called, _}
+
+      settle(w.id)
+      assert [{_url, body}] = wait_for_requests(1)
+      refute description(body) =~ "zkillboard.com/corporation"
+    end
+
     test "counts a batch that resolved nothing as a failure, not a healthy no-op",
          %{map: map, system: w} do
       # Every id was asked for because its ticker was missing, so resolving none

--- a/test/unit/external_events/discord_dispatcher_test.exs
+++ b/test/unit/external_events/discord_dispatcher_test.exs
@@ -1507,6 +1507,31 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcherTest do
       assert length(wait_for_requests(4)) == 4
     end
 
+    test "counts a batch that resolved nothing as a failure, not a healthy no-op",
+         %{map: map, system: w} do
+      # Every id was asked for because its ticker was missing, so resolving none
+      # of them means ESI answered nothing — an outage wearing the shape of the
+      # original bug. It has to trip the cooldown rather than reset it, or we
+      # keep paying the round trip on every batch for the length of the outage.
+      returns_tickers(%{})
+
+      log =
+        capture_log(fn ->
+          for id <- 1..3 do
+            dispatch(map, [corp_kill(9_740 + id, victim_corp_id: 98_721_938)])
+            assert_received {:tickers_called, _}
+          end
+        end)
+
+      assert log =~ "resolved none of 1 corporations"
+
+      dispatch(map, [corp_kill(9_750, victim_corp_id: 98_721_938)])
+      refute_received {:tickers_called, _}
+
+      settle(w.id)
+      assert length(wait_for_requests(4)) == 4
+    end
+
     test "emits telemetry carrying how much was owed and resolved",
          %{map: map, system: w} do
       handler = "corp-tickers-test-#{System.unique_integer([:positive])}"

--- a/test/unit/external_events/discord_dispatcher_test.exs
+++ b/test/unit/external_events/discord_dispatcher_test.exs
@@ -21,6 +21,24 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcherTest.Enricher do
   end
 end
 
+defmodule WandererApp.ExternalEvents.DiscordDispatcherTest.TickerEnricher do
+  @behaviour WandererApp.ExternalEvents.Discord.CorpTickers
+
+  @impl true
+  def enrich(kills) do
+    case Process.whereis(:corp_tickers_observer) do
+      nil -> :ok
+      pid -> send(pid, {:tickers_called, kills})
+    end
+
+    case Application.get_env(:wanderer_app, :test_corp_tickers_mode, %{}) do
+      :timeout -> Process.sleep(:infinity)
+      :crash -> raise "ticker enricher boom"
+      tickers when is_map(tickers) -> tickers
+    end
+  end
+end
+
 defmodule WandererApp.ExternalEvents.DiscordDispatcherTest do
   # `async: false` is mandatory: `HttpStub` keeps its state in a single named
   # Agent, and this file also mutates application env.
@@ -37,12 +55,14 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcherTest do
   }
 
   alias WandererApp.ExternalEvents.DiscordDispatcherTest.Enricher
+  alias WandererApp.ExternalEvents.DiscordDispatcherTest.TickerEnricher
   alias WandererAppWeb.Factory
 
   # Must match `DiscordDispatcher`'s own key: the cooldown tests clear it
   # between runs, and a private counter left behind would silently disable
   # enrichment for every later test in this file.
   @failure_key "discord-notable-items-failures"
+  @ticker_failure_key "discord-corp-tickers-failures"
 
   # A real wormhole system id (J-space) and a real known-space id (Jita).
   @wh_system 31_000_005
@@ -1376,6 +1396,174 @@ defmodule WandererApp.ExternalEvents.DiscordDispatcherTest do
 
       settle(w.id)
     end
+  end
+
+  describe "corporation tickers" do
+    setup do
+      Process.register(self(), :corp_tickers_observer)
+      Cachex.del(:api_cache, @ticker_failure_key)
+
+      Application.put_env(:wanderer_app, :corp_tickers_enricher, TickerEnricher)
+      Application.put_env(:wanderer_app, :test_corp_tickers_mode, %{})
+
+      on_exit(fn ->
+        Application.delete_env(:wanderer_app, :corp_tickers_enricher)
+        Application.delete_env(:wanderer_app, :test_corp_tickers_mode)
+        Cachex.del(:api_cache, @ticker_failure_key)
+      end)
+
+      :ok
+    end
+
+    test "renders the corporation a payload arrived without", %{map: map, system: w} do
+      # The reported bug: the ticker is absent, so the embed used to drop the
+      # whole parenthetical and read as though the pilot had no corporation.
+      returns_tickers(%{"98721938" => ".STEX"})
+
+      dispatch(map, [corp_kill(9_701, victim_corp_id: 98_721_938)])
+      settle(w.id)
+
+      assert [{_url, body}] = wait_for_requests(1)
+      assert description(body) =~ "(**[.STEX](https://zkillboard.com/corporation/98721938/)**)"
+    end
+
+    test "resolves the final blow's corporation too", %{map: map, system: w} do
+      returns_tickers(%{"98832599" => "SKRPR"})
+
+      kill =
+        corp_kill(9_702,
+          final_blow_corp_id: 98_832_599,
+          extra: %{"final_blow_char_name" => "MiniNinja37"}
+        )
+
+      dispatch(map, [kill])
+      settle(w.id)
+
+      assert [{_url, body}] = wait_for_requests(1)
+      assert description(body) =~ "to **MiniNinja37** (**[SKRPR]"
+    end
+
+    test "does not run at all when the payload already carried the tickers",
+         %{map: map, system: w} do
+      kill =
+        corp_kill(9_703,
+          victim_corp_id: 98_721_938,
+          extra: %{"victim_corp_ticker" => "PAYLOAD"}
+        )
+
+      dispatch(map, [kill])
+      settle(w.id)
+
+      refute_received {:tickers_called, _}
+      assert [{_url, body}] = wait_for_requests(1)
+      assert description(body) =~ "(**[PAYLOAD]"
+    end
+
+    test "does not run when no kill carries a corporation id", %{map: map, system: w} do
+      dispatch(map, [fresh_kill(9_704)])
+      settle(w.id)
+
+      refute_received {:tickers_called, _}
+      assert [{_url, _body}] = wait_for_requests(1)
+    end
+
+    test "delivers without the corporation when the enricher times out",
+         %{map: map, system: w} do
+      corp_tickers_timeout(50)
+      returns_tickers(:timeout)
+
+      dispatch(map, [corp_kill(9_705, victim_corp_id: 98_721_938)])
+      settle(w.id)
+
+      assert [{_url, body}] = wait_for_requests(1)
+      assert description(body) =~ "lost their **Rifter**"
+      refute description(body) =~ "zkillboard.com/corporation"
+    end
+
+    test "delivers, and survives, when the enricher crashes", %{map: map} do
+      returns_tickers(:crash)
+
+      capture_log(fn -> dispatch(map, [corp_kill(9_706, victim_corp_id: 98_721_938)]) end)
+
+      assert Process.alive?(Process.whereis(DiscordDispatcher))
+      assert [{_url, body}] = wait_for_requests(1)
+      refute description(body) =~ "zkillboard.com/corporation"
+    end
+
+    test "stops resolving after repeated failures", %{map: map, system: w} do
+      returns_tickers(:crash)
+
+      capture_log(fn ->
+        for id <- 1..3 do
+          dispatch(map, [corp_kill(9_710 + id, victim_corp_id: 98_721_938)])
+          assert_received {:tickers_called, _}
+        end
+      end)
+
+      dispatch(map, [corp_kill(9_720, victim_corp_id: 98_721_938)])
+      refute_received {:tickers_called, _}
+
+      settle(w.id)
+      assert length(wait_for_requests(4)) == 4
+    end
+
+    test "emits telemetry carrying how much was owed and resolved",
+         %{map: map, system: w} do
+      handler = "corp-tickers-test-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler,
+        [:wanderer_app, :discord, :corp_tickers],
+        fn _event, measurements, metadata, _ ->
+          send(test_pid, {:telemetry, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      returns_tickers(%{"98721938" => ".STEX"})
+      dispatch(map, [corp_kill(9_730, victim_corp_id: 98_721_938)])
+
+      assert_received {:telemetry, measurements, %{outcome: :ok}}
+      assert measurements.corp_count == 1
+      assert measurements.resolved_count == 1
+
+      settle(w.id)
+    end
+  end
+
+  # -- corporation ticker helpers ---------------------------------------------
+
+  defp returns_tickers(mode),
+    do: Application.put_env(:wanderer_app, :test_corp_tickers_mode, mode)
+
+  defp corp_tickers_timeout(ms) do
+    original = Application.get_env(:wanderer_app, :external_events, [])
+
+    Application.put_env(
+      :wanderer_app,
+      :external_events,
+      Keyword.put(original, :corp_tickers_timeout_ms, ms)
+    )
+
+    on_exit(fn -> Application.put_env(:wanderer_app, :external_events, original) end)
+  end
+
+  # A kill carrying corporation ids but no tickers — the shape that reaches the
+  # dispatcher when upstream has not enriched the killmail.
+  defp corp_kill(id, opts) do
+    extra = Keyword.get(opts, :extra, %{})
+
+    [victim_corp_id: "victim_corp_id", final_blow_corp_id: "final_blow_corp_id"]
+    |> Enum.reduce(fresh_kill(id), fn {opt, key}, kill ->
+      case Keyword.get(opts, opt) do
+        nil -> kill
+        corp_id -> Map.put(kill, key, corp_id)
+      end
+    end)
+    |> Map.merge(extra)
   end
 
   # -- notable items helpers --------------------------------------------------


### PR DESCRIPTION
## The bug

Discord kill embeds were posting without the corporation ticker after each pilot name:

> Xan Sav lost their Hyperion to MiniNinja37, top damage by Dibs 3D, and 7 others.

instead of `Xan Sav (**.STEX**) lost their Hyperion to MiniNinja37 (**SKRPR**)`. Both victim and final blow were affected.

## Root cause

`EmbedFormatter.corporation_link/2` drops the whole parenthetical when the ticker is nil, and nothing in wanderer's kills path ever resolved a ticker from a corporation id — it only rendered what the upstream payload carried. Verified on prod: the *cached* copy of killmail 137512514 does carry `"victim_corp_ticker" => ".STEX"`, and the deployed formatter renders it correctly when handed that map. So the map that reached the dispatcher at post time did not yet have the key; the cached copy is a later, enriched arrival.

wanderer-notifier never had this bug because it always resolved the ticker from `corporation_id` via cache → ESI. That fallback is what was missing here.

## The fix

A `Discord.CorpTickers` enricher, mirroring the `NotableItems` precedent this repo established in #120:

- **Discord path only.** Nothing in ingest, the kills widget, or the cache changes.
- Collects corp ids whose ticker is missing, **only for kills that will actually be rendered** (after routing and after the per-destination cap), deduplicated.
- Resolves them concurrently (8 at a time) under the existing `Discord.TaskSupervisor`, bounded by `WANDERER_CORP_TICKERS_TIMEOUT_MS` (default 1500).
- **Fails open.** Any failure omits the ticker; the kill still posts.
- Derives from `victim_corp_id` / `final_blow_corp_id`, which come off the raw ESI killmail — so it is correct regardless of which copy of the payload arrives first.

The payload's *tickers* can't be trusted as a signal (every wanderer-kills serializer rejects nil fields, so "not yet enriched" and "no ticker" are indistinguishable), but the payload's *ids* can. That asymmetry is why this resolves from ids and never overwrites a ticker the payload did carry.

### Cost

Zero on batches whose payload already carried its tickers — `missing_corp_ids/1` returns `[]` and no task is started. When work is owed, ESI corp info is cached for an hour, so a busy map converges to cache reads.

### Failure handling

- 3 consecutive failures → enrichment skipped for 60s (its own cooldown key, so an ESI outage here doesn't also suppress notable items).
- A batch that resolves **none** of what it asked for counts as a failure and logs — unlike notable items, where an empty result legitimately means "no notable loot", every id here was requested *because* a ticker was missing.
- A batch that resolves **some** logs a line but is treated as success; the kills that resolved render correctly.
- `WANDERER_CORP_TICKERS_ENABLED` (default `true`) is an incident switch for stopping the lookups without a deploy.

## Test suite side effect worth a look

`config/test.exs` now points `:esi_client` at a new `WandererApp.Esi.OfflineStub` that errors on everything, so no test reaches real ESI now that ticker enrichment is on by default. Confirmed the seam is read only by the two Discord enrichers — every other ESI caller uses `WandererApp.Esi` directly, so this has no effect elsewhere.

## Verification

- `mix test` — 1440 tests, 0 failures, 64 excluded, 22 skipped
- `mix credo --strict` on all changed lib files — no issues
- `mix format --check-formatted` — clean
- Dialyzer not run

## Where to focus review

1. `enrich_corp_tickers/1` is **not** gated behind an opt-in flag the way notable items is (`discord_dispatcher.ex:487`). Deliberate: an off-by-default flag here just means "keep the bug". The switch exists for incidents only.
2. The "resolved none of N" branch — whether tripping the cooldown there is the behaviour you want during an ESI outage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord kill notifications now enrich missing victim and final-blow corporation tickers.
  * Existing tickers are preserved, while unresolved lookups are omitted without delaying notification delivery.
  * Ticker lookups are cached and performed within a configurable timeout.
  * Corporation ticker enrichment can be enabled or disabled through configuration.

* **Bug Fixes**
  * Improved resilience when external ticker lookups fail, time out, return invalid data, or become unavailable.

* **Documentation**
  * Added configuration guidance and documented corporation ticker enrichment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->