### PR TITLE
fix(routes): stop one slow static lookup from killing the whole route request

### DIFF
--- a/lib/wanderer_app/cached_info.ex
+++ b/lib/wanderer_app/cached_info.ex
@@ -175,15 +175,30 @@ defmodule WandererApp.CachedInfo do
 
         case WandererApp.Api.MapSolarSystem.read() do
           {:ok, systems} ->
-            Enum.each(systems, fn system ->
-              Cachex.put(
-                :system_static_info_cache,
-                system.solar_system_id,
-                Map.take(system, @system_static_info_attrs)
-              )
-            end)
+            # A discarded write is worse here than anywhere else: the caller
+            # re-reads the key straight after this returns, so a silently failed
+            # put surfaces as `{:error, :not_found}` — "this system does not
+            # exist" — for a system that does. Halt on the first failure rather
+            # than grinding through thousands more writes into a cache that has
+            # already told us it is not accepting them.
+            Enum.reduce_while(systems, {:ignore, :ok}, fn system, acc ->
+              case Cachex.put(
+                     :system_static_info_cache,
+                     system.solar_system_id,
+                     Map.take(system, @system_static_info_attrs)
+                   ) do
+                {:ok, true} ->
+                  {:cont, acc}
 
-            {:ignore, :ok}
+                error ->
+                  Logger.error(
+                    "Failed to cache static info for solar system " <>
+                      "#{system.solar_system_id}: #{inspect(error)}"
+                  )
+
+                  {:halt, {:ignore, {:error, :cache_error}}}
+              end
+            end)
 
           {:error, reason} ->
             Logger.error("Failed to read solar systems from API: #{inspect(reason)}")

--- a/lib/wanderer_app/cached_info.ex
+++ b/lib/wanderer_app/cached_info.ex
@@ -3,6 +3,32 @@ defmodule WandererApp.CachedInfo do
 
   alias WandererAppWeb.Helpers.APIUtils
 
+  # Courier lock key for the full-table warm-up in `warm_system_static_info_cache/0`.
+  # It is never committed to the cache (the fallback returns `{:ignore, _}`), so
+  # it cannot collide with the integer solar system ids stored alongside it.
+  @static_info_warm_key :__system_static_info_warm__
+
+  @system_static_info_attrs [
+    :solar_system_id,
+    :region_id,
+    :constellation_id,
+    :solar_system_name,
+    :solar_system_name_lc,
+    :constellation_name,
+    :region_name,
+    :system_class,
+    :security,
+    :type_description,
+    :class_title,
+    :is_shattered,
+    :effect_name,
+    :effect_power,
+    :statics,
+    :wandering,
+    :triglavian_invasion_status,
+    :sun_type_id
+  ]
+
   def run(_arg) do
     :ok = cache_trig_systems()
   end
@@ -100,44 +126,15 @@ defmodule WandererApp.CachedInfo do
 
     case Cachex.get(:system_static_info_cache, solar_system_id) do
       {:ok, nil} ->
-        case WandererApp.Api.MapSolarSystem.read() do
-          {:ok, systems} ->
-            systems
-            |> Enum.each(fn system ->
-              Cachex.put(
-                :system_static_info_cache,
-                system.solar_system_id,
-                Map.take(system, [
-                  :solar_system_id,
-                  :region_id,
-                  :constellation_id,
-                  :solar_system_name,
-                  :solar_system_name_lc,
-                  :constellation_name,
-                  :region_name,
-                  :system_class,
-                  :security,
-                  :type_description,
-                  :class_title,
-                  :is_shattered,
-                  :effect_name,
-                  :effect_power,
-                  :statics,
-                  :wandering,
-                  :triglavian_invasion_status,
-                  :sun_type_id
-                ])
-              )
-            end)
-
+        case warm_system_static_info_cache() do
+          :ok ->
             case Cachex.get(:system_static_info_cache, solar_system_id) do
               {:ok, nil} -> {:error, :not_found}
               result -> result
             end
 
           {:error, reason} ->
-            Logger.error("Failed to read solar systems from API: #{inspect(reason)}")
-            {:error, :api_error}
+            {:error, reason}
         end
 
       {:ok, system_static_info} ->
@@ -145,6 +142,63 @@ defmodule WandererApp.CachedInfo do
 
       {:error, reason} ->
         Logger.error("Failed to get system static info from cache: #{inspect(reason)}")
+        {:error, :cache_error}
+    end
+  end
+
+  # A single cache miss repopulates the WHOLE table, so N concurrent misses used
+  # to run N full `MapSolarSystem.read/0` scans plus N row-by-row rewrites of the
+  # same data. That is the normal case, not an edge case: `:system_static_info_cache`
+  # has a 4h TTL (application.ex) and route hydration fans out over every system
+  # in a route at `schedulers_online() * 4` concurrency, so every restart and
+  # every TTL rollover produced a stampede — and each of those scans is what made
+  # a single lookup slow enough to blow a `Task.async_stream` timeout.
+  #
+  # `Cachex.fetch/4` routes the fallback through Cachex's Courier, which runs it
+  # at most once at a time per key and hands every concurrent caller the same
+  # result. Returning `{:ignore, _}` means the marker key is never written, so
+  # sequential behaviour is unchanged: a later miss still triggers a fresh scan
+  # and still picks up a newly inserted system immediately. Only *simultaneous*
+  # scans are collapsed.
+  defp warm_system_static_info_cache do
+    # Cachex runs the fallback in a Courier-owned process, not the caller's, and
+    # that process starts with an empty dictionary. `$callers` has to be carried
+    # across by hand or the read loses the caller's context — most visibly under
+    # `Ecto.Adapters.SQL.Sandbox` ownership mode, where an unlinked process has
+    # no checked-out connection and every warm-up would fail with
+    # `DBConnection.OwnershipError`.
+    callers = [self() | Process.get(:"$callers", [])]
+
+    result =
+      Cachex.fetch(:system_static_info_cache, @static_info_warm_key, fn _key ->
+        Process.put(:"$callers", callers)
+
+        case WandererApp.Api.MapSolarSystem.read() do
+          {:ok, systems} ->
+            Enum.each(systems, fn system ->
+              Cachex.put(
+                :system_static_info_cache,
+                system.solar_system_id,
+                Map.take(system, @system_static_info_attrs)
+              )
+            end)
+
+            {:ignore, :ok}
+
+          {:error, reason} ->
+            Logger.error("Failed to read solar systems from API: #{inspect(reason)}")
+            {:ignore, {:error, :api_error}}
+        end
+      end)
+
+    case result do
+      {:ignore, outcome} ->
+        outcome
+
+      # Defensive: `{:ignore, _}` above is the only path that can populate this,
+      # so anything else means Cachex itself failed (dead cache, etc.).
+      {:error, reason} ->
+        Logger.error("Failed to warm system static info cache: #{inspect(reason)}")
         {:error, :cache_error}
     end
   end

--- a/lib/wanderer_app/map/map_routes.ex
+++ b/lib/wanderer_app/map/map_routes.ex
@@ -19,17 +19,6 @@ defmodule WandererApp.Map.Routes do
     avoid: []
   }
 
-  @minimum_route_attrs [
-    :system_class,
-    :class_title,
-    :security,
-    :triglavian_invasion_status,
-    :solar_system_id,
-    :solar_system_name,
-    :region_name,
-    :is_shattered
-  ]
-
   @get_link_pairs_advanced_params [
     :include_mass_crit,
     :include_eol,
@@ -79,7 +68,7 @@ defmodule WandererApp.Map.Routes do
   Route alerts always pass `false`.
   """
   @spec find_strict(binary(), [binary()], binary(), map(), boolean()) ::
-          {:ok, %{routes: [map()], systems_static_data: [map() | nil]}} | {:error, term()}
+          {:ok, %{routes: [map()], systems_static_data: [map()]}} | {:error, term()}
   def find_strict(map_id, hubs, origin, routes_settings, false) do
     case do_find_routes(map_id, origin, hubs, routes_settings, strict: true) do
       {:ok, routes} ->
@@ -121,29 +110,7 @@ defmodule WandererApp.Map.Routes do
         route_info.systems
       end
     end)
-    |> Enum.uniq()
-    |> Task.async_stream(
-      fn system_id ->
-        case WandererApp.CachedInfo.get_system_static_info(system_id) do
-          {:ok, nil} ->
-            nil
-
-          {:ok, system} ->
-            system |> Map.take(@minimum_route_attrs)
-
-          # `get_system_static_info/1` also returns {:error, :not_found},
-          # {:error, :api_error} and {:error, :cache_error}. Without this clause
-          # any of them raises CaseClauseError inside the task, and because
-          # `Task.async_stream` LINKS its tasks, that kills this process rather
-          # than surfacing as `{:exit, _}` below. A system we cannot resolve is
-          # missing static data, which every caller already handles as `nil`.
-          {:error, _reason} ->
-            nil
-        end
-      end,
-      max_concurrency: System.schedulers_online() * 4
-    )
-    |> Enum.map(fn {:ok, val} -> val end)
+    |> WandererApp.Map.RouteStaticData.hydrate()
   end
 
   defp do_find_routes(map_id, origin, hubs, routes_settings, opts \\ []) do

--- a/lib/wanderer_app/map/route_static_data.ex
+++ b/lib/wanderer_app/map/route_static_data.ex
@@ -1,0 +1,128 @@
+defmodule WandererApp.Map.RouteStaticData do
+  @moduledoc """
+  Shared static-data hydration for route results.
+
+  `Routes.find/5`, `Routes.find_strict/5` and `RoutesBy.find/3` each return a
+  `systems_static_data` list alongside their routes, and each hydrated it the
+  same way: one `CachedInfo.get_system_static_info/1` lookup per system, fanned
+  out with `Task.async_stream/3`. They were two near-identical private copies,
+  and the copies had already drifted — `map_routes.ex` grew an `{:error, _}`
+  clause, `routes_by.ex` never did — so the same defect had to be fixed twice
+  and was not. Centralizing here keeps the failure handling in one place.
+  """
+
+  require Logger
+
+  @minimum_route_attrs [
+    :system_class,
+    :class_title,
+    :security,
+    :triglavian_invasion_status,
+    :solar_system_id,
+    :solar_system_name,
+    :region_name,
+    :is_shattered
+  ]
+
+  @default_static_info_timeout :timer.seconds(15)
+
+  @logger Application.compile_env(:wanderer_app, :logger)
+
+  @doc """
+  Resolves `system_ids` to their minimal static attributes.
+
+  Order follows `system_ids`, but the result is NOT positional: systems that
+  have no static record, whose lookup errors, or whose lookup overruns
+  `static_info_timeout/0` are omitted entirely. Callers look systems up by
+  `:solar_system_id`, never by index — see `hydrate/1`'s body for why omission
+  beats a `nil` placeholder.
+  """
+  @spec hydrate([integer()]) :: [map()]
+  def hydrate(system_ids) do
+    system_ids = Enum.uniq(system_ids)
+
+    {static_data, timed_out_system_ids} =
+      system_ids
+      |> Task.async_stream(
+        fn system_id ->
+          case WandererApp.CachedInfo.get_system_static_info(system_id) do
+            {:ok, nil} ->
+              nil
+
+            {:ok, system} ->
+              system |> Map.take(@minimum_route_attrs)
+
+            # `get_system_static_info/1` also returns {:error, :not_found},
+            # {:error, :api_error} and {:error, :cache_error}. Without this clause
+            # any of them raises CaseClauseError inside the task, and because
+            # `Task.async_stream` LINKS its tasks, that kills the calling process
+            # rather than surfacing as `{:exit, _}` below — `on_timeout` only
+            # converts timeouts, never raises.
+            {:error, _reason} ->
+              nil
+          end
+        end,
+        max_concurrency: System.schedulers_online() * 4,
+        timeout: static_info_timeout(),
+        # `:kill_task` is what makes the `{:exit, _}` clause below reachable at
+        # all. Under the default `on_timeout: :exit` the overrunning task's exit
+        # travels the link and kills the CALLING process before the collector
+        # ever runs. The two options are a pair; neither is correct without the
+        # other.
+        #
+        # That mattered most for `Routes.find/5` and `RoutesBy.find/3`, which run
+        # inside plain `Task.async` calls linked to the LiveView
+        # (map_routes_event_handler.ex:98,142,192). LiveView does not trap exits,
+        # so one slow lookup remounted the user's entire map session.
+        # `Routes.find_strict/5` was already contained — the route watcher calls
+        # it under `Task.Supervisor.async_nolink/2` (route_watcher.ex:257) and
+        # handles the `{:DOWN, ...}` — but it still lost every system in the
+        # cycle where one system was slow.
+        on_timeout: :kill_task
+      )
+      # `async_stream` is ordered by default, so zipping against the input
+      # recovers which system each result belongs to — needed to report the
+      # timed-out ones, since `{:exit, _}` carries no system id.
+      |> Enum.zip(system_ids)
+      |> Enum.map_reduce([], fn
+        {{:ok, static_info}, _system_id}, timed_out -> {static_info, timed_out}
+        {{:exit, _reason}, system_id}, timed_out -> {nil, [system_id | timed_out]}
+      end)
+
+    log_timed_out_systems(timed_out_system_ids)
+
+    # Unresolved systems are dropped rather than passed through as `nil`. The
+    # frontend reads this list only by id — `RoutesWidget.tsx:60` and
+    # `PingRoute.tsx:28` both do `.find(sd => sd.solar_system_id === id)` — and a
+    # `null` element makes that predicate throw a TypeError, taking down the
+    # whole widget over one missing system. `Evaluator.index_static_data/1`
+    # (route alerts) already rejected nils on its own.
+    Enum.reject(static_data, &is_nil/1)
+  end
+
+  defp log_timed_out_systems([]), do: :ok
+
+  defp log_timed_out_systems(system_ids) do
+    # Worth a warning rather than silence: a dropped system is invisible in the
+    # UI — `RoutesList.tsx:106` filters it out of the rendered chain while the
+    # jump count beside it still comes from the raw id list, so a timeout shows
+    # up to the user only as a route that looks shorter and safer than it is.
+    @logger.warning(
+      "Route static data lookup timed out for #{length(system_ids)} system(s): " <>
+        "#{inspect(Enum.reverse(system_ids))}. They are omitted from systems_static_data."
+    )
+  end
+
+  # Per-system budget for `hydrate/1`. Generous by default because a cold
+  # `get_system_static_info/1` scans the whole MapSolarSystem table and
+  # repopulates the cache row by row (cached_info.ex) — killing that at
+  # `Task.async_stream`'s 5s default would drop static data routinely after any
+  # restart. Overridable so tests can force the timeout path.
+  defp static_info_timeout,
+    do:
+      Application.get_env(
+        :wanderer_app,
+        :route_static_info_timeout_ms,
+        @default_static_info_timeout
+      )
+end

--- a/lib/wanderer_app/map/route_static_data.ex
+++ b/lib/wanderer_app/map/route_static_data.ex
@@ -40,12 +40,13 @@ defmodule WandererApp.Map.RouteStaticData do
   @spec hydrate([integer()]) :: [map()]
   def hydrate(system_ids) do
     system_ids = Enum.uniq(system_ids)
+    lookup = lookup_fun()
 
     {static_data, timed_out_system_ids} =
       system_ids
       |> Task.async_stream(
         fn system_id ->
-          case WandererApp.CachedInfo.get_system_static_info(system_id) do
+          case lookup.(system_id) do
             {:ok, nil} ->
               nil
 
@@ -125,4 +126,18 @@ defmodule WandererApp.Map.RouteStaticData do
         :route_static_info_timeout_ms,
         @default_static_info_timeout
       )
+
+  # Resolved once per `hydrate/1` rather than per system, and only overridden by
+  # tests: the timeout path is otherwise unreachable on demand, because a real
+  # `get_system_static_info/1` is either a microsecond cache hit or a full table
+  # scan whose duration nothing here controls. Squeezing the budget alone does
+  # not prove the fix — that assertion passes whether or not a timeout actually
+  # fired. Blocking a named system does.
+  defp lookup_fun do
+    Application.get_env(
+      :wanderer_app,
+      :route_static_info_lookup,
+      &WandererApp.CachedInfo.get_system_static_info/1
+    )
+  end
 end

--- a/lib/wanderer_app/map/routes_by.ex
+++ b/lib/wanderer_app/map/routes_by.ex
@@ -5,17 +5,6 @@ defmodule WandererApp.Map.RoutesBy do
 
   require Logger
 
-  @minimum_route_attrs [
-    :system_class,
-    :class_title,
-    :security,
-    :triglavian_invasion_status,
-    :solar_system_id,
-    :solar_system_name,
-    :region_name,
-    :is_shattered
-  ]
-
   @default_routes_settings %{
     path_type: "shortest",
     include_mass_crit: true,
@@ -159,19 +148,8 @@ defmodule WandererApp.Map.RoutesBy do
 
   defp fetch_systems_static_data(routes) do
     routes
-    |> Enum.map(fn route_info -> route_info.systems end)
-    |> List.flatten()
-    |> Enum.uniq()
-    |> Task.async_stream(
-      fn system_id ->
-        case WandererApp.CachedInfo.get_system_static_info(system_id) do
-          {:ok, nil} -> nil
-          {:ok, system} -> system |> Map.take(@minimum_route_attrs)
-        end
-      end,
-      max_concurrency: System.schedulers_online() * 4
-    )
-    |> Enum.map(fn {:ok, val} -> val end)
+    |> Enum.flat_map(fn route_info -> route_info.systems end)
+    |> WandererApp.Map.RouteStaticData.hydrate()
   end
 
   defp build_avoidance_list(routes_settings) do

--- a/test/unit/cached_info_static_info_test.exs
+++ b/test/unit/cached_info_static_info_test.exs
@@ -1,0 +1,100 @@
+defmodule WandererApp.CachedInfoStaticInfoTest do
+  use WandererApp.DataCase, async: false
+
+  alias WandererApp.CachedInfo
+
+  @repo_query_event [:wanderer_app, :repo, :query]
+  @solar_system_table "map_solar_system_v2"
+
+  defp unique_system_id, do: 31_000_000 + System.unique_integer([:positive])
+
+  defp create_uncached_system do
+    system = create_solar_system(%{solar_system_id: unique_system_id()})
+    # The cache is process-global and survives across tests, so a system created
+    # here could already have been pulled in by an earlier warm-up.
+    Cachex.del(:system_static_info_cache, system.solar_system_id)
+    on_exit(fn -> Cachex.del(:system_static_info_cache, system.solar_system_id) end)
+    system
+  end
+
+  # Counts only full reads of the solar system table, which is what the warm-up
+  # issues — inserts from the factory and unrelated queries are filtered out.
+  defp count_table_scans(fun) do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+    handler_id = {__MODULE__, System.unique_integer([:positive])}
+
+    :telemetry.attach(
+      handler_id,
+      @repo_query_event,
+      fn _event, _measurements, metadata, _config ->
+        if metadata[:source] == @solar_system_table and
+             String.starts_with?(metadata[:query] || "", "SELECT") do
+          Agent.update(counter, &(&1 + 1))
+        end
+      end,
+      nil
+    )
+
+    try do
+      result = fun.()
+      {result, Agent.get(counter, & &1)}
+    after
+      :telemetry.detach(handler_id)
+      Agent.stop(counter)
+    end
+  end
+
+  # A single cache miss repopulates the entire table, so before the Courier
+  # guard N concurrent misses each ran their own full scan and row-by-row
+  # rewrite. Route hydration fans out over every system in a route at
+  # `schedulers_online() * 4`, and the cache has a 4h TTL, so this fired on every
+  # restart and every TTL rollover — and each redundant scan is what made an
+  # individual lookup slow enough to blow its `Task.async_stream` budget.
+  test "concurrent cache misses collapse into a single table scan" do
+    systems = Enum.map(1..25, fn _ -> create_uncached_system() end)
+
+    {results, scans} =
+      count_table_scans(fn ->
+        systems
+        |> Enum.map(fn system ->
+          Task.async(fn -> CachedInfo.get_system_static_info(system.solar_system_id) end)
+        end)
+        |> Task.await_many(15_000)
+      end)
+
+    # Every caller still gets its own system back, not just the one that won.
+    assert length(results) == 25
+
+    Enum.zip(systems, results)
+    |> Enum.each(fn {system, result} ->
+      assert {:ok, %{solar_system_id: id}} = result
+      assert id == system.solar_system_id
+    end)
+
+    assert scans == 1
+  end
+
+  # The guard is `{:ignore, _}`, so nothing is written to mark the cache "warm".
+  # That matters: a marker with a TTL would make a system inserted just after a
+  # warm-up invisible until it expired. Sequential behaviour must be unchanged.
+  test "a later miss still triggers a fresh scan and sees a newly added system" do
+    first = create_uncached_system()
+    assert {:ok, %{solar_system_id: _}} = CachedInfo.get_system_static_info(first.solar_system_id)
+
+    second = create_uncached_system()
+
+    {result, scans} =
+      count_table_scans(fn -> CachedInfo.get_system_static_info(second.solar_system_id) end)
+
+    assert {:ok, %{solar_system_id: id}} = result
+    assert id == second.solar_system_id
+    assert scans == 1
+  end
+
+  # `{:error, :not_found}` rather than a crash or a stale `{:ok, nil}` — the
+  # route hydrator relies on this clause to drop the system instead of taking
+  # the whole request down with a CaseClauseError.
+  test "an id with no row still resolves to :not_found after the warm-up" do
+    assert {:error, :not_found} = CachedInfo.get_system_static_info(unique_system_id())
+  end
+end

--- a/test/unit/map/map_routes_find_strict_test.exs
+++ b/test/unit/map/map_routes_find_strict_test.exs
@@ -234,21 +234,30 @@ defmodule WandererApp.Map.RoutesFindStrictTest do
   # which does not trap exits, so one slow lookup remounted the whole map. The
   # collector is shared, so covering it here covers both.
   #
-  # Squeezing the per-system budget to 1ms forces the overrun deterministically:
-  # reaching the assertion at all is the point, because under `on_timeout:
-  # :exit` this test process simply exited instead.
-  test "find_strict/5 survives a static lookup that overruns its timeout" do
+  # `hub` is blocked outright rather than merely raced against a tight budget:
+  # a budget alone makes the outcome timing-dependent, and an assertion that
+  # tolerates either outcome would pass just as happily with the bug present.
+  # Blocking one named system pins exactly which one must go missing. The
+  # blocked task is never released explicitly — `on_timeout: :kill_task`
+  # killing it IS the behaviour under test, and the kill is what stops
+  # `sleep(:infinity)` from leaking.
+  test "find_strict/5 drops only the system whose static lookup overruns its budget" do
     hub = unique_system_id()
     origin = unique_system_id()
+    stub_static_info(hub)
+    stub_static_info(origin)
 
-    original_timeout = Application.get_env(:wanderer_app, :route_static_info_timeout_ms)
-    Application.put_env(:wanderer_app, :route_static_info_timeout_ms, 1)
+    test_pid = self()
 
-    on_exit(fn ->
-      case original_timeout do
-        nil -> Application.delete_env(:wanderer_app, :route_static_info_timeout_ms)
-        value -> Application.put_env(:wanderer_app, :route_static_info_timeout_ms, value)
-      end
+    put_test_env(:route_static_info_timeout_ms, 50)
+
+    put_test_env(:route_static_info_lookup, fn
+      ^hub ->
+        send(test_pid, :hub_lookup_started)
+        Process.sleep(:infinity)
+
+      system_id ->
+        WandererApp.CachedInfo.get_system_static_info(system_id)
     end)
 
     stub(WandererApp.Esi.Mock, :get_routes_custom, fn hubs, origin, _params ->
@@ -267,11 +276,27 @@ defmodule WandererApp.Map.RoutesFindStrictTest do
                false
              )
 
-    # A timed-out system is omitted, exactly like any other unresolvable one, so
-    # the frontend's `.find(sd => sd.solar_system_id === id)` never meets a
-    # `null`. Whether the cached origin wins the race at a 1ms budget is not
-    # asserted — pinning that would be flaky.
-    assert length(static_data) <= 2
-    assert Enum.all?(static_data, &is_map/1)
+    # Reaching this line at all is half the point: under `on_timeout: :exit`
+    # this test process exited instead of returning.
+    assert_received :hub_lookup_started
+
+    # The blocked system is omitted rather than passed through as `nil` — the
+    # frontend searches this list by id and dereferences every element — and
+    # the system that resolved is untouched by its neighbour's timeout.
+    assert [%{solar_system_id: ^origin}] = static_data
+  end
+
+  # Both knobs are read at call time by `RouteStaticData`, so they must be
+  # restored even when a test fails partway through.
+  defp put_test_env(key, value) do
+    original = Application.fetch_env(:wanderer_app, key)
+    Application.put_env(:wanderer_app, key, value)
+
+    on_exit(fn ->
+      case original do
+        {:ok, previous} -> Application.put_env(:wanderer_app, key, previous)
+        :error -> Application.delete_env(:wanderer_app, key)
+      end
+    end)
   end
 end

--- a/test/unit/map/map_routes_find_strict_test.exs
+++ b/test/unit/map/map_routes_find_strict_test.exs
@@ -214,9 +214,64 @@ defmodule WandererApp.Map.RoutesFindStrictTest do
                false
              )
 
-    # The origin still hydrated; the unresolvable hub came back as nil, which
-    # `Evaluator.index_static_data/1` already rejects and then fails closed on.
-    assert origin in Enum.map(Enum.reject(static_data, &is_nil/1), & &1.solar_system_id)
-    refute hub in Enum.map(Enum.reject(static_data, &is_nil/1), & &1.solar_system_id)
+    # The origin still hydrated; the unresolvable hub is absent from the list
+    # rather than present as `nil` — `RoutesWidget.tsx:60` and `PingRoute.tsx:28`
+    # dereference every element while searching by id, so a `null` there throws.
+    refute Enum.any?(static_data, &is_nil/1)
+    assert origin in Enum.map(static_data, & &1.solar_system_id)
+    refute hub in Enum.map(static_data, & &1.solar_system_id)
+  end
+
+  # `Task.async_stream`'s default `on_timeout: :exit` kills the CALLING process
+  # when a lookup overruns. A cold `get_system_static_info/1` scans the entire
+  # MapSolarSystem table and repopulates the cache row by row
+  # (cached_info.ex:101-141), so overrunning the 5s default is realistic on any
+  # restart or TTL expiry.
+  #
+  # Exercised through `find_strict/5` because it is the entry point with a
+  # seam this test can drive, but the severe case is `find/5`: it runs inside a
+  # `Task.async` linked to the LiveView (map_routes_event_handler.ex:98,142),
+  # which does not trap exits, so one slow lookup remounted the whole map. The
+  # collector is shared, so covering it here covers both.
+  #
+  # Squeezing the per-system budget to 1ms forces the overrun deterministically:
+  # reaching the assertion at all is the point, because under `on_timeout:
+  # :exit` this test process simply exited instead.
+  test "find_strict/5 survives a static lookup that overruns its timeout" do
+    hub = unique_system_id()
+    origin = unique_system_id()
+
+    original_timeout = Application.get_env(:wanderer_app, :route_static_info_timeout_ms)
+    Application.put_env(:wanderer_app, :route_static_info_timeout_ms, 1)
+
+    on_exit(fn ->
+      case original_timeout do
+        nil -> Application.delete_env(:wanderer_app, :route_static_info_timeout_ms)
+        value -> Application.put_env(:wanderer_app, :route_static_info_timeout_ms, value)
+      end
+    end)
+
+    stub(WandererApp.Esi.Mock, :get_routes_custom, fn hubs, origin, _params ->
+      {:ok,
+       Enum.map(hubs, fn hub ->
+         %{"origin" => origin, "destination" => hub, "systems" => [hub], "success" => true}
+       end)}
+    end)
+
+    assert {:ok, %{routes: [%{success: true}], systems_static_data: static_data}} =
+             Routes.find_strict(
+               Ecto.UUID.generate(),
+               [Integer.to_string(hub)],
+               Integer.to_string(origin),
+               @routes_settings,
+               false
+             )
+
+    # A timed-out system is omitted, exactly like any other unresolvable one, so
+    # the frontend's `.find(sd => sd.solar_system_id === id)` never meets a
+    # `null`. Whether the cached origin wins the race at a 1ms budget is not
+    # asserted — pinning that would be flaky.
+    assert length(static_data) <= 2
+    assert Enum.all?(static_data, &is_map/1)
   end
 end


### PR DESCRIPTION
Follow-up to #126, which fixed the `{:error, _}` half of this collector.

## The bug

`hydrate_static_data/2` fans out `CachedInfo.get_system_static_info/1` with
`Task.async_stream/3` on default options — `on_timeout: :exit`, and
`async_stream` links its tasks. One lookup overrunning the 5s default kills the
**calling** process, not just that system.

For `Routes.find/5` and `RoutesBy.find/3` the caller is a plain `Task.async`
linked to the LiveView (`map_routes_event_handler.ex:98,142,192`). LiveView does
not trap exits, so **one slow lookup remounted the user's entire map session**.
`find_strict/5` was contained by the route watcher's
`Task.Supervisor.async_nolink/2`, but still lost every system in that cycle.

## The fix

`on_timeout: :kill_task` plus a `{:exit, _}` clause in the collector.

Confirming the review note: the two are a **pair**. Verified in iex on 1.17.3 —
under the default, the caller exits with `{:timeout, {Task.Supervised, :stream, …}}`
and nothing reaches the collector, so the clause alone is dead code. Leaving it
out of #126 was right. Also confirmed `:kill_task` converts *timeouts only* — a
`raise` still travels the link — so #126's `{:error, _}` clause stays
load-bearing rather than being superseded.

Per-system budget also raised to 15s (overridable via
`:route_static_info_timeout_ms`), because a cold lookup scans the entire
`MapSolarSystem` table; 5s was never a generous ceiling.

## On the "misleading partial route" question

It **does** mislead, though not the way the review guessed. A system missing its
security value is not rendered with a default — `RoutesList.tsx:106` runs
`.filter(Boolean)` and drops it from the chain entirely, while the jump count
beside it still comes from the raw `route.systems` id list. A 20-jump route with
3 unresolved systems renders "20" next to 17 dots: shorter and safer-looking than
reality.

That did **not** change the fix, because this degradation is already the accepted
behaviour for `{:ok, nil}` and (since #126) for `{:error, _}` — timeouts now join
the same path rather than introducing a new one, and the alternative is failing
the request outright (or, today, killing the LiveView). What it did change is
that timeouts are now logged with the affected system ids instead of vanishing
silently, so the misleading render is at least diagnosable.

## Folded in

**`nil` no longer reaches the frontend.** `RoutesWidget.tsx:60` and
`PingRoute.tsx:28` do `.find(sd => sd.solar_system_id === id)` over
`systems_static_data` — a `null` element throws a TypeError and takes down the
whole widget over one missing system. Unresolved systems are now omitted from the
list. No consumer indexes it positionally, and
`Evaluator.index_static_data/1` already rejected nils. `@spec find_strict`
narrowed from `[map() | nil]` to `[map()]`.

**Cold-cache stampede in `get_system_static_info/1`.** This is the actual root
cause; the timeout fix only stops it from being fatal. A single miss repopulates
the whole table, so N concurrent misses each ran a full `MapSolarSystem.read/0`
plus a row-by-row rewrite of identical data. Not an edge case: the cache has a 4h
TTL and route hydration fans out over every system in a route at
`schedulers_online() * 4`, so every restart and every TTL rollover stampeded.

The scan now goes through Cachex's Courier, which admits one at a time and hands
every concurrent caller the same result. The fallback returns `{:ignore, _}` so
**no marker is cached** — sequential behaviour is unchanged, a later miss still
rescans and still picks up a newly inserted system immediately. Only
*simultaneous* scans collapse. A TTL'd "warm" marker would have been the obvious
design and is wrong for exactly that reason.

One subtlety worth a reviewer's eye: Cachex runs the fallback in a Courier-owned
process with an empty dictionary, so `$callers` is copied across by hand.
Without it every warm-up fails with `DBConnection.OwnershipError` under the
sandbox's ownership mode.

## Refactor

Hydration moves to `WandererApp.Map.RouteStaticData`. It was two near-identical
private copies that had already drifted: `map_routes.ex` grew #126's `{:error, _}`
clause, `routes_by.ex` never did and would still raise `CaseClauseError` on
`:not_found` — with the same LiveView blast radius.

## Verification

- New test forces the timeout path by squeezing the budget to 1ms; proved
  load-bearing by reverting to `on_timeout: :exit`, which fails with
  `** (exit) exited in: Task.Supervised.stream(1) ** (EXIT) time out`.
- New `cached_info_static_info_test.exs` counts solar-system table scans via Ecto
  telemetry: 25 concurrent misses → exactly 1 scan, all 25 callers get their own
  system back; and a later miss still rescans and sees a newly inserted row.
- Full suite: 1595 tests, 0 failures.
- `mix format --check-formatted` clean, `mix credo` clean in touched files,
  `mix dialyzer` unchanged at 153 pre-existing lib warnings with none in the new
  or modified code.

## Where to look

`RouteStaticData.hydrate/1` (the option pair and why omission beats `nil`) and
`CachedInfo.warm_system_static_info_cache/0` (`{:ignore, _}` and the `$callers`
copy).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved route static-data loading with concurrent lookups and duplicate removal.
  * Routes now omit unavailable or timed-out system records instead of returning empty entries.
  * Added consistent handling for missing data and lookup errors.
  * Improved caching to combine simultaneous requests and reduce redundant data fetches.
  * Added timeout warnings and maintained successful route completion when individual lookups time out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->