### PR TITLE
ci: replace the guarzo/release hard reset with an approval-gated deploy

### DIFF
--- a/.github/workflows/zoo-deploy.yml
+++ b/.github/workflows/zoo-deploy.yml
@@ -1,0 +1,174 @@
+name: 🚀 Zoo Deploy
+
+# Deploys are gated on a green test suite, so the trigger is the test workflow
+# finishing — not the push itself. An environment gate does not wait for another
+# workflow's checks, so `on: push` would offer approval while the suite is still
+# running, and a red commit could be approved and shipped.
+on:
+  workflow_run:
+    workflows: ["🧪 Test Suite"]
+    types: [completed]
+    branches: [guarzo/zoo]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag or SHA to deploy (defaults to guarzo/zoo HEAD)'
+        required: false
+        type: string
+
+# Default token is read-only; the job scopes itself up because it pushes a tag
+# and moves a branch.
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to Fly
+    # workflow_run fires on EVERY completion of the test suite — GitHub offers
+    # no conclusion filter on the trigger itself, so a red suite still creates a
+    # Zoo Deploy run. This condition is what makes it inert: the single job is
+    # skipped, so no environment is referenced, no approval is requested, and no
+    # credential is released. Expect skipped runs in the Actions tab after every
+    # failed suite; that is the mechanism working, not a misfire.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    # The gate AND the work live in one job on purpose. A protected environment
+    # gates every job that references it, so splitting them would prompt twice;
+    # and FLY_API_TOKEN is an environment secret, readable only by a job inside
+    # the environment. Secrets cannot be passed between jobs.
+    environment: production-deploy
+
+    permissions:
+      contents: write
+
+    # NEVER set cancel-in-progress: true here. Cancellation applies to running
+    # jobs, not just to runs awaiting approval: a merge landing mid-deploy would
+    # kill this job while Fly's builder keeps going, changing production with no
+    # tag and no bookmark. That is the exact failure this workflow exists to
+    # prevent. `false` also serializes deploys onto the single machine.
+    concurrency:
+      group: zoo-deploy-run
+      cancel-in-progress: false
+
+    steps:
+      - name: Resolve the ref to deploy
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_REF: ${{ inputs.ref }}
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            REF="${DISPATCH_REF:-guarzo/zoo}"
+          else
+            # NOT github.ref: under workflow_run that resolves to the default
+            # branch tip at trigger time, which may not be the tested commit.
+            REF="$RUN_SHA"
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "Resolved deploy ref: $REF"
+
+      - name: Check out the ref
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ steps.resolve.outputs.ref }}
+          # Annotated tagging needs full history.
+          fetch-depth: 0
+
+      # Runs AFTER approval, which is the entire point: a run may sit pending
+      # for hours while guarzo/zoo moves on. Because runs are never cancelled,
+      # this is what stops an old approval from shipping a superseded commit.
+      - name: Guard against a superseded commit
+        id: guard
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "workflow_dispatch: staleness guard skipped — deploying a ref that is not the branch tip is what rollback is for."
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --quiet origin guarzo/zoo
+          TIP="$(git rev-parse origin/guarzo/zoo)"
+          HERE="$(git rev-parse HEAD)"
+          if [ "$TIP" != "$HERE" ]; then
+            echo "::notice title=Superseded::guarzo/zoo has moved to ${TIP}; this run was approved for ${HERE}. Nothing was deployed."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up flyctl
+        if: steps.guard.outputs.proceed == 'true'
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1
+
+      # Fly runs release_command first (fly.toml:29 — migrations against
+      # DIRECT_DATABASE_URL), so a failed migration fails the deploy before new
+      # code serves traffic. Under strategy = 'rolling' (fly.toml:30) this
+      # blocks on the /health check (fly.toml:84-88).
+      - name: Deploy to Fly
+        if: steps.guard.outputs.proceed == 'true'
+        id: deploy
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          flyctl deploy --app wanderer --remote-only
+          # Recorded in the tag message so a tag can be matched to a Fly release
+          # without the dashboard. Best-effort: a lookup failure must not fail a
+          # deploy that already succeeded.
+          VERSION="$(flyctl releases --app wanderer --json | jq -r '.[0].version' || echo unknown)"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      # Everything below runs only after a healthy deploy. That ordering is what
+      # makes the tag mean "this commit served production traffic".
+      - name: Tag the deployed commit
+        if: steps.guard.outputs.proceed == 'true'
+        id: tag
+        run: |
+          set -euo pipefail
+          SHA="$(git rev-parse --short HEAD)"
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          # Convergent, not merely collision-safe. A recovery re-run (deploy
+          # succeeded, bookmark push failed) must reuse the tag the first run
+          # created, not mint a second one for the same commit — the tag name is
+          # generated from the clock, so checking only the new name would always
+          # miss the existing one.
+          # Tags are present because checkout used fetch-depth: 0.
+          EXISTING="$(git tag --points-at HEAD --list 'v[0-9]*' | head -n1)"
+          if [ -n "${EXISTING}" ]; then
+            TAG="${EXISTING}"
+            echo "Commit is already tagged ${TAG}; reusing it."
+          else
+            TAG="v$(date +%Y%m%d%H%M%S)"
+            git tag -a "${TAG}" -m "Deployed ${SHA} to Fly app wanderer (release v${{ steps.deploy.outputs.version }})"
+            git push origin "${TAG}"
+            echo "Tagged ${SHA} as ${TAG}"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      # Force-push: guarzo/zoo is rebased regularly, so this is not a
+      # fast-forward. Requires the ruleset bypass from Task 1 Step 9.
+      - name: Move the guarzo/release bookmark
+        if: steps.guard.outputs.proceed == 'true'
+        run: |
+          set -euo pipefail
+          git push --force origin "HEAD:refs/heads/guarzo/release"
+          echo "guarzo/release now points at $(git rev-parse HEAD)"
+
+      - name: Summarize
+        if: steps.guard.outputs.proceed == 'true'
+        run: |
+          {
+            echo "### Deployed"
+            echo ""
+            echo "- commit: \`$(git rev-parse HEAD)\`"
+            echo "- tag: \`${{ steps.tag.outputs.tag }}\`"
+            echo "- app: \`wanderer\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/zoo-deploy.yml
+++ b/.github/workflows/zoo-deploy.yml
@@ -30,9 +30,17 @@ jobs:
     # skipped, so no environment is referenced, no approval is requested, and no
     # credential is released. Expect skipped runs in the Actions tab after every
     # failed suite; that is the mechanism working, not a misfire.
+    #
+    # The `event == 'push'` clause guards a narrower hole: workflow_run's
+    # `branches:` filter (above) matches the triggering run's head_branch, and
+    # this is a public fork whose default branch is itself named `guarzo/zoo`.
+    # Without this clause, a fork PR whose source branch is also named
+    # `guarzo/zoo` would match the filter and, if its tests pass, raise a
+    # production-deploy approval request for a commit the requester controls.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
 
     # The gate AND the work live in one job on purpose. A protected environment
@@ -98,6 +106,15 @@ jobs:
           HERE="$(git rev-parse HEAD)"
           if [ "$TIP" != "$HERE" ]; then
             echo "::notice title=Superseded::guarzo/zoo has moved to ${TIP}; this run was approved for ${HERE}. Nothing was deployed."
+            # Also write to the job summary, not just the notice: a notice
+            # requires opening the run to see, so without this the summary
+            # pane stays blank and a superseded run reads identically to a
+            # real deploy in the Actions list.
+            {
+              echo "### Not deployed — superseded"
+              echo ""
+              echo "guarzo/zoo has moved to \`${TIP}\`; this run was approved for \`${HERE}\`. Nothing was deployed."
+            } >> "$GITHUB_STEP_SUMMARY"
             echo "proceed=false" >> "$GITHUB_OUTPUT"
           else
             echo "proceed=true" >> "$GITHUB_OUTPUT"
@@ -130,6 +147,8 @@ jobs:
       - name: Tag the deployed commit
         if: steps.guard.outputs.proceed == 'true'
         id: tag
+        env:
+          DEPLOY_VERSION: ${{ steps.deploy.outputs.version }}
         run: |
           set -euo pipefail
           SHA="$(git rev-parse --short HEAD)"
@@ -141,13 +160,17 @@ jobs:
           # generated from the clock, so checking only the new name would always
           # miss the existing one.
           # Tags are present because checkout used fetch-depth: 0.
-          EXISTING="$(git tag --points-at HEAD --list 'v[0-9]*' | head -n1)"
+          # 'v20[0-9]*' (not 'v[0-9]*') excludes upstream semver release tags
+          # like v1.2.3 — git tag sorts lexicographically, so head -n1 would
+          # otherwise prefer an upstream tag over a timestamped deploy tag on
+          # any commit carrying both.
+          EXISTING="$(git tag --points-at HEAD --list 'v20[0-9]*' | head -n1)"
           if [ -n "${EXISTING}" ]; then
             TAG="${EXISTING}"
             echo "Commit is already tagged ${TAG}; reusing it."
           else
-            TAG="v$(date +%Y%m%d%H%M%S)"
-            git tag -a "${TAG}" -m "Deployed ${SHA} to Fly app wanderer (release v${{ steps.deploy.outputs.version }})"
+            TAG="v$(date -u +%Y%m%d%H%M%S)"
+            git tag -a "${TAG}" -m "Deployed ${SHA} to Fly app wanderer (release v${DEPLOY_VERSION})"
             git push origin "${TAG}"
             echo "Tagged ${SHA} as ${TAG}"
           fi
@@ -164,11 +187,13 @@ jobs:
 
       - name: Summarize
         if: steps.guard.outputs.proceed == 'true'
+        env:
+          DEPLOY_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           {
             echo "### Deployed"
             echo ""
             echo "- commit: \`$(git rev-parse HEAD)\`"
-            echo "- tag: \`${{ steps.tag.outputs.tag }}\`"
+            echo "- tag: \`${DEPLOY_TAG}\`"
             echo "- app: \`wanderer\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/zoo-deploy.yml
+++ b/.github/workflows/zoo-deploy.yml
@@ -16,8 +16,9 @@ on:
         required: false
         type: string
 
-# Default token is read-only; the job scopes itself up because it pushes a tag
-# and moves a branch.
+# Default token is read-only; the job scopes itself up because it pushes a tag.
+# The tag is the ONLY record of what is in production — no branch tracks it, by
+# design (see docs/ZOO-FORK.md, "Deployment").
 permissions:
   contents: read
 
@@ -55,8 +56,9 @@ jobs:
     # NEVER set cancel-in-progress: true here. Cancellation applies to running
     # jobs, not just to runs awaiting approval: a merge landing mid-deploy would
     # kill this job while Fly's builder keeps going, changing production with no
-    # tag and no bookmark. That is the exact failure this workflow exists to
-    # prevent. `false` also serializes deploys onto the single machine.
+    # tag — and the tag is the only record of what is live. That is the exact
+    # failure this workflow exists to prevent. `false` also serializes deploys
+    # onto the single machine.
     concurrency:
       group: zoo-deploy-run
       cancel-in-progress: false
@@ -155,7 +157,7 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           # Convergent, not merely collision-safe. A recovery re-run (deploy
-          # succeeded, bookmark push failed) must reuse the tag the first run
+          # succeeded, tag push failed) must reuse the tag the first run
           # created, not mint a second one for the same commit — the tag name is
           # generated from the clock, so checking only the new name would always
           # miss the existing one.
@@ -175,15 +177,6 @@ jobs:
             echo "Tagged ${SHA} as ${TAG}"
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-
-      # Force-push: guarzo/zoo is rebased regularly, so this is not a
-      # fast-forward. Requires the ruleset bypass from Task 1 Step 9.
-      - name: Move the guarzo/release bookmark
-        if: steps.guard.outputs.proceed == 'true'
-        run: |
-          set -euo pipefail
-          git push --force origin "HEAD:refs/heads/guarzo/release"
-          echo "guarzo/release now points at $(git rev-parse HEAD)"
 
       - name: Summarize
         if: steps.guard.outputs.proceed == 'true'

--- a/.github/workflows/zoo-deploy.yml
+++ b/.github/workflows/zoo-deploy.yml
@@ -46,7 +46,7 @@ jobs:
 
     # The gate AND the work live in one job on purpose. A protected environment
     # gates every job that references it, so splitting them would prompt twice;
-    # and FLY_API_TOKEN is an environment secret, readable only by a job inside
+    # and FLY_DEPLOY_TOKEN is an environment secret, readable only by a job inside
     # the environment. Secrets cannot be passed between jobs.
     environment: production-deploy
 
@@ -134,7 +134,12 @@ jobs:
         if: steps.guard.outputs.proceed == 'true'
         id: deploy
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          # Repository secret name is FLY_DEPLOY_TOKEN, deliberately NOT
+          # FLY_API_TOKEN: advanced-test.yml reads a secret of that name with no
+          # environment gate, for the separate wanderer-test app. Distinct names
+          # mean this production credential can never be picked up there. The
+          # env var flyctl itself reads is still FLY_API_TOKEN.
+          FLY_API_TOKEN: ${{ secrets.FLY_DEPLOY_TOKEN }}
         run: |
           set -euo pipefail
           flyctl deploy --app wanderer --remote-only

--- a/docs/ZOO-FORK.md
+++ b/docs/ZOO-FORK.md
@@ -284,13 +284,21 @@ comment at the top of `fly.toml`).
 3. On success, `🚀 Zoo Deploy` opens a run that **waits for approval** in the
    `production-deploy` environment. GitHub emails an approval request; the run
    also shows as pending in the Actions tab.
-4. Approving it deploys to Fly, then tags the commit `v<UTC timestamp>` and
-   moves `guarzo/release` to that commit.
+4. Approving it deploys to Fly, then tags the commit `v<UTC timestamp>`.
 
-**`guarzo/release` is CI-owned.** It is a bookmark of what is in production, not
-a trigger. Direct pushes are rejected by a ruleset — resetting and pushing it by
-hand does nothing except fail. This is deliberate: it used to be the deploy
-trigger, and the change is easy to forget.
+**The newest `v20*` tag is the record of what is in production.** No branch
+tracks it. To see what you have written but not yet deployed:
+
+```bash
+git fetch origin --tags
+git log --oneline "$(git tag -l 'v20*' | sort | tail -1)"..guarzo/zoo
+```
+
+**`guarzo/release` is retired.** It used to be the deploy trigger — hard-resetting
+and pushing it was how you shipped. It no longer moves, deploys nothing, and is
+frozen by a ruleset that rejects pushes to it, so the old habit fails loudly
+instead of silently doing nothing. It survives only as a marker of where the
+old process stopped.
 
 **Nothing deploys without approval**, including a run that has been sitting
 pending. Pending approvals expire after 30 days.
@@ -302,22 +310,21 @@ revert a schema change.
 **Approving a stale run is safe.** If `guarzo/zoo` has moved on since the run
 was created, the workflow exits without deploying and says so.
 
-**If a deploy half-succeeded.** The deploy, the tag push, and the
-`guarzo/release` bookmark move are three separate steps, not one atomic
-operation. If the deploy step fails, nothing else runs and production is
-unchanged (or partially migrated if the `release_command` succeeded before the
-health check failed — see `fly.toml`). If the tag push fails after a successful
-deploy, that is the dangerous case: production is now running a new commit that
-carries **no tag** and a **stale `guarzo/release` bookmark**. If `guarzo/zoo` is
-rebased or squashed before this is fixed, that commit becomes unreachable from
-any branch — the exact loss this whole mechanism exists to prevent. Recover by
-running `🚀 Zoo Deploy` manually (`workflow_dispatch`) with `ref` set to the
-deployed commit's explicit SHA and approving it: this skips the staleness
-guard, so it works even after `guarzo/zoo` has moved on, and it redeploys and
-tags the commit. The only cost is one extra machine restart, because the app
-runs exactly one machine. Simply re-running (or re-approving) the automatic
-path does **not** recover this — once `guarzo/zoo` has moved, the staleness
-guard blocks it.
+**If a deploy half-succeeded.** The deploy and the tag push are two separate
+steps, not one atomic operation. If the deploy step fails, nothing else runs and
+production is unchanged (or partially migrated if the `release_command`
+succeeded before the health check failed — see `fly.toml`). If the tag push
+fails after a successful deploy, that is the dangerous case: production is now
+running a commit that carries **no tag**, and the tag is the only record of what
+is live. If `guarzo/zoo` is rebased or squashed before this is fixed, that commit
+becomes unreachable from any ref — the exact loss this whole mechanism exists to
+prevent. Recover by running `🚀 Zoo Deploy` manually (`workflow_dispatch`) with
+`ref` set to the deployed commit's explicit SHA and approving it: this skips the
+staleness guard, so it works even after `guarzo/zoo` has moved on, and it
+redeploys and tags the commit. The only cost is one extra machine restart,
+because the app runs exactly one machine. Simply re-running (or re-approving)
+the automatic path does **not** recover this — once `guarzo/zoo` has moved, the
+staleness guard blocks it.
 
 **`FLY_API_TOKEN` must stay an environment secret on `production-deploy`, never
 a repository secret** — an environment secret is released only to a job that

--- a/docs/ZOO-FORK.md
+++ b/docs/ZOO-FORK.md
@@ -326,15 +326,15 @@ because the app runs exactly one machine. Simply re-running (or re-approving)
 the automatic path does **not** recover this — once `guarzo/zoo` has moved, the
 staleness guard blocks it.
 
-**`FLY_API_TOKEN` must stay an environment secret on `production-deploy`, never
+**`FLY_DEPLOY_TOKEN` must stay an environment secret on `production-deploy`, never
 a repository secret** — an environment secret is released only to a job that
-has cleared the approval gate, which is the entire point. Note that
-`advanced-test.yml` also reads a secret named `FLY_API_TOKEN`, with no
-environment gate, targeting the separate `wanderer-test` app; no
-repository-scoped secret of that name exists today, but adding one in the
-future would hand this workflow's production credential to that ungated
-workflow, so keep any `develop`-deploy credential scoped to its own name or
-environment instead.
+has cleared the approval gate, which is the entire point. The name is
+deliberately not `FLY_API_TOKEN`: `advanced-test.yml` reads a secret of that
+name with no environment gate, targeting the separate `wanderer-test` app.
+Keeping the names distinct means this production credential can never be picked
+up by that ungated workflow, whatever gets added to repository secrets later.
+The workflow maps it onto the `FLY_API_TOKEN` env var that `flyctl` itself
+reads.
 
 ---
 

--- a/docs/ZOO-FORK.md
+++ b/docs/ZOO-FORK.md
@@ -16,6 +16,7 @@ This document describes the zoo fork's extensions to upstream Wanderer, includin
 5. [Signature Cleanup](#signature-cleanup)
 6. [Fleet Readiness](#fleet-readiness)
 7. [Upstream PR Recommendations](#upstream-pr-recommendations)
+8. [Deployment](#deployment)
 
 ---
 
@@ -266,6 +267,40 @@ Could be generalized to a "character tags" system. Requires significant refactor
 | System Ownership | Specific to tracking wormhole space occupation |
 | Custom Flags | Generic "store anything" field lacks structure |
 | Connection Loop Type | Niche EVE mechanic |
+
+---
+
+## Deployment
+
+Production is the Fly app `wanderer` (single machine — see the constraint
+comment at the top of `fly.toml`).
+
+**How a change reaches production:**
+
+1. Merge to `guarzo/zoo`.
+2. `🧪 Test Suite` runs. If it fails, a `🚀 Zoo Deploy` run still appears in the
+   Actions tab but its only job is **skipped** — no approval is requested and
+   nothing can be deployed. Skipped deploy runs after a red suite are normal.
+3. On success, `🚀 Zoo Deploy` opens a run that **waits for approval** in the
+   `production-deploy` environment. GitHub emails an approval request; the run
+   also shows as pending in the Actions tab.
+4. Approving it deploys to Fly, then tags the commit `v<UTC timestamp>` and
+   moves `guarzo/release` to that commit.
+
+**`guarzo/release` is CI-owned.** It is a bookmark of what is in production, not
+a trigger. Direct pushes are rejected by a ruleset — resetting and pushing it by
+hand does nothing except fail. This is deliberate: it used to be the deploy
+trigger, and the change is easy to forget.
+
+**Nothing deploys without approval**, including a run that has been sitting
+pending. Pending approvals expire after 30 days.
+
+**To roll back**, run `🚀 Zoo Deploy` manually with `ref` set to a previous tag
+and approve it. Note that migrations only run forward — a rollback does not
+revert a schema change.
+
+**Approving a stale run is safe.** If `guarzo/zoo` has moved on since the run
+was created, the workflow exits without deploying and says so.
 
 ---
 

--- a/docs/ZOO-FORK.md
+++ b/docs/ZOO-FORK.md
@@ -302,6 +302,33 @@ revert a schema change.
 **Approving a stale run is safe.** If `guarzo/zoo` has moved on since the run
 was created, the workflow exits without deploying and says so.
 
+**If a deploy half-succeeded.** The deploy, the tag push, and the
+`guarzo/release` bookmark move are three separate steps, not one atomic
+operation. If the deploy step fails, nothing else runs and production is
+unchanged (or partially migrated if the `release_command` succeeded before the
+health check failed — see `fly.toml`). If the tag push fails after a successful
+deploy, that is the dangerous case: production is now running a new commit that
+carries **no tag** and a **stale `guarzo/release` bookmark**. If `guarzo/zoo` is
+rebased or squashed before this is fixed, that commit becomes unreachable from
+any branch — the exact loss this whole mechanism exists to prevent. Recover by
+running `🚀 Zoo Deploy` manually (`workflow_dispatch`) with `ref` set to the
+deployed commit's explicit SHA and approving it: this skips the staleness
+guard, so it works even after `guarzo/zoo` has moved on, and it redeploys and
+tags the commit. The only cost is one extra machine restart, because the app
+runs exactly one machine. Simply re-running (or re-approving) the automatic
+path does **not** recover this — once `guarzo/zoo` has moved, the staleness
+guard blocks it.
+
+**`FLY_API_TOKEN` must stay an environment secret on `production-deploy`, never
+a repository secret** — an environment secret is released only to a job that
+has cleared the approval gate, which is the entire point. Note that
+`advanced-test.yml` also reads a secret named `FLY_API_TOKEN`, with no
+environment gate, targeting the separate `wanderer-test` app; no
+repository-scoped secret of that name exists today, but adding one in the
+future would hand this workflow's production credential to that ungated
+workflow, so keep any `develop`-deploy credential scoped to its own name or
+environment instead.
+
 ---
 
 ## Key Files Reference

--- a/docs/superpowers/plans/2026-08-07-deploy-approval-gate.md
+++ b/docs/superpowers/plans/2026-08-07-deploy-approval-gate.md
@@ -1,0 +1,710 @@
+# Deploy Approval Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Fly's branch-watch auto-deploy with a GitHub Actions workflow that deploys `guarzo/zoo` to Fly only after a green test suite and an explicit human approval, then tags the deployed commit.
+
+**Architecture:** One workflow (`.github/workflows/zoo-deploy.yml`) with a single gated job. It triggers on the `🧪 Test Suite` workflow succeeding on `guarzo/zoo`, waits on the `production-deploy` GitHub Environment for approval, verifies the commit is still current, runs `flyctl deploy`, and only then tags the SHA and moves `guarzo/release` to it as a bookmark. Fly's own GitHub integration is disconnected — the workflow replaces it rather than running alongside it.
+
+**Tech Stack:** GitHub Actions, GitHub Environments (deployment protection rules), GitHub repository rulesets, Fly.io (`flyctl`), Docker build on Fly remote builders.
+
+**Spec:** `docs/superpowers/specs/2026-08-07-deploy-approval-gate-design.md`
+
+## Global Constraints
+
+- **Repository:** `guarzo/wanderer`. Default branch is `guarzo/zoo`, which is regularly rebased onto upstream and has commits squashed.
+- **Fly app name:** `wanderer`. Never `wanderer-*`; the other Fly apps (`kills`, `route-builder`) are separate services and must not be touched.
+- **Exactly one machine.** `fly.toml:1-11` documents this as an architectural constraint: map state lives in node-local Cachex tables and a node-local Registry. Do not add autoscaling, raise machine counts, or change `[deploy].strategy` from `rolling`. Every deploy is a full restart with a user-visible gap.
+- **Tag format:** `v$(date +%Y%m%d%H%M%S)` — matches the tags the deleted `release.yml` produced (e.g. `v20260805165448`). Do not switch to semver.
+- **Deploy credential:** `FLY_API_TOKEN` is an **environment** secret on `production-deploy`, never a repository secret.
+- **Pin every third-party action to a full commit SHA** with the version in a trailing comment. This matches the deleted `release.yml` and the surviving workflows.
+- **Never cancel a running deploy.** `cancel-in-progress` must be `false` on the deploy job.
+- **Do not modify** `.github/workflows/test.yml`, `build.yml`, `build-develop.yml`, `advanced-test.yml`, `release_actions.yml`, or `flaky-test-detection.yml`. The last four are upstream's.
+
+## A note on verification in this plan
+
+Most of this plan is CI configuration and GitHub/Fly settings, not application code, so there is no unit-test cycle to drive it. Verification is therefore **observation of real effects** — API queries against GitHub, `flyctl` output, and one deliberate production deploy — rather than assertions in a test file. Every task still ends with a concrete, checkable deliverable. Where a step's outcome cannot be verified without deploying, the plan says so instead of implying coverage it does not have.
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `.github/workflows/zoo-deploy.yml` | Create | The entire deploy pipeline: trigger, gate, staleness guard, deploy, tag, bookmark |
+| `docs/ZOO-FORK.md` | Modify | Document the deploy process so it stops being tribal knowledge |
+
+No application code changes. No migrations.
+
+## Task Sequence and Why It Is Ordered This Way
+
+1. **Task 1 — operator prerequisites** (manual). Must precede everything: the workflow references an environment and a secret that must already exist, and Fly's integration must be disconnected before the workflow can deploy without double-deploying.
+2. **Task 2 — the workflow file**, merged to `guarzo/zoo`. Both `workflow_run` and `workflow_dispatch` only see workflow files on the default branch, so the file must be merged before any run is possible.
+3. **Task 3 — validation deploy** via `workflow_dispatch`. Proves the gate, the credential, the deploy, the tag, and the ruleset bypass.
+4. **Task 4 — trigger validation** via a real push. Proves the part `workflow_dispatch` cannot exercise: that a deploy run appears only after a green suite.
+5. **Task 5 — documentation.**
+
+---
+
+### Task 1: Operator prerequisites
+
+**This task is performed by a human in the GitHub and Fly web UIs.** An agent cannot complete it — it requires dashboard access and secret material. An agent executing this plan should present these steps to the operator and wait, then run the verification steps.
+
+**Files:** none — this is configuration in GitHub and Fly.
+
+**Interfaces:**
+- Produces: GitHub Environment `production-deploy` with a required reviewer; environment secret `FLY_API_TOKEN` scoped to it; a repository ruleset on `guarzo/release`; Fly app `wanderer` with no GitHub integration.
+
+- [ ] **Step 1: Record the current deploy state, so a revert is possible**
+
+Run:
+
+```bash
+flyctl releases -a wanderer | head -3
+git rev-parse origin/guarzo/release
+```
+
+Write both down. If this task needs reverting, these are the values to return to.
+
+- [ ] **Step 2: Disconnect Fly's GitHub integration**
+
+In the Fly dashboard: app `wanderer` → Settings → find the GitHub integration/repository connection → disconnect.
+
+This is **first** deliberately. Until Task 2 lands there is no CI deploy path, and `flyctl deploy` from a workstation is the interim one. Doing it last instead would mean the first workflow run deploys twice — two full restarts of the single machine for one release.
+
+- [ ] **Step 3: Verify no push-triggered deploy remains**
+
+Push any trivial commit to `guarzo/release` (or simply wait for the next one) and confirm no new Fly release appears:
+
+```bash
+flyctl releases -a wanderer | head -3
+```
+
+Expected: the release counter is unchanged from Step 1.
+
+If a new release appears, the integration is still connected — stop and resolve that before continuing. Everything downstream assumes exactly one system deploys.
+
+- [ ] **Step 4: Create the `production-deploy` environment**
+
+GitHub → repository Settings → Environments → New environment → name it exactly `production-deploy`.
+
+Do **not** reuse the existing `production` environment. It was created 2026-08-05, most likely by Fly's integration for its own deployment records, and the interaction is untested.
+
+Enable **Required reviewers** and add yourself.
+
+- [ ] **Step 5: Verify the environment exists with protection**
+
+Run:
+
+```bash
+gh api repos/guarzo/wanderer/environments/production-deploy \
+  --jq '{name, protection_rules: [.protection_rules[].type]}'
+```
+
+Expected: `{"name":"production-deploy","protection_rules":["required_reviewers"]}`
+
+If `protection_rules` is empty, the reviewer was not saved — the gate would not gate anything.
+
+- [ ] **Step 6: Create the Fly deploy token**
+
+Run:
+
+```bash
+flyctl tokens create deploy -a wanderer
+```
+
+Copy the full output token, including the `FlyV1 ` prefix.
+
+Deploy-scoped, not a personal org token: a compromised runner must not be able to reach `kills`, `route-builder`, or anything else in the org.
+
+- [ ] **Step 7: Store it as an environment secret**
+
+GitHub → Settings → Environments → `production-deploy` → **Environment secrets** → Add secret → name `FLY_API_TOKEN`, value from Step 6.
+
+**Environment secret, not repository secret.** A repository secret is readable by any workflow on a trusted branch; an environment secret is released only to a job that has cleared the approval gate. The whole premise is that nothing reaches production without approval, and the credential is part of "nothing".
+
+- [ ] **Step 8: Verify the secret is scoped to the environment, not the repo**
+
+Run:
+
+```bash
+gh api repos/guarzo/wanderer/environments/production-deploy/secrets --jq '.secrets[].name'
+gh api repos/guarzo/wanderer/actions/secrets --jq '.secrets[].name'
+```
+
+Expected: `FLY_API_TOKEN` appears in the **first** output and **not** in the second.
+
+If it appears in the second, it was created as a repository secret — delete it there and redo Step 7.
+
+- [ ] **Step 9: Add the `guarzo/release` ruleset with a bypass for Actions**
+
+GitHub → Settings → Rules → Rulesets → New branch ruleset:
+
+- Name: `guarzo/release protected`
+- Enforcement: Active
+- Target branches: include `refs/heads/guarzo/release`
+- Rules: enable **Restrict updates** (blocks direct pushes)
+- **Bypass list: add the `GitHub Actions` bypass actor** (Repository role / integration `GitHub Actions`), mode **Always**
+
+The bypass is load-bearing. Without it the workflow's own push at the final step is rejected — *after* a successful production deploy, leaving production changed but untagged and unbookmarked. Verified for real in Task 3, because it cannot be verified any other way.
+
+- [ ] **Step 10: Verify the ruleset and its bypass**
+
+Run:
+
+```bash
+gh api repos/guarzo/wanderer/rulesets --jq '.[] | {id, name, enforcement}'
+```
+
+Note the id of `guarzo/release protected`, then:
+
+```bash
+gh api repos/guarzo/wanderer/rulesets/<ID> \
+  --jq '{conditions: .conditions.ref_name.include, bypass: [.bypass_actors[] | {actor_type, bypass_mode}], rules: [.rules[].type]}'
+```
+
+Expected: the include list contains `refs/heads/guarzo/release`, `bypass` contains an entry with `"actor_type":"Integration"` (or `RepositoryRole`) and `"bypass_mode":"always"`, and `rules` contains `update`.
+
+- [ ] **Step 11: Confirm a direct push is now refused**
+
+Run:
+
+```bash
+git push origin origin/guarzo/zoo:guarzo/release --force
+```
+
+Expected: **rejected** by the ruleset, with a message naming the rule.
+
+This is the point of the ruleset: the old hard-reset-and-push habit now fails loudly instead of silently doing nothing. A push that *succeeds* here means the ruleset is not protecting the branch — fix it before continuing.
+
+---
+
+### Task 2: The deploy workflow
+
+**Files:**
+- Create: `.github/workflows/zoo-deploy.yml`
+
+**Interfaces:**
+- Consumes: environment `production-deploy`, environment secret `FLY_API_TOKEN`, and the `guarzo/release` ruleset bypass from Task 1.
+- Produces: a workflow named `🚀 Zoo Deploy` triggerable by `workflow_dispatch` (with an optional `ref` input) and by the `🧪 Test Suite` workflow completing on `guarzo/zoo`.
+
+- [ ] **Step 1: Resolve the action SHAs to pin**
+
+Every third-party action is pinned to a full commit SHA. Two are needed:
+
+```bash
+gh api repos/actions/checkout/git/ref/tags/v4 --jq '.object.sha'
+gh api repos/superfly/flyctl-actions/git/ref/tags/master --jq '.object.sha'
+```
+
+If `superfly/flyctl-actions` has no `master` ref, list what it does have:
+
+```bash
+gh api repos/superfly/flyctl-actions/git/refs --jq '.[].ref'
+```
+
+Use the resolved SHAs in Step 2 in place of `<CHECKOUT_SHA>` and `<FLYCTL_SHA>`, keeping the trailing version comment.
+
+- [ ] **Step 2: Write the workflow**
+
+Create `.github/workflows/zoo-deploy.yml`:
+
+```yaml
+name: 🚀 Zoo Deploy
+
+# Deploys are gated on a green test suite, so the trigger is the test workflow
+# finishing — not the push itself. An environment gate does not wait for another
+# workflow's checks, so `on: push` would offer approval while the suite is still
+# running, and a red commit could be approved and shipped.
+on:
+  workflow_run:
+    workflows: ["🧪 Test Suite"]
+    types: [completed]
+    branches: [guarzo/zoo]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag or SHA to deploy (defaults to guarzo/zoo HEAD)'
+        required: false
+        type: string
+
+# Default token is read-only; the job scopes itself up because it pushes a tag
+# and moves a branch.
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to Fly
+    # Any conclusion other than success — failure, cancelled, timed_out,
+    # skipped — produces no deploy run at all. Silence means "not shippable",
+    # never "shipped without checking".
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    # The gate AND the work live in one job on purpose. A protected environment
+    # gates every job that references it, so splitting them would prompt twice;
+    # and FLY_API_TOKEN is an environment secret, readable only by a job inside
+    # the environment. Secrets cannot be passed between jobs.
+    environment: production-deploy
+
+    permissions:
+      contents: write
+
+    # NEVER set cancel-in-progress: true here. Cancellation applies to running
+    # jobs, not just to runs awaiting approval: a merge landing mid-deploy would
+    # kill this job while Fly's builder keeps going, changing production with no
+    # tag and no bookmark. That is the exact failure this workflow exists to
+    # prevent. `false` also serializes deploys onto the single machine.
+    concurrency:
+      group: zoo-deploy-run
+      cancel-in-progress: false
+
+    steps:
+      - name: Resolve the ref to deploy
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_REF: ${{ inputs.ref }}
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            REF="${DISPATCH_REF:-guarzo/zoo}"
+          else
+            # NOT github.ref: under workflow_run that resolves to the default
+            # branch tip at trigger time, which may not be the tested commit.
+            REF="$RUN_SHA"
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "Resolved deploy ref: $REF"
+
+      - name: Check out the ref
+        uses: actions/checkout@<CHECKOUT_SHA> # v4
+        with:
+          ref: ${{ steps.resolve.outputs.ref }}
+          # Annotated tagging needs full history.
+          fetch-depth: 0
+
+      # Runs AFTER approval, which is the entire point: a run may sit pending
+      # for hours while guarzo/zoo moves on. Because runs are never cancelled,
+      # this is what stops an old approval from shipping a superseded commit.
+      - name: Guard against a superseded commit
+        id: guard
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "workflow_dispatch: staleness guard skipped — deploying a ref that is not the branch tip is what rollback is for."
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --quiet origin guarzo/zoo
+          TIP="$(git rev-parse origin/guarzo/zoo)"
+          HERE="$(git rev-parse HEAD)"
+          if [ "$TIP" != "$HERE" ]; then
+            echo "::notice title=Superseded::guarzo/zoo has moved to ${TIP}; this run was approved for ${HERE}. Nothing was deployed."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up flyctl
+        if: steps.guard.outputs.proceed == 'true'
+        uses: superfly/flyctl-actions/setup-flyctl@<FLYCTL_SHA> # v1
+
+      # Fly runs release_command first (fly.toml:29 — migrations against
+      # DIRECT_DATABASE_URL), so a failed migration fails the deploy before new
+      # code serves traffic. Under strategy = 'rolling' (fly.toml:30) this
+      # blocks on the /health check (fly.toml:84-88).
+      - name: Deploy to Fly
+        if: steps.guard.outputs.proceed == 'true'
+        id: deploy
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          flyctl deploy --app wanderer --remote-only
+          # Recorded in the tag message so a tag can be matched to a Fly release
+          # without the dashboard. Best-effort: a lookup failure must not fail a
+          # deploy that already succeeded.
+          VERSION="$(flyctl releases --app wanderer --json | jq -r '.[0].version' || echo unknown)"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      # Everything below runs only after a healthy deploy. That ordering is what
+      # makes the tag mean "this commit served production traffic".
+      - name: Tag the deployed commit
+        if: steps.guard.outputs.proceed == 'true'
+        id: tag
+        run: |
+          set -euo pipefail
+          TAG="v$(date +%Y%m%d%H%M%S)"
+          SHA="$(git rev-parse --short HEAD)"
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          # Idempotent: a workflow_dispatch re-run recovering from a failed
+          # bookmark push must converge, not error.
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists; leaving it alone."
+          else
+            git tag -a "${TAG}" -m "Deployed ${SHA} to Fly app wanderer (release v${{ steps.deploy.outputs.version }})"
+            git push origin "${TAG}"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Tagged ${SHA} as ${TAG}"
+
+      # Force-push: guarzo/zoo is rebased regularly, so this is not a
+      # fast-forward. Requires the ruleset bypass from Task 1 Step 9.
+      - name: Move the guarzo/release bookmark
+        if: steps.guard.outputs.proceed == 'true'
+        run: |
+          set -euo pipefail
+          git push --force origin "HEAD:refs/heads/guarzo/release"
+          echo "guarzo/release now points at $(git rev-parse HEAD)"
+
+      - name: Summarize
+        if: steps.guard.outputs.proceed == 'true'
+        run: |
+          {
+            echo "### Deployed"
+            echo ""
+            echo "- commit: \`$(git rev-parse HEAD)\`"
+            echo "- tag: \`${{ steps.tag.outputs.tag }}\`"
+            echo "- app: \`wanderer\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+```
+
+- [ ] **Step 3: Verify the YAML parses**
+
+Run:
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/zoo-deploy.yml')); print('parses OK')"
+```
+
+Expected: `parses OK`
+
+A YAML error here would otherwise surface as a workflow that silently never appears in the Actions tab.
+
+- [ ] **Step 4: Verify no action is left unpinned**
+
+Run:
+
+```bash
+grep -n "uses:" .github/workflows/zoo-deploy.yml
+```
+
+Expected: every line has a 40-character hex SHA and a trailing `# v…` comment. No `@v4`, no `@master`, and no literal `<CHECKOUT_SHA>` / `<FLYCTL_SHA>` placeholders left from Step 2.
+
+- [ ] **Step 5: Verify the two invariants that carry the most risk**
+
+Run:
+
+```bash
+grep -n -A2 "concurrency:" .github/workflows/zoo-deploy.yml
+grep -n "environment:" .github/workflows/zoo-deploy.yml
+```
+
+Expected: `cancel-in-progress: false`, and exactly one `environment: production-deploy` line.
+
+`cancel-in-progress: true` here would let a merge kill a running deploy. A second `environment:` line would mean a second approval prompt.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/zoo-deploy.yml
+git commit -m "ci: gated deploy workflow for guarzo/zoo
+
+Triggers on a successful Test Suite run, waits on the production-deploy
+environment for approval, then deploys to Fly and tags the commit only after
+the release is healthy. Replaces Fly's branch-watch integration on
+guarzo/release, which now becomes a CI-owned bookmark of what is in production."
+```
+
+- [ ] **Step 7: Open a PR and merge to `guarzo/zoo`**
+
+```bash
+git push -u origin HEAD
+gh pr create --base guarzo/zoo --fill
+```
+
+Merge once `Test Suite` is green.
+
+**This merge is a hard prerequisite for Task 3.** Both `workflow_run` and `workflow_dispatch` only see workflow files that exist on the default branch. Until this is merged, the workflow cannot be triggered at all — it will not even appear in the Actions tab.
+
+- [ ] **Step 8: Verify the workflow is registered**
+
+Run:
+
+```bash
+gh workflow list | grep -i "Zoo Deploy"
+```
+
+Expected: one row, state `active`.
+
+If it does not appear, the file is not on `guarzo/zoo` or the YAML failed to parse server-side.
+
+---
+
+### Task 3: Validation deploy
+
+Proves the pipeline end to end with a deliberate release. This costs one restart of the single machine — cheaper than discovering a broken pipeline during a real change.
+
+**Files:** none.
+
+**Interfaces:**
+- Consumes: the merged workflow from Task 2 and all configuration from Task 1.
+- Produces: confirmation that self-approval works, the credential resolves, the deploy succeeds, and the ruleset bypass permits the bookmark push.
+
+- [ ] **Step 1: Record the pre-deploy state**
+
+```bash
+flyctl releases -a wanderer | head -3
+git fetch origin --tags
+git for-each-ref --sort=-creatordate --format='%(creatordate:iso) %(refname:short)' refs/tags | head -3
+git rev-parse origin/guarzo/release origin/guarzo/zoo
+```
+
+Note the Fly release number, the newest tag, and both branch SHAs.
+
+- [ ] **Step 2: Trigger the workflow**
+
+```bash
+gh workflow run "🚀 Zoo Deploy"
+```
+
+Then find the run:
+
+```bash
+gh run list --workflow "🚀 Zoo Deploy" --limit 1
+```
+
+- [ ] **Step 3: Verify it is waiting for approval, and approve it**
+
+Expected: status `waiting`, not `in_progress` or `completed`.
+
+If it ran straight through without waiting, the environment protection is not attached — stop, and recheck Task 1 Step 5.
+
+Approve it in the GitHub UI (Actions → the run → Review deployments → Approve and deploy).
+
+**This is the first thing to confirm and the most consequential.** If GitHub refuses to let you approve a run you triggered, the gate is unopenable with a single required reviewer, and the design needs a second reviewer or a different protection rule. Everything else is moot if this fails.
+
+- [ ] **Step 4: Watch the run**
+
+```bash
+gh run watch
+```
+
+Expected: all steps green. Note in particular that `Guard against a superseded commit` reports the `workflow_dispatch` skip message rather than a staleness comparison.
+
+- [ ] **Step 5: Verify the deploy actually happened**
+
+```bash
+flyctl releases -a wanderer | head -3
+flyctl status -a wanderer
+```
+
+Expected: the release counter incremented by one from Step 1; the machine is `started` and passing health checks.
+
+- [ ] **Step 6: Verify the tag**
+
+```bash
+git fetch origin --tags
+git for-each-ref --sort=-creatordate --format='%(creatordate:iso) %(refname:short)' refs/tags | head -3
+git rev-parse "$(git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags | head -1)"
+```
+
+Expected: a new `v2026…` tag exists, newer than the one recorded in Step 1, pointing at the SHA that was deployed.
+
+- [ ] **Step 7: Verify the bookmark moved — the step most likely to fail**
+
+```bash
+git fetch origin
+git rev-parse origin/guarzo/release origin/guarzo/zoo
+```
+
+Expected: both print the same SHA.
+
+**If the run failed at `Move the guarzo/release bookmark`,** the ruleset bypass from Task 1 Step 9 is misconfigured. Note that production is *already deployed* at this point — this is the partial-failure state the spec describes. Fix the bypass, then recover by re-running:
+
+```bash
+gh workflow run "🚀 Zoo Deploy" -f ref="$(git rev-parse origin/guarzo/zoo)"
+```
+
+and approving it. The tag step is idempotent and the deploy is a no-op change, at the cost of one more restart.
+
+- [ ] **Step 8: Verify the app is actually serving**
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' https://wanderer.fly.dev/health
+```
+
+Expected: `200`.
+
+Substitute the real public hostname if the app is served from a custom domain.
+
+---
+
+### Task 4: Trigger validation
+
+`workflow_dispatch` cannot exercise the trigger itself. This task proves the property the whole design rests on: a deploy run appears **only** after a green suite.
+
+**Files:** none (uses a throwaway commit).
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–3.
+- Produces: confirmation that `workflow_run` fires correctly and that a red suite produces no deploy run.
+
+- [ ] **Step 1: Push a trivial commit to `guarzo/zoo`**
+
+Any no-op change is fine — a comment or a whitespace fix in a file that does not affect behavior. Merge it the normal way.
+
+- [ ] **Step 2: Verify the deploy run does NOT appear immediately**
+
+Immediately after the merge:
+
+```bash
+gh run list --workflow "🚀 Zoo Deploy" --limit 3
+gh run list --workflow "🧪 Test Suite" --limit 3
+```
+
+Expected: the `Test Suite` run is `in_progress`; **no** new Zoo Deploy run yet.
+
+A Zoo Deploy run appearing here means the trigger is wrong — likely reverted to `on: push` — and a commit could be approved before its tests finish.
+
+- [ ] **Step 3: Verify it appears after the suite goes green**
+
+Once `Test Suite` completes successfully:
+
+```bash
+gh run list --workflow "🚀 Zoo Deploy" --limit 1
+```
+
+Expected: a new run, status `waiting` (awaiting approval).
+
+- [ ] **Step 4: Verify the staleness guard, then leave the run unapproved**
+
+Push a second trivial commit to `guarzo/zoo` and let its suite finish, so two runs are now pending. Approve the **older** one.
+
+Expected: it completes successfully **without deploying**, and the `Guard against a superseded commit` step logs the `Superseded` notice naming the newer tip. The Fly release counter must be unchanged.
+
+This is the behavior that replaces cancellation. If the older run deploys, the guard is broken and stale approvals can ship superseded commits.
+
+- [ ] **Step 5: Approve the newest run, or dismiss both**
+
+Either approve the newest pending run to ship the trivial commits, or cancel the pending runs to leave production where it is. Both are valid; just do not leave the queue ambiguous.
+
+- [ ] **Step 6: Confirm a red suite produces no deploy run**
+
+Push a commit that fails the suite — a deliberately broken test is simplest — to a branch, open a PR, and merge only if you are willing to ship it. **Safer alternative:** verify from history instead, by finding any past `Test Suite` run on `guarzo/zoo` with a `failure` conclusion and confirming no Zoo Deploy run shares its head SHA:
+
+```bash
+gh run list --workflow "🧪 Test Suite" --branch guarzo/zoo --status failure --limit 5 \
+  --json headSha,conclusion,createdAt
+gh run list --workflow "🚀 Zoo Deploy" --limit 20 --json headSha,createdAt
+```
+
+Expected: no overlap between the two `headSha` sets.
+
+Prefer the history check. Deliberately merging a broken commit to the default branch to test a guard is not worth the risk on a fork that is regularly rebased.
+
+---
+
+### Task 5: Document the deploy process
+
+The spec does not require this. It is included because the process being undocumented is what produced the original problem — the reason for the old `guarzo/release` reset had been forgotten, and the tags disappearing went unnoticed for two days.
+
+**Files:**
+- Modify: `docs/ZOO-FORK.md`
+
+**Interfaces:**
+- Consumes: the finished pipeline from Tasks 1–4.
+- Produces: no code interface.
+
+- [ ] **Step 1: Add the section**
+
+Insert into `docs/ZOO-FORK.md` immediately **after** the `## Upstream PR Recommendations` section (currently starting at line 207) and **before** `## Key Files Reference` (currently line 272). That position keeps the seven TOC-listed sections contiguous — `## Key Files Reference` (272) and `## Maintenance Notes` (324) sit below the TOC's range and are not listed in it.
+
+```markdown
+## Deployment
+
+Production is the Fly app `wanderer` (single machine — see the constraint
+comment at the top of `fly.toml`).
+
+**How a change reaches production:**
+
+1. Merge to `guarzo/zoo`.
+2. `🧪 Test Suite` runs. If it fails, nothing else happens.
+3. On success, `🚀 Zoo Deploy` opens a run that **waits for approval** in the
+   `production-deploy` environment. GitHub emails an approval request; the run
+   also shows as pending in the Actions tab.
+4. Approving it deploys to Fly, then tags the commit `v<UTC timestamp>` and
+   moves `guarzo/release` to that commit.
+
+**`guarzo/release` is CI-owned.** It is a bookmark of what is in production, not
+a trigger. Direct pushes are rejected by a ruleset — resetting and pushing it by
+hand does nothing except fail. This is deliberate: it used to be the deploy
+trigger, and the change is easy to forget.
+
+**Nothing deploys without approval**, including a run that has been sitting
+pending. Pending approvals expire after 30 days.
+
+**To roll back**, run `🚀 Zoo Deploy` manually with `ref` set to a previous tag
+and approve it. Note that migrations only run forward — a rollback does not
+revert a schema change.
+
+**Approving a stale run is safe.** If `guarzo/zoo` has moved on since the run
+was created, the workflow exits without deploying and says so.
+```
+
+- [ ] **Step 2: Add it to the table of contents**
+
+In the `## Table of Contents` list at the top of `docs/ZOO-FORK.md` (lines 12–18), add as entry 8:
+
+```markdown
+8. [Deployment](#deployment)
+```
+
+- [ ] **Step 3: Verify the anchor resolves**
+
+Run:
+
+```bash
+grep -n "^## Deployment" docs/ZOO-FORK.md
+grep -n "(#deployment)" docs/ZOO-FORK.md
+```
+
+Expected: both return exactly one line.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/ZOO-FORK.md
+git commit -m "docs: describe the gated deploy process
+
+The old process was undocumented, which is how the guarzo/release reset became
+folklore and how the deploy tags going away went unnoticed."
+```
+
+---
+
+## Rollback for the whole change
+
+Order matters, and it is the reverse of the rollout.
+
+1. **Disable or delete `.github/workflows/zoo-deploy.yml`** first.
+2. Reconnect Fly's GitHub integration to `guarzo/release`.
+3. Delete the `guarzo/release` ruleset.
+4. Optionally delete the `production-deploy` environment and its secret.
+
+Reconnecting Fly while the workflow is still active recreates double deployment in a confusing form: the workflow deploys, then pushes `guarzo/release` as its final step, which triggers the reconnected integration to deploy the same commit again — two restarts, the second apparently uncaused.
+
+`guarzo/release` still tracks the same commits throughout, so the old process resumes unchanged.
+
+## Known risks carried into implementation
+
+- **`flyctl deploy` may not exit non-zero on a failed health check.** The tag and bookmark steps depend on it. If Task 3 shows a deploy reported as successful while the machine is unhealthy, add an explicit `flyctl status` / `/health` poll between the deploy and tag steps.
+- **Steps 2–5 of the job are not atomic.** A failure after the deploy leaves production changed but untagged. Recovery is the idempotent `workflow_dispatch` re-run in Task 3 Step 7, at the cost of one restart.
+- **Self-approval is assumed and verified in Task 3 Step 3.** If it does not hold, the design needs a second reviewer.
+- **`superfly/flyctl-actions/setup-flyctl` is a new dependency** on this repo. If pinning proves awkward, installing flyctl directly (`curl -L https://fly.io/install.sh | sh`) is a viable substitute, but a piped installer is a worse supply-chain posture than a pinned action.

--- a/docs/superpowers/plans/2026-08-07-deploy-approval-gate.md
+++ b/docs/superpowers/plans/2026-08-07-deploy-approval-gate.md
@@ -17,7 +17,7 @@
 - **Exactly one machine.** `fly.toml:1-11` documents this as an architectural constraint: map state lives in node-local Cachex tables and a node-local Registry. Do not add autoscaling, raise machine counts, or change `[deploy].strategy` from `rolling`. Every deploy is a full restart with a user-visible gap.
 - **Tag format:** `v$(date +%Y%m%d%H%M%S)` — matches the tags the deleted `release.yml` produced (e.g. `v20260805165448`). Do not switch to semver.
 - **Deploy credential:** `FLY_API_TOKEN` is an **environment** secret on `production-deploy`, never a repository secret.
-- **Pin every third-party action to a full commit SHA** with the version in a trailing comment. This matches the deleted `release.yml` and the surviving workflows.
+- **Pin every third-party action to a full commit SHA** with the version in a trailing comment. This matches the deleted `release.yml` (`git show ce58765b^:.github/workflows/release.yml`), which pinned all four of its actions. It deliberately does **not** match `test.yml`, which uses floating version tags throughout (`test.yml:34`, `:87`, `:133`, `:210`, `:291`) — this workflow holds a production deploy credential, so it takes the stricter posture rather than the local majority one.
 - **Never cancel a running deploy.** `cancel-in-progress` must be `false` on the deploy job.
 - **Do not modify** `.github/workflows/test.yml`, `build.yml`, `build-develop.yml`, `advanced-test.yml`, `release_actions.yml`, or `flaky-test-detection.yml`. The last four are upstream's.
 
@@ -234,9 +234,12 @@ permissions:
 jobs:
   deploy:
     name: Deploy to Fly
-    # Any conclusion other than success — failure, cancelled, timed_out,
-    # skipped — produces no deploy run at all. Silence means "not shippable",
-    # never "shipped without checking".
+    # workflow_run fires on EVERY completion of the test suite — GitHub offers
+    # no conclusion filter on the trigger itself, so a red suite still creates a
+    # Zoo Deploy run. This condition is what makes it inert: the single job is
+    # skipped, so no environment is referenced, no approval is requested, and no
+    # credential is released. Expect skipped runs in the Actions tab after every
+    # failed suite; that is the mechanism working, not a misfire.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
@@ -339,20 +342,26 @@ jobs:
         id: tag
         run: |
           set -euo pipefail
-          TAG="v$(date +%Y%m%d%H%M%S)"
           SHA="$(git rev-parse --short HEAD)"
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          # Idempotent: a workflow_dispatch re-run recovering from a failed
-          # bookmark push must converge, not error.
-          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
-            echo "Tag ${TAG} already exists; leaving it alone."
+          # Convergent, not merely collision-safe. A recovery re-run (deploy
+          # succeeded, bookmark push failed) must reuse the tag the first run
+          # created, not mint a second one for the same commit — the tag name is
+          # generated from the clock, so checking only the new name would always
+          # miss the existing one.
+          # Tags are present because checkout used fetch-depth: 0.
+          EXISTING="$(git tag --points-at HEAD --list 'v[0-9]*' | head -n1)"
+          if [ -n "${EXISTING}" ]; then
+            TAG="${EXISTING}"
+            echo "Commit is already tagged ${TAG}; reusing it."
           else
+            TAG="v$(date +%Y%m%d%H%M%S)"
             git tag -a "${TAG}" -m "Deployed ${SHA} to Fly app wanderer (release v${{ steps.deploy.outputs.version }})"
             git push origin "${TAG}"
+            echo "Tagged ${SHA} as ${TAG}"
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Tagged ${SHA} as ${TAG}"
 
       # Force-push: guarzo/zoo is rebased regularly, so this is not a
       # fast-forward. Requires the ruleset bypass from Task 1 Step 9.
@@ -433,6 +442,8 @@ Merge once `Test Suite` is green.
 
 **This merge is a hard prerequisite for Task 3.** Both `workflow_run` and `workflow_dispatch` only see workflow files that exist on the default branch. Until this is merged, the workflow cannot be triggered at all — it will not even appear in the Actions tab.
 
+**The merge arms the automatic path immediately.** `test.yml:6-7` triggers on pushes to `guarzo/zoo`, so merging runs the suite; when it goes green, `workflow_run` fires against the now-present workflow file and opens a **pending deploy run for the merge commit**. Step 9 deals with it — do not skip ahead to Task 3 while it is outstanding.
+
 - [ ] **Step 8: Verify the workflow is registered**
 
 Run:
@@ -444,6 +455,36 @@ gh workflow list | grep -i "Zoo Deploy"
 Expected: one row, state `active`.
 
 If it does not appear, the file is not on `guarzo/zoo` or the YAML failed to parse server-side.
+
+- [ ] **Step 9: Cancel the automatic pending run created by the merge**
+
+Wait for `Test Suite` to finish on the merge commit, then:
+
+```bash
+gh run list --workflow "🚀 Zoo Deploy" --limit 3
+```
+
+If a run is in state `waiting`, cancel it:
+
+```bash
+gh run cancel <RUN_ID>
+```
+
+**Do not approve it, and do not leave it pending.** It targets the same SHA Task 3 will dispatch, so the staleness guard cannot tell the two apart — it compares against the branch tip, and both *are* the branch tip. Approving both deploys the same commit twice: two full restarts of the single machine for one release, with the second appearing uncaused.
+
+Cancelling rather than approving keeps Task 3 as the validation run. Task 3 exercises `workflow_dispatch`, which is also the rollback path, so it is the trigger worth proving deliberately; the automatic path gets its own coverage in Task 4.
+
+- [ ] **Step 10: Verify nothing is left pending**
+
+Run:
+
+```bash
+gh run list --workflow "🚀 Zoo Deploy" --limit 5
+```
+
+Expected: no run in state `waiting`. Anything `completed` or `cancelled` is fine.
+
+Task 3 starts from a clean queue, so that the run it approves is unambiguously the one it triggered.
 
 ---
 
@@ -548,19 +589,21 @@ Substitute the real public hostname if the app is served from a custom domain.
 
 ### Task 4: Trigger validation
 
-`workflow_dispatch` cannot exercise the trigger itself. This task proves the property the whole design rests on: a deploy run appears **only** after a green suite.
+`workflow_dispatch` cannot exercise the trigger itself. This task proves the property the whole design rests on: a deploy run **requests approval** only after a green suite.
+
+Note the precise claim. A red suite does not suppress the run — `workflow_run` has no conclusion filter, so GitHub creates a Zoo Deploy run for every completion and the job-level `if:` skips it. What a red suite suppresses is the approval request and everything downstream of it. The verifications below check for that, not for the absence of a run.
 
 **Files:** none (uses a throwaway commit).
 
 **Interfaces:**
 - Consumes: everything from Tasks 1–3.
-- Produces: confirmation that `workflow_run` fires correctly and that a red suite produces no deploy run.
+- Produces: confirmation that `workflow_run` fires correctly and that a red suite produces a skipped run rather than an approvable one.
 
 - [ ] **Step 1: Push a trivial commit to `guarzo/zoo`**
 
 Any no-op change is fine — a comment or a whitespace fix in a file that does not affect behavior. Merge it the normal way.
 
-- [ ] **Step 2: Verify the deploy run does NOT appear immediately**
+- [ ] **Step 2: Verify no deploy run appears while the suite is still running**
 
 Immediately after the merge:
 
@@ -571,7 +614,7 @@ gh run list --workflow "🧪 Test Suite" --limit 3
 
 Expected: the `Test Suite` run is `in_progress`; **no** new Zoo Deploy run yet.
 
-A Zoo Deploy run appearing here means the trigger is wrong — likely reverted to `on: push` — and a commit could be approved before its tests finish.
+`workflow_run` fires on `completed`, so nothing should exist until the suite finishes. A Zoo Deploy run appearing here means the trigger is wrong — likely reverted to `on: push` — and a commit could be approved before its tests finish.
 
 - [ ] **Step 3: Verify it appears after the suite goes green**
 
@@ -595,19 +638,28 @@ This is the behavior that replaces cancellation. If the older run deploys, the g
 
 Either approve the newest pending run to ship the trivial commits, or cancel the pending runs to leave production where it is. Both are valid; just do not leave the queue ambiguous.
 
-- [ ] **Step 6: Confirm a red suite produces no deploy run**
+- [ ] **Step 6: Confirm a red suite produces a skipped run, not an approvable one**
 
-Push a commit that fails the suite — a deliberately broken test is simplest — to a branch, open a PR, and merge only if you are willing to ship it. **Safer alternative:** verify from history instead, by finding any past `Test Suite` run on `guarzo/zoo` with a `failure` conclusion and confirming no Zoo Deploy run shares its head SHA:
+Verify from history rather than by breaking the suite deliberately. Find past `Test Suite` runs on `guarzo/zoo` that concluded `failure`, then check what the corresponding Zoo Deploy runs did:
 
 ```bash
 gh run list --workflow "🧪 Test Suite" --branch guarzo/zoo --status failure --limit 5 \
   --json headSha,conclusion,createdAt
-gh run list --workflow "🚀 Zoo Deploy" --limit 20 --json headSha,createdAt
+gh run list --workflow "🚀 Zoo Deploy" --limit 20 \
+  --json headSha,conclusion,status,createdAt
 ```
 
-Expected: no overlap between the two `headSha` sets.
+Expected: for any head SHA appearing in both lists, the Zoo Deploy run has conclusion `skipped` (or `success` with the job skipped) and **never** reached `waiting`. Confirm on one such run:
 
-Prefer the history check. Deliberately merging a broken commit to the default branch to test a guard is not worth the risk on a fork that is regularly rebased.
+```bash
+gh run view <RUN_ID> --json jobs --jq '.jobs[] | {name, conclusion}'
+```
+
+Expected: the `Deploy to Fly` job's conclusion is `skipped`.
+
+A run in state `waiting` against a red SHA is the failure that matters — it means the `if:` condition is wrong and a red commit is one click from production. A *skipped* run against a red SHA is the design working.
+
+**If no failed `Test Suite` run exists on `guarzo/zoo` yet,** this check has nothing to read. Record that it was not exercised rather than marking it done; do not merge a deliberately broken commit to the default branch to manufacture one, on a fork that is regularly rebased.
 
 ---
 
@@ -635,7 +687,9 @@ comment at the top of `fly.toml`).
 **How a change reaches production:**
 
 1. Merge to `guarzo/zoo`.
-2. `🧪 Test Suite` runs. If it fails, nothing else happens.
+2. `🧪 Test Suite` runs. If it fails, a `🚀 Zoo Deploy` run still appears in the
+   Actions tab but its only job is **skipped** — no approval is requested and
+   nothing can be deployed. Skipped deploy runs after a red suite are normal.
 3. On success, `🚀 Zoo Deploy` opens a run that **waits for approval** in the
    `production-deploy` environment. GitHub emails an approval request; the run
    also shows as pending in the Actions tab.

--- a/docs/superpowers/plans/2026-08-07-deploy-approval-gate.md
+++ b/docs/superpowers/plans/2026-08-07-deploy-approval-gate.md
@@ -16,7 +16,7 @@
 - **Fly app name:** `wanderer`. Never `wanderer-*`; the other Fly apps (`kills`, `route-builder`) are separate services and must not be touched.
 - **Exactly one machine.** `fly.toml:1-11` documents this as an architectural constraint: map state lives in node-local Cachex tables and a node-local Registry. Do not add autoscaling, raise machine counts, or change `[deploy].strategy` from `rolling`. Every deploy is a full restart with a user-visible gap.
 - **Tag format:** `v$(date +%Y%m%d%H%M%S)` — matches the tags the deleted `release.yml` produced (e.g. `v20260805165448`). Do not switch to semver.
-- **Deploy credential:** `FLY_API_TOKEN` is an **environment** secret on `production-deploy`, never a repository secret.
+- **Deploy credential:** `FLY_DEPLOY_TOKEN` is an **environment** secret on `production-deploy`, never a repository secret. The name is deliberately not `FLY_API_TOKEN`: `advanced-test.yml` reads an ungated secret of that name for the separate `wanderer-test` app. The workflow maps it onto the `FLY_API_TOKEN` env var that `flyctl` itself reads.
 - **Pin every third-party action to a full commit SHA** with the version in a trailing comment. This matches the deleted `release.yml` (`git show ce58765b^:.github/workflows/release.yml`), which pinned all four of its actions. It deliberately does **not** match `test.yml`, which uses floating version tags throughout (`test.yml:34`, `:87`, `:133`, `:210`, `:291`) — this workflow holds a production deploy credential, so it takes the stricter posture rather than the local majority one.
 - **Never cancel a running deploy.** `cancel-in-progress` must be `false` on the deploy job.
 - **Do not modify** `.github/workflows/test.yml`, `build.yml`, `build-develop.yml`, `advanced-test.yml`, `release_actions.yml`, or `flaky-test-detection.yml`. The last four are upstream's.
@@ -51,7 +51,7 @@ No application code changes. No migrations.
 **Files:** none — this is configuration in GitHub and Fly.
 
 **Interfaces:**
-- Produces: GitHub Environment `production-deploy` with a required reviewer; environment secret `FLY_API_TOKEN` scoped to it; a repository ruleset freezing `guarzo/release`; Fly app `wanderer` with no GitHub integration.
+- Produces: GitHub Environment `production-deploy` with a required reviewer; environment secret `FLY_DEPLOY_TOKEN` scoped to it; a repository ruleset freezing `guarzo/release`; Fly app `wanderer` with no GitHub integration.
 
 - [ ] **Step 1: Record the current deploy state, so a revert is possible**
 
@@ -117,7 +117,7 @@ Deploy-scoped, not a personal org token: a compromised runner must not be able t
 
 - [ ] **Step 7: Store it as an environment secret**
 
-GitHub → Settings → Environments → `production-deploy` → **Environment secrets** → Add secret → name `FLY_API_TOKEN`, value from Step 6.
+GitHub → Settings → Environments → `production-deploy` → **Environment secrets** → Add secret → name `FLY_DEPLOY_TOKEN`, value from Step 6.
 
 **Environment secret, not repository secret.** A repository secret is readable by any workflow on a trusted branch; an environment secret is released only to a job that has cleared the approval gate. The whole premise is that nothing reaches production without approval, and the credential is part of "nothing".
 
@@ -130,7 +130,7 @@ gh api repos/guarzo/wanderer/environments/production-deploy/secrets --jq '.secre
 gh api repos/guarzo/wanderer/actions/secrets --jq '.secrets[].name'
 ```
 
-Expected: `FLY_API_TOKEN` appears in the **first** output and **not** in the second.
+Expected: `FLY_DEPLOY_TOKEN` appears in the **first** output and **not** in the second.
 
 If it appears in the second, it was created as a repository secret — delete it there and redo Step 7.
 
@@ -200,7 +200,7 @@ gh api repos/guarzo/wanderer/environments/production --method DELETE
 - Create: `.github/workflows/zoo-deploy.yml`
 
 **Interfaces:**
-- Consumes: environment `production-deploy` and environment secret `FLY_API_TOKEN` from Task 1.
+- Consumes: environment `production-deploy` and environment secret `FLY_DEPLOY_TOKEN` from Task 1.
 - Produces: a workflow named `🚀 Zoo Deploy` triggerable by `workflow_dispatch` (with an optional `ref` input) and by the `🧪 Test Suite` workflow completing on `guarzo/zoo`.
 
 - [ ] **Step 1: Resolve the action SHAs to pin**
@@ -273,7 +273,7 @@ jobs:
 
     # The gate AND the work live in one job on purpose. A protected environment
     # gates every job that references it, so splitting them would prompt twice;
-    # and FLY_API_TOKEN is an environment secret, readable only by a job inside
+    # and FLY_DEPLOY_TOKEN is an environment secret, readable only by a job inside
     # the environment. Secrets cannot be passed between jobs.
     environment: production-deploy
 
@@ -361,7 +361,12 @@ jobs:
         if: steps.guard.outputs.proceed == 'true'
         id: deploy
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          # Repository secret name is FLY_DEPLOY_TOKEN, deliberately NOT
+          # FLY_API_TOKEN: advanced-test.yml reads a secret of that name with no
+          # environment gate, for the separate wanderer-test app. Distinct names
+          # mean this production credential can never be picked up there. The
+          # env var flyctl itself reads is still FLY_API_TOKEN.
+          FLY_API_TOKEN: ${{ secrets.FLY_DEPLOY_TOKEN }}
         run: |
           set -euo pipefail
           flyctl deploy --app wanderer --remote-only

--- a/docs/superpowers/plans/2026-08-07-deploy-approval-gate.md
+++ b/docs/superpowers/plans/2026-08-07-deploy-approval-gate.md
@@ -4,7 +4,7 @@
 
 **Goal:** Replace Fly's branch-watch auto-deploy with a GitHub Actions workflow that deploys `guarzo/zoo` to Fly only after a green test suite and an explicit human approval, then tags the deployed commit.
 
-**Architecture:** One workflow (`.github/workflows/zoo-deploy.yml`) with a single gated job. It triggers on the `🧪 Test Suite` workflow succeeding on `guarzo/zoo`, waits on the `production-deploy` GitHub Environment for approval, verifies the commit is still current, runs `flyctl deploy`, and only then tags the SHA and moves `guarzo/release` to it as a bookmark. Fly's own GitHub integration is disconnected — the workflow replaces it rather than running alongside it.
+**Architecture:** One workflow (`.github/workflows/zoo-deploy.yml`) with a single gated job. It triggers on the `🧪 Test Suite` workflow succeeding on `guarzo/zoo`, waits on the `production-deploy` GitHub Environment for approval, verifies the commit is still current, runs `flyctl deploy`, and only then tags the SHA. The tag is the sole record of what is in production; `guarzo/release` is retired and frozen rather than kept as a bookmark. Fly's own GitHub integration is disconnected — the workflow replaces it rather than running alongside it.
 
 **Tech Stack:** GitHub Actions, GitHub Environments (deployment protection rules), GitHub repository rulesets, Fly.io (`flyctl`), Docker build on Fly remote builders.
 
@@ -29,7 +29,7 @@ Most of this plan is CI configuration and GitHub/Fly settings, not application c
 
 | File | Status | Responsibility |
 |---|---|---|
-| `.github/workflows/zoo-deploy.yml` | Create | The entire deploy pipeline: trigger, gate, staleness guard, deploy, tag, bookmark |
+| `.github/workflows/zoo-deploy.yml` | Create | The entire deploy pipeline: trigger, gate, staleness guard, deploy, tag |
 | `docs/ZOO-FORK.md` | Modify | Document the deploy process so it stops being tribal knowledge |
 
 No application code changes. No migrations.
@@ -38,7 +38,7 @@ No application code changes. No migrations.
 
 1. **Task 1 — operator prerequisites** (manual). Must precede everything: the workflow references an environment and a secret that must already exist, and Fly's integration must be disconnected before the workflow can deploy without double-deploying.
 2. **Task 2 — the workflow file**, merged to `guarzo/zoo`. Both `workflow_run` and `workflow_dispatch` only see workflow files on the default branch, so the file must be merged before any run is possible.
-3. **Task 3 — validation deploy** via `workflow_dispatch`. Proves the gate, the credential, the deploy, the tag, and the ruleset bypass.
+3. **Task 3 — validation deploy** via `workflow_dispatch`. Proves the gate, the credential, the deploy, and the tag.
 4. **Task 4 — trigger validation** via a real push. Proves the part `workflow_dispatch` cannot exercise: that a deploy run appears only after a green suite.
 5. **Task 5 — documentation.**
 
@@ -51,7 +51,7 @@ No application code changes. No migrations.
 **Files:** none — this is configuration in GitHub and Fly.
 
 **Interfaces:**
-- Produces: GitHub Environment `production-deploy` with a required reviewer; environment secret `FLY_API_TOKEN` scoped to it; a repository ruleset on `guarzo/release`; Fly app `wanderer` with no GitHub integration.
+- Produces: GitHub Environment `production-deploy` with a required reviewer; environment secret `FLY_API_TOKEN` scoped to it; a repository ruleset freezing `guarzo/release`; Fly app `wanderer` with no GitHub integration.
 
 - [ ] **Step 1: Record the current deploy state, so a revert is possible**
 
@@ -134,19 +134,28 @@ Expected: `FLY_API_TOKEN` appears in the **first** output and **not** in the sec
 
 If it appears in the second, it was created as a repository secret — delete it there and redo Step 7.
 
-- [ ] **Step 9: Add the `guarzo/release` ruleset with a bypass for Actions**
+- [ ] **Step 9: Freeze `guarzo/release` with a ruleset**
+
+`guarzo/release` is retired: the workflow does not push it, and nothing reads it. The ruleset exists solely so the old hard-reset-and-push habit fails loudly instead of silently doing nothing.
 
 GitHub → Settings → Rules → Rulesets → New branch ruleset:
 
-- Name: `guarzo/release protected`
+- Name: `guarzo/release frozen`
 - Enforcement: Active
 - Target branches: include `refs/heads/guarzo/release`
-- Rules: enable **Restrict updates** (blocks direct pushes)
-- **Bypass list: add the `GitHub Actions` bypass actor** (Repository role / integration `GitHub Actions`), mode **Always**
+- Rules: enable **Restrict updates** and **Restrict deletions**
+- **Bypass list: empty.** Nothing needs to write to this branch, including Actions.
 
-The bypass is load-bearing. Without it the workflow's own push at the final step is rejected — *after* a successful production deploy, leaving production changed but untagged and unbookmarked. Verified for real in Task 3, because it cannot be verified any other way.
+The equivalent API call, from `.superpowers/sdd/2026-08-07-deploy-approval-gate/release-ruleset.json`:
 
-- [ ] **Step 10: Verify the ruleset and its bypass**
+```bash
+gh api repos/guarzo/wanderer/rulesets --method POST \
+  --input .superpowers/sdd/2026-08-07-deploy-approval-gate/release-ruleset.json
+```
+
+**Do not add a `GitHub Actions` bypass actor.** It is not needed here, and it is not available: `guarzo/wanderer` is user-owned, and GitHub rejects the `Integration` actor type on user-owned repositories with *"Actor GitHub Actions integration must be part of the ruleset source or owner organization"* (verified, HTTP 422).
+
+- [ ] **Step 10: Verify the ruleset**
 
 Run:
 
@@ -154,14 +163,14 @@ Run:
 gh api repos/guarzo/wanderer/rulesets --jq '.[] | {id, name, enforcement}'
 ```
 
-Note the id of `guarzo/release protected`, then:
+Note the id of `guarzo/release frozen`, then:
 
 ```bash
 gh api repos/guarzo/wanderer/rulesets/<ID> \
-  --jq '{conditions: .conditions.ref_name.include, bypass: [.bypass_actors[] | {actor_type, bypass_mode}], rules: [.rules[].type]}'
+  --jq '{conditions: .conditions.ref_name.include, bypass: .bypass_actors, rules: [.rules[].type], can_bypass: .current_user_can_bypass}'
 ```
 
-Expected: the include list contains `refs/heads/guarzo/release`, `bypass` contains an entry with `"actor_type":"Integration"` (or `RepositoryRole`) and `"bypass_mode":"always"`, and `rules` contains `update`.
+Expected: the include list contains `refs/heads/guarzo/release`, `bypass` is `[]`, `rules` contains `update` and `deletion`, and `can_bypass` is `"never"`.
 
 - [ ] **Step 11: Confirm a direct push is now refused**
 
@@ -173,7 +182,15 @@ git push origin origin/guarzo/zoo:guarzo/release --force
 
 Expected: **rejected** by the ruleset, with a message naming the rule.
 
-This is the point of the ruleset: the old hard-reset-and-push habit now fails loudly instead of silently doing nothing. A push that *succeeds* here means the ruleset is not protecting the branch — fix it before continuing.
+A push that *succeeds* here means the ruleset is not protecting the branch — fix it before continuing.
+
+- [ ] **Step 12: Delete the unused `production` environment (optional)**
+
+An empty, unprotected environment named `production` exists alongside `production-deploy`. Nothing references it. Two similarly named environments where only one gates anything is a footgun during an incident, so delete it:
+
+```bash
+gh api repos/guarzo/wanderer/environments/production --method DELETE
+```
 
 ---
 
@@ -183,7 +200,7 @@ This is the point of the ruleset: the old hard-reset-and-push habit now fails lo
 - Create: `.github/workflows/zoo-deploy.yml`
 
 **Interfaces:**
-- Consumes: environment `production-deploy`, environment secret `FLY_API_TOKEN`, and the `guarzo/release` ruleset bypass from Task 1.
+- Consumes: environment `production-deploy` and environment secret `FLY_API_TOKEN` from Task 1.
 - Produces: a workflow named `🚀 Zoo Deploy` triggerable by `workflow_dispatch` (with an optional `ref` input) and by the `🧪 Test Suite` workflow completing on `guarzo/zoo`.
 
 - [ ] **Step 1: Resolve the action SHAs to pin**
@@ -226,8 +243,9 @@ on:
         required: false
         type: string
 
-# Default token is read-only; the job scopes itself up because it pushes a tag
-# and moves a branch.
+# Default token is read-only; the job scopes itself up because it pushes a tag.
+# The tag is the ONLY record of what is in production — no branch tracks it, by
+# design (see docs/ZOO-FORK.md, "Deployment").
 permissions:
   contents: read
 
@@ -265,8 +283,9 @@ jobs:
     # NEVER set cancel-in-progress: true here. Cancellation applies to running
     # jobs, not just to runs awaiting approval: a merge landing mid-deploy would
     # kill this job while Fly's builder keeps going, changing production with no
-    # tag and no bookmark. That is the exact failure this workflow exists to
-    # prevent. `false` also serializes deploys onto the single machine.
+    # tag — and the tag is the only record of what is live. That is the exact
+    # failure this workflow exists to prevent. `false` also serializes deploys
+    # onto the single machine.
     concurrency:
       group: zoo-deploy-run
       cancel-in-progress: false
@@ -365,7 +384,7 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           # Convergent, not merely collision-safe. A recovery re-run (deploy
-          # succeeded, bookmark push failed) must reuse the tag the first run
+          # succeeded, tag push failed) must reuse the tag the first run
           # created, not mint a second one for the same commit — the tag name is
           # generated from the clock, so checking only the new name would always
           # miss the existing one.
@@ -385,15 +404,6 @@ jobs:
             echo "Tagged ${SHA} as ${TAG}"
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-
-      # Force-push: guarzo/zoo is rebased regularly, so this is not a
-      # fast-forward. Requires the ruleset bypass from Task 1 Step 9.
-      - name: Move the guarzo/release bookmark
-        if: steps.guard.outputs.proceed == 'true'
-        run: |
-          set -euo pipefail
-          git push --force origin "HEAD:refs/heads/guarzo/release"
-          echo "guarzo/release now points at $(git rev-parse HEAD)"
 
       - name: Summarize
         if: steps.guard.outputs.proceed == 'true'
@@ -461,7 +471,8 @@ git commit -m "ci: gated deploy workflow for guarzo/zoo
 Triggers on a successful Test Suite run, waits on the production-deploy
 environment for approval, then deploys to Fly and tags the commit only after
 the release is healthy. Replaces Fly's branch-watch integration on
-guarzo/release, which now becomes a CI-owned bookmark of what is in production."
+guarzo/release, which is retired — the deploy tag is now the record of what is
+in production."
 ```
 
 - [ ] **Step 7: Open a PR and merge to `guarzo/zoo`**
@@ -529,7 +540,7 @@ Proves the pipeline end to end with a deliberate release. This costs one restart
 
 **Interfaces:**
 - Consumes: the merged workflow from Task 2 and all configuration from Task 1.
-- Produces: confirmation that self-approval works, the credential resolves, the deploy succeeds, and the ruleset bypass permits the bookmark push.
+- Produces: confirmation that self-approval works, the credential resolves, the deploy succeeds, and the commit is tagged.
 
 - [ ] **Step 1: Record the pre-deploy state**
 
@@ -591,22 +602,22 @@ git rev-parse "$(git for-each-ref --sort=-creatordate --format='%(refname:short)
 
 Expected: a new `v2026…` tag exists, newer than the one recorded in Step 1, pointing at the SHA that was deployed.
 
-- [ ] **Step 7: Verify the bookmark moved — the step most likely to fail**
+- [ ] **Step 7: Verify the tag push is the only ref write — the step most likely to fail**
 
 ```bash
-git fetch origin
-git rev-parse origin/guarzo/release origin/guarzo/zoo
+git fetch origin --tags --prune
+git rev-parse origin/guarzo/release
 ```
 
-Expected: both print the same SHA.
+Expected: `guarzo/release` is **unchanged** from the SHA recorded in Step 1. The workflow no longer touches it, and the Task 1 Step 9 ruleset rejects any push to it.
 
-**If the run failed at `Move the guarzo/release bookmark`,** the ruleset bypass from Task 1 Step 9 is misconfigured. Note that production is *already deployed* at this point — this is the partial-failure state the spec describes. Fix the bypass, then recover by re-running:
+**If the run failed at `Tag the deployed commit`,** production is *already deployed* at this point and the deployed commit carries no tag — the partial-failure state the spec describes, and now the only one, since the tag is the sole production record. The likely cause is the job's `permissions: contents: write` not taking effect. Fix it, then recover by re-running against the explicit SHA:
 
 ```bash
 gh workflow run "🚀 Zoo Deploy" -f ref="$(git rev-parse origin/guarzo/zoo)"
 ```
 
-and approving it. The tag step is idempotent and the deploy is a no-op change, at the cost of one more restart.
+and approving it. The tag step is convergent and the deploy is a no-op change, at the cost of one more restart.
 
 - [ ] **Step 8: Verify the app is actually serving**
 
@@ -726,13 +737,21 @@ comment at the top of `fly.toml`).
 3. On success, `🚀 Zoo Deploy` opens a run that **waits for approval** in the
    `production-deploy` environment. GitHub emails an approval request; the run
    also shows as pending in the Actions tab.
-4. Approving it deploys to Fly, then tags the commit `v<UTC timestamp>` and
-   moves `guarzo/release` to that commit.
+4. Approving it deploys to Fly, then tags the commit `v<UTC timestamp>`.
 
-**`guarzo/release` is CI-owned.** It is a bookmark of what is in production, not
-a trigger. Direct pushes are rejected by a ruleset — resetting and pushing it by
-hand does nothing except fail. This is deliberate: it used to be the deploy
-trigger, and the change is easy to forget.
+**The newest `v20*` tag is the record of what is in production.** No branch
+tracks it. To see what you have written but not yet deployed:
+
+```bash
+git fetch origin --tags
+git log --oneline "$(git tag -l 'v20*' | sort | tail -1)"..guarzo/zoo
+```
+
+**`guarzo/release` is retired.** It used to be the deploy trigger — hard-resetting
+and pushing it was how you shipped. It no longer moves, deploys nothing, and is
+frozen by a ruleset that rejects pushes to it, so the old habit fails loudly
+instead of silently doing nothing. It survives only as a marker of where the
+old process stopped.
 
 **Nothing deploys without approval**, including a run that has been sitting
 pending. Pending approvals expire after 30 days.
@@ -781,17 +800,18 @@ folklore and how the deploy tags going away went unnoticed."
 Order matters, and it is the reverse of the rollout.
 
 1. **Disable or delete `.github/workflows/zoo-deploy.yml`** first.
-2. Reconnect Fly's GitHub integration to `guarzo/release`.
-3. Delete the `guarzo/release` ruleset.
-4. Optionally delete the `production-deploy` environment and its secret.
+2. Delete the `guarzo/release frozen` ruleset, so the branch can move again.
+3. Hard-reset `guarzo/release` to `guarzo/zoo` and push it — it has been frozen since Task 1, so it is stale by however many deploys have happened.
+4. Reconnect Fly's GitHub integration to `guarzo/release`.
+5. Optionally delete the `production-deploy` environment and its secret.
 
-Reconnecting Fly while the workflow is still active recreates double deployment in a confusing form: the workflow deploys, then pushes `guarzo/release` as its final step, which triggers the reconnected integration to deploy the same commit again — two restarts, the second apparently uncaused.
+Steps 2 and 3 must precede step 4. Reconnecting Fly first would make the next hard-reset push deploy whatever `guarzo/release` was frozen at — an old commit — rather than current `guarzo/zoo`.
 
-`guarzo/release` still tracks the same commits throughout, so the old process resumes unchanged.
+Unlike the earlier design that kept `guarzo/release` as a live bookmark, this rollback requires an explicit catch-up push: the branch stopped tracking production the moment the workflow landed. The newest `v20*` tag records what was actually deployed in the interim.
 
 ## Known risks carried into implementation
 
-- **`flyctl deploy` may not exit non-zero on a failed health check.** The tag and bookmark steps depend on it. If Task 3 shows a deploy reported as successful while the machine is unhealthy, add an explicit `flyctl status` / `/health` poll between the deploy and tag steps.
+- **`flyctl deploy` may not exit non-zero on a failed health check.** The tag step depends on it. If Task 3 shows a deploy reported as successful while the machine is unhealthy, add an explicit `flyctl status` / `/health` poll between the deploy and tag steps.
 - **Steps 2–5 of the job are not atomic.** A failure after the deploy leaves production changed but untagged. Recovery is the idempotent `workflow_dispatch` re-run in Task 3 Step 7, at the cost of one restart.
 - **Self-approval is assumed and verified in Task 3 Step 3.** If it does not hold, the design needs a second reviewer.
 - **`superfly/flyctl-actions/setup-flyctl` is a new dependency** on this repo. If pinning proves awkward, installing flyctl directly (`curl -L https://fly.io/install.sh | sh`) is a viable substitute, but a piped installer is a worse supply-chain posture than a pinned action.

--- a/docs/superpowers/plans/2026-08-07-deploy-approval-gate.md
+++ b/docs/superpowers/plans/2026-08-07-deploy-approval-gate.md
@@ -240,9 +240,17 @@ jobs:
     # skipped, so no environment is referenced, no approval is requested, and no
     # credential is released. Expect skipped runs in the Actions tab after every
     # failed suite; that is the mechanism working, not a misfire.
+    #
+    # The `event == 'push'` clause guards a narrower hole: workflow_run's
+    # `branches:` filter (above) matches the triggering run's head_branch, and
+    # this is a public fork whose default branch is itself named `guarzo/zoo`.
+    # Without this clause, a fork PR whose source branch is also named
+    # `guarzo/zoo` would match the filter and, if its tests pass, raise a
+    # production-deploy approval request for a commit the requester controls.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
 
     # The gate AND the work live in one job on purpose. A protected environment
@@ -308,6 +316,15 @@ jobs:
           HERE="$(git rev-parse HEAD)"
           if [ "$TIP" != "$HERE" ]; then
             echo "::notice title=Superseded::guarzo/zoo has moved to ${TIP}; this run was approved for ${HERE}. Nothing was deployed."
+            # Also write to the job summary, not just the notice: a notice
+            # requires opening the run to see, so without this the summary
+            # pane stays blank and a superseded run reads identically to a
+            # real deploy in the Actions list.
+            {
+              echo "### Not deployed — superseded"
+              echo ""
+              echo "guarzo/zoo has moved to \`${TIP}\`; this run was approved for \`${HERE}\`. Nothing was deployed."
+            } >> "$GITHUB_STEP_SUMMARY"
             echo "proceed=false" >> "$GITHUB_OUTPUT"
           else
             echo "proceed=true" >> "$GITHUB_OUTPUT"
@@ -340,6 +357,8 @@ jobs:
       - name: Tag the deployed commit
         if: steps.guard.outputs.proceed == 'true'
         id: tag
+        env:
+          DEPLOY_VERSION: ${{ steps.deploy.outputs.version }}
         run: |
           set -euo pipefail
           SHA="$(git rev-parse --short HEAD)"
@@ -351,13 +370,17 @@ jobs:
           # generated from the clock, so checking only the new name would always
           # miss the existing one.
           # Tags are present because checkout used fetch-depth: 0.
-          EXISTING="$(git tag --points-at HEAD --list 'v[0-9]*' | head -n1)"
+          # 'v20[0-9]*' (not 'v[0-9]*') excludes upstream semver release tags
+          # like v1.2.3 — git tag sorts lexicographically, so head -n1 would
+          # otherwise prefer an upstream tag over a timestamped deploy tag on
+          # any commit carrying both.
+          EXISTING="$(git tag --points-at HEAD --list 'v20[0-9]*' | head -n1)"
           if [ -n "${EXISTING}" ]; then
             TAG="${EXISTING}"
             echo "Commit is already tagged ${TAG}; reusing it."
           else
-            TAG="v$(date +%Y%m%d%H%M%S)"
-            git tag -a "${TAG}" -m "Deployed ${SHA} to Fly app wanderer (release v${{ steps.deploy.outputs.version }})"
+            TAG="v$(date -u +%Y%m%d%H%M%S)"
+            git tag -a "${TAG}" -m "Deployed ${SHA} to Fly app wanderer (release v${DEPLOY_VERSION})"
             git push origin "${TAG}"
             echo "Tagged ${SHA} as ${TAG}"
           fi
@@ -374,15 +397,25 @@ jobs:
 
       - name: Summarize
         if: steps.guard.outputs.proceed == 'true'
+        env:
+          DEPLOY_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           {
             echo "### Deployed"
             echo ""
             echo "- commit: \`$(git rev-parse HEAD)\`"
-            echo "- tag: \`${{ steps.tag.outputs.tag }}\`"
+            echo "- tag: \`${DEPLOY_TAG}\`"
             echo "- app: \`wanderer\`"
           } >> "$GITHUB_STEP_SUMMARY"
 ```
+
+**Note (final review, 2026-08-07):** the workflow above reflects fixes from the
+final whole-branch review — the `event == 'push'` clause on the job `if:` (I-3),
+writing the staleness-guard outcome to `$GITHUB_STEP_SUMMARY` (I-1), narrowing
+the tag glob to `'v20[0-9]*'` (M-2), routing `steps.deploy.outputs.version` and
+`steps.tag.outputs.tag` through `env:` (M-1), and adding `-u` to the tag
+timestamp's `date` call. See
+`.superpowers/sdd/2026-08-07-deploy-approval-gate/final-review.md`.
 
 - [ ] **Step 3: Verify the YAML parses**
 

--- a/docs/superpowers/specs/2026-08-07-deploy-approval-gate-design.md
+++ b/docs/superpowers/specs/2026-08-07-deploy-approval-gate-design.md
@@ -123,16 +123,27 @@ checks. `Test Suite` is a separate workflow (`.github/workflows/test.yml`) whose
 deploy run. On a plain `push` trigger the approval prompt would appear
 immediately, and a commit whose tests were still running, or already red, could
 be approved and shipped. `workflow_run` makes the dependency real: a red suite
-produces no deploy run at all.
+can never reach the approval prompt.
 
 `workflow_run` evaluates its workflow file from the default branch, which is
 `guarzo/zoo` — the branch being deployed — so this trigger works without extra
 configuration.
 
-**Failure and cancellation of the test run** are handled by the same condition:
-any conclusion other than `success` (`failure`, `cancelled`, `timed_out`,
-`skipped`) produces no deploy run. Silence therefore means "not shippable",
-never "shipped without checking".
+**Failure and cancellation of the test run** are handled by the job's `if:`
+condition: any conclusion other than `success` (`failure`, `cancelled`,
+`timed_out`, `skipped`) skips the job.
+
+Note precisely what this does and does not do. `workflow_run` offers **no
+conclusion filter on the trigger itself**, so GitHub creates a deploy run for
+*every* completion of the test suite, red or green. The `if:` condition operates
+one level down: it skips the single job, so no environment is referenced, no
+approval is requested, and the deploy credential is never released.
+
+The observable consequence is that the Actions tab accumulates **skipped** deploy
+runs after failed suites. That is the mechanism working. The invariant is "a red
+commit cannot reach the approval prompt", not "a red commit produces no run" —
+the latter is not achievable with this trigger, and any validation written
+against it would fail on a correct implementation.
 
 ### Concurrency: one non-cancellable job, with a staleness guard
 
@@ -237,11 +248,12 @@ made recoverable and loud:
 - **Bounded blast radius.** Only the tag/bookmark steps can fail this way. They
   are pure git operations against a known SHA, with no dependency on Fly.
 - **Idempotent recovery.** Re-running the workflow via `workflow_dispatch` with
-  `ref` set to the deployed SHA must converge rather than error: creating a tag
-  that already points at that SHA is a no-op, and the bookmark force-push is
-  idempotent by construction. A tag name collision is not a realistic concern —
-  the name is second-resolution — but a re-run within the same second must not
-  hard-fail the job.
+  `ref` set to the deployed SHA must converge rather than error. The tag name is
+  generated from the clock, so a re-run would otherwise mint a *second* tag for
+  the same commit. The tag step therefore looks for an existing `v*` tag
+  pointing at HEAD and reuses it if present, creating a new one only when the
+  commit is genuinely untagged. The bookmark force-push is idempotent by
+  construction.
 - **Loud, not silent.** A failure here fails the run, so the red run is the
   signal. The recovery is the `workflow_dispatch` re-run above; it redeploys the
   same SHA, which on this app costs one restart.
@@ -329,9 +341,17 @@ it, then confirm:
   it from being discovered during a real release.
 
 Then confirm the trigger itself, which `workflow_dispatch` does not exercise:
-push a trivial commit to `guarzo/zoo` and verify that a deploy run appears only
-after `Test Suite` goes green, and that a commit with a failing suite produces
-no deploy run at all.
+push a trivial commit to `guarzo/zoo` and verify that no deploy run exists while
+the suite is still running, that one appears in state `waiting` once it goes
+green, and that a commit whose suite went red produces a **skipped** deploy run
+that never reaches `waiting`.
+
+Note also that **merging the workflow itself arms the automatic path**:
+`test.yml` triggers on pushes to `guarzo/zoo` (`test.yml:6-7`), so the merge
+commit's green suite opens a pending deploy run for the same SHA the validation
+`workflow_dispatch` will target. The staleness guard cannot distinguish them —
+both are the branch tip — so approving both would deploy one commit twice. The
+automatic run is cancelled before validation begins.
 
 This costs one deliberate restart to prove the pipeline, which is preferable to
 discovering a broken pipeline during a real change.

--- a/docs/superpowers/specs/2026-08-07-deploy-approval-gate-design.md
+++ b/docs/superpowers/specs/2026-08-07-deploy-approval-gate-design.md
@@ -51,13 +51,14 @@ desired property, not a limitation to remove.
 
 | Decision | Choice |
 |---|---|
-| Trigger | Push to `guarzo/zoo` opens a deploy run that waits for approval |
+| Trigger | A **successful `Test Suite` run** on `guarzo/zoo` opens a deploy run that waits for approval (`workflow_run`, not `push`) |
 | Gate | GitHub Environment `production-deploy` with required reviewer |
 | Who talks to Fly | The workflow, via `flyctl deploy` with a scoped token |
 | Fly GitHub integration | Disconnected — replaced, not run alongside |
 | Tag timing | **After** a verified-healthy deploy, never before |
 | `guarzo/release` | Retained as a CI-owned bookmark of what is in production |
-| Preconditions | `Test Suite` must be green on the SHA before approval is offered |
+| Concurrency | Two groups: approvals coalesce and cancel; deploys serialize and are **not** cancellable |
+| Deploy credential | Stored as an **environment** secret on `production-deploy`, not a repository secret |
 | Rollback | `workflow_dispatch` with a `ref` input (tag or SHA) |
 
 ### Rejected alternatives
@@ -72,6 +73,15 @@ desired property, not a limitation to remove.
   run appearing after every merge is precisely what makes this work.
 - **Auto-deploy every merge to `guarzo/zoo`.** Removes the failure mode
   entirely, but discards the "deploy is a decision" property, which is wanted.
+- **`on: push` trigger with the test suite as a stated precondition.** This was
+  the first draft of this design. It does not work: an environment gate does not
+  wait on another workflow's checks, so the approval prompt appears while the
+  suite is still running, and a red commit can be approved and shipped. Replaced
+  by the `workflow_run` trigger.
+- **A single concurrency group with `cancel-in-progress: true`.** Also from the
+  first draft. It correctly coalesces pending approvals but also cancels a run
+  that is mid-deploy, which changes production without tagging or bookmarking
+  it. Replaced by two groups.
 
 ## Architecture
 
@@ -81,9 +91,14 @@ tag-and-push logic, SHA-pinned actions, and a concurrency group.
 
 ### Trigger and gate
 
+The deploy workflow is **not** triggered by the push directly. It is triggered by
+the test workflow finishing successfully on `guarzo/zoo`:
+
 ```yaml
 on:
-  push:
+  workflow_run:
+    workflows: ["🧪 Test Suite"]
+    types: [completed]
     branches: [guarzo/zoo]
   workflow_dispatch:
     inputs:
@@ -92,30 +107,81 @@ on:
         required: false
 ```
 
-- **`concurrency: {group: zoo-deploy, cancel-in-progress: true}`.** Merging
-  three PRs before approving leaves one pending approval for the newest SHA, not
-  three stale runs queued in order. Deploying an intermediate commit that was
-  already superseded is never the intent.
-- **`environment: production-deploy`** on the deploying job. Nothing runs until
-  approved. GitHub holds a pending run for 30 days, so a run may wait as long as
-  needed. The repository is public, so environment protection rules are
-  available at no cost, and GitHub permits a reviewer to approve their own
-  deployment run.
-- **Precondition:** the `Test Suite` check must be green on the exact SHA before
-  approval is offered. Approval is a judgment about timing, not about whether
-  the code works. `test.yml` already runs on every push to `guarzo/zoo`.
+with `if: github.event.workflow_run.conclusion == 'success'` on the first job,
+and the deployed commit taken from `github.event.workflow_run.head_sha` rather
+than from `github.ref`.
+
+**Why not `on: push`.** An environment gate does not wait for another workflow's
+checks. `Test Suite` is a separate workflow (`.github/workflows/test.yml`) whose
+`gate` job is named `Test Suite` (`test.yml:334-335`) and is wired to the
+`guarzo/zoo` ruleset for pull requests — nothing connects it to a push-triggered
+deploy run. On a plain `push` trigger the approval prompt would appear
+immediately, and a commit whose tests were still running, or already red, could
+be approved and shipped. `workflow_run` makes the dependency real: a red suite
+produces no deploy run at all.
+
+`workflow_run` evaluates its workflow file from the default branch, which is
+`guarzo/zoo` — the branch being deployed — so this trigger works without extra
+configuration.
+
+**Failure and cancellation of the test run** are handled by the same condition:
+any conclusion other than `success` (`failure`, `cancelled`, `timed_out`,
+`skipped`) produces no deploy run. Silence therefore means "not shippable",
+never "shipped without checking".
+
+### Concurrency: coalesce approvals, serialize deploys
+
+Two jobs with **different** concurrency groups. Collapsing them into one group
+is a correctness bug, not a simplification.
+
+| Job | Concurrency | Rationale |
+|---|---|---|
+| `await-approval` (gate only) | `group: zoo-deploy-approval`, `cancel-in-progress: true` | Merging three PRs before approving leaves one pending approval for the newest SHA, not three stale runs queued in order. Deploying an already-superseded intermediate commit is never the intent. |
+| `deploy` (everything after approval) | `group: zoo-deploy-run`, `cancel-in-progress: false` | Once approved, the run must not be interruptible. |
+
+**Why `cancel-in-progress` must not cover the deploy job.** GitHub's
+cancellation applies to *running* jobs, not only to runs waiting on approval. A
+merge landing mid-`flyctl deploy` would cancel the workflow while Fly's builder
+continues remotely — production changes, and the tag and bookmark steps never
+run. That is precisely the failure this design exists to prevent, reintroduced
+by the mechanism meant to tidy the approval queue.
+
+`cancel-in-progress: false` on the deploy group also serializes deploys: a
+second approved run queues behind the first rather than racing it onto the
+single machine.
+
+### The approval gate
+
+**`environment: production-deploy`** on the deploying job. Nothing runs until
+approved. The repository is public, so environment protection rules are
+available at no cost.
+
+**Pending runs expire after 30 days** and are then marked failed. This is a real
+bound, not "wait as long as you like". It is acceptable rather than mitigated: a
+run that has sat unapproved for 30 days is itself a signal, and any subsequent
+push to `guarzo/zoo` opens a fresh run against a newer SHA. No expiry-renewal
+mechanism is specified, deliberately.
+
+**Self-approval must be confirmed, not assumed.** GitHub is understood to permit
+a reviewer to approve a run they triggered, but with a single required reviewer
+this is load-bearing — if it does not hold, the gate is unopenable. Verify
+before relying on it (see Validation).
+
 
 ### Post-approval sequence
 
 Strictly linear; each step runs only if the previous one succeeded. That
 ordering is what makes the tag trustworthy.
 
-1. **Checkout the approved SHA** with `fetch-depth: 0` (annotated tagging needs
-   full history).
-2. **`flyctl deploy --app wanderer`** authenticated with `FLY_API_TOKEN`. Fly
-   runs `release_command` first (`fly.toml:29` — migrations against
-   `DIRECT_DATABASE_URL`), so a failed migration fails the deploy before new
-   code serves traffic.
+1. **Checkout the approved SHA** — `github.event.workflow_run.head_sha` for
+   `workflow_run` runs, or the `ref` input for `workflow_dispatch` — with
+   `fetch-depth: 0` (annotated tagging needs full history). Never `github.ref`:
+   under `workflow_run` that resolves to the default branch's tip at trigger
+   time, not the tested commit.
+2. **`flyctl deploy --app wanderer`** authenticated with the `FLY_API_TOKEN`
+   environment secret. Fly runs `release_command` first (`fly.toml:29` —
+   migrations against `DIRECT_DATABASE_URL`), so a failed migration fails the
+   deploy before new code serves traffic.
 3. **Wait for healthy.** Under `strategy = 'rolling'` (`fly.toml:30`),
    `flyctl deploy` blocks on the `/health` check (`fly.toml:84-88`;
    route at `lib/wanderer_app_web/router.ex:391`). An unhealthy machine fails
@@ -135,6 +201,43 @@ served traffic.
 This is a real improvement over the current process, where `guarzo/release` is
 moved *before* Fly attempts anything — so a failed deploy leaves the branch
 asserting a success that never happened.
+
+#### Partial failure after a successful deploy
+
+Steps 2–5 are **not atomic**. If the deploy succeeds and step 4 or 5 then fails,
+production has moved while the tag or bookmark has not — the one state that
+contradicts the invariant this design is built on. It cannot be prevented, only
+made recoverable and loud:
+
+- **Bounded blast radius.** Only the tag/bookmark steps can fail this way. They
+  are pure git operations against a known SHA, with no dependency on Fly.
+- **Idempotent recovery.** Re-running the workflow via `workflow_dispatch` with
+  `ref` set to the deployed SHA must converge rather than error: creating a tag
+  that already points at that SHA is a no-op, and the bookmark force-push is
+  idempotent by construction. A tag name collision is not a realistic concern —
+  the name is second-resolution — but a re-run within the same second must not
+  hard-fail the job.
+- **Loud, not silent.** A failure here fails the run, so the red run is the
+  signal. The recovery is the `workflow_dispatch` re-run above; it redeploys the
+  same SHA, which on this app costs one restart.
+
+#### Permissions and the `guarzo/release` ruleset
+
+The workflow needs `contents: write`, scoped to the deploy job only — the
+default token is read-only, and the approval-gate job has no reason to hold
+write access.
+
+**The ruleset restricting pushes to `guarzo/release` will reject the workflow's
+own push unless a bypass actor is configured for it.** This is the design's
+sharpest self-inflicted failure mode: it surfaces at step 5, *after* a
+successful production deploy, in exactly the partial-failure state described
+above. The bypass must also permit **force-push** (non-fast-forward), since a
+`guarzo/zoo` rebase guarantees the bookmark update is not a fast-forward.
+
+Both behaviors — bypass actor and force-push permission — are verified during
+validation rather than assumed, because the cost of getting them wrong is paid
+in production.
+
 
 ### `guarzo/release` becomes CI-owned
 
@@ -164,33 +267,64 @@ Manual steps, in order:
 
 1. **Disconnect Fly's GitHub integration** for app `wanderer` (Fly dashboard →
    app → Settings).
-2. **Create a deploy-scoped token** — `fly tokens create deploy -a wanderer` —
-   stored as repository secret `FLY_API_TOKEN`. Deploy-scoped rather than a
-   personal org token, so a compromised runner cannot reach `kills`,
-   `route-builder`, or other apps in the org.
-3. **Create environment `production-deploy`** with the repository owner as
+2. **Create environment `production-deploy`** with the repository owner as
    required reviewer.
-4. **Add a ruleset on `guarzo/release`** restricting direct pushes.
+3. **Create a deploy-scoped token** — `fly tokens create deploy -a wanderer` —
+   stored as an **environment secret on `production-deploy`**, not a repository
+   secret. A repository secret is readable by any workflow running on a trusted
+   branch; an environment secret is released only to a job that has cleared the
+   approval gate. The design's whole premise is that nothing reaches production
+   without approval, and the credential is part of "nothing". Deploy-scoped
+   rather than a personal org token, so a compromised runner cannot reach
+   `kills`, `route-builder`, or other apps in the org.
+4. **Add a ruleset on `guarzo/release`** restricting direct pushes, with a
+   bypass actor for the deploy workflow that permits force-push (see
+   *Permissions and the `guarzo/release` ruleset*).
 
 Then land `.github/workflows/zoo-deploy.yml`.
+
+Step 2 precedes step 3 because the environment must exist before a secret can be
+attached to it.
 
 ### Validation
 
 First run is a `workflow_dispatch` against current `guarzo/zoo` HEAD. Approve
 it, then confirm:
 
+- **self-approval works** — the required reviewer can approve a run they
+  triggered. If not, the gate is unopenable and a second reviewer or a different
+  protection rule is needed. Check this first; everything else is moot if it
+  fails.
 - the Fly release counter increments,
 - `/health` passes and the machine stays up,
 - a `v2026...` tag exists pointing at the expected SHA,
-- `guarzo/release` has moved to that SHA.
+- **`guarzo/release` has moved to that SHA** — this is the check that proves the
+  ruleset bypass and force-push permission are configured correctly. It fails
+  *after* a successful deploy, so verifying it deliberately here is what keeps
+  it from being discovered during a real release.
+
+Then confirm the trigger itself, which `workflow_dispatch` does not exercise:
+push a trivial commit to `guarzo/zoo` and verify that a deploy run appears only
+after `Test Suite` goes green, and that a commit with a failing suite produces
+no deploy run at all.
 
 This costs one deliberate restart to prove the pipeline, which is preferable to
 discovering a broken pipeline during a real change.
 
 ### Reverting the whole design
 
-Reconnect Fly's GitHub integration and delete the ruleset. `guarzo/release`
-still tracks the same commits, so the current process resumes unchanged.
+**Order matters here too, in reverse.** Disable or delete
+`.github/workflows/zoo-deploy.yml` **first**, then reconnect Fly's GitHub
+integration, then drop the `guarzo/release` ruleset.
+
+Reconnecting Fly while the workflow is still active recreates the double-deploy
+this design removes, in a more confusing form: the workflow deploys, then pushes
+`guarzo/release` as its final step, which triggers the reconnected integration
+to deploy the same commit again — two restarts, the second one apparently
+uncaused.
+
+Once the workflow is gone, `guarzo/release` still tracks the same commits, so
+the current process resumes unchanged.
 
 ## Assumptions and unresolved risks
 
@@ -202,10 +336,20 @@ still tracks the same commits, so the current process resumes unchanged.
 - **Unverified: whether disconnecting the GitHub integration affects anything
   else on the Fly app.** It is understood to be a build trigger rather than
   runtime configuration, but this has not been confirmed.
+- **Unverified: that GitHub permits self-approval of a deployment run.** With a
+  single required reviewer this is load-bearing — if it does not hold, the gate
+  cannot be opened at all. First item in the validation checklist.
+- **Unverified: that a ruleset bypass actor can force-push to `guarzo/release`.**
+  Required by step 5, and failing there leaves production deployed but
+  unbookmarked. Also in the validation checklist.
 - **Assumed: `flyctl deploy` exits non-zero when the release fails its health
   check.** Steps 4 and 5 depend on this. To be confirmed during validation; if
   it does not hold, an explicit `flyctl status` / `/health` poll is needed
   before tagging.
+- **Accepted: steps 2–5 are not atomic.** See *Partial failure after a
+  successful deploy*. Recovery is a `workflow_dispatch` re-run, at the cost of
+  one restart.
+- **Accepted: pending approvals expire after 30 days.** No renewal mechanism.
 - **Not addressed: migration rollback.** `release_command` runs migrations
   forward. Deploying an older tag does not revert a schema change, so a
   destructive migration is still a manual recovery. Unchanged from today.

--- a/docs/superpowers/specs/2026-08-07-deploy-approval-gate-design.md
+++ b/docs/superpowers/specs/2026-08-07-deploy-approval-gate-design.md
@@ -5,6 +5,45 @@
 **Replaces:** Fly GitHub integration auto-deploying on push to `guarzo/release`
 **Related:** `docs/superpowers/specs/2026-08-02-flyio-migration-design.md`, `ce58765b` (ci: drop the VM release pipeline)
 
+## Amendment — 2026-08-07, during implementation
+
+**`guarzo/release` is retired, not retained as a CI-owned bookmark.** Everything
+below describing the workflow force-pushing that branch as its final step no
+longer holds. The workflow deploys and tags; the newest `v20*` tag is the sole
+record of what is in production, and `guarzo/release` is frozen by a ruleset with
+an empty bypass list.
+
+Two things forced the change:
+
+1. **The Actions bypass actor is unavailable on user-owned repositories.**
+   `guarzo/wanderer` is owned by a user, not an org. Creating the ruleset with
+   `{"actor_type": "Integration", "actor_id": 15368}` returns HTTP 422:
+   *"Actor GitHub Actions integration must be part of the ruleset source or
+   owner organization."* This invalidates the section *Permissions and the
+   `guarzo/release` ruleset* below, whose open question — whether a bypass actor
+   can force-push — turns out to be unanswerable as posed. A `DeployKey` bypass
+   actor **is** accepted (verified against a disposable probe ruleset), but it
+   costs a long-lived SSH key with write access to every branch, stored beside
+   the Fly deploy token.
+2. **Given that, the bookmark was not worth its own credential.** Its only
+   consumers were `git diff guarzo/release..guarzo/zoo` and human reassurance —
+   both of which the tag already serves. Retiring it removes a ref that is
+   authoritative-looking but only conditionally accurate, and removes the last
+   thing in the design that needed write access beyond `GITHUB_TOKEN`.
+
+**What this costs:** `git diff guarzo/release..guarzo/zoo` is replaced by
+`git diff "$(git tag -l 'v20*' | sort | tail -1)"..guarzo/zoo`.
+
+**What it does not cost:** tag reachability across rebases — the original reason
+tags matter — was always the tag's job, never the branch's. The section *A failed
+deploy produces no tag and does not move the bookmark* still holds with the
+bookmark clause dropped; the partial-failure window narrows from three steps to
+two.
+
+The runbook in `docs/ZOO-FORK.md` and the plan at
+`docs/superpowers/plans/2026-08-07-deploy-approval-gate.md` reflect the amended
+design. Where they disagree with the text below, they govern.
+
 ## Problem
 
 Two problems, discovered together.

--- a/docs/superpowers/specs/2026-08-07-deploy-approval-gate-design.md
+++ b/docs/superpowers/specs/2026-08-07-deploy-approval-gate-design.md
@@ -1,0 +1,220 @@
+# Deploy Approval Gate — Design
+
+**Date:** 2026-08-07
+**Status:** Approved (brainstorming session)
+**Replaces:** Fly GitHub integration auto-deploying on push to `guarzo/release`
+**Related:** `docs/superpowers/specs/2026-08-02-flyio-migration-design.md`, `ce58765b` (ci: drop the VM release pipeline)
+
+## Problem
+
+Two problems, discovered together.
+
+**1. Promotion is a silent manual step.** Work merges to `guarzo/zoo`. Production
+only moves when `guarzo/release` is hard-reset to `guarzo/zoo` and pushed, which
+Fly's GitHub integration watches. Forgetting the reset produces no signal
+anywhere — the merge succeeds, CI is green, and production quietly keeps serving
+the old commit until someone notices a shipped change missing.
+
+**2. Deploy tags stopped being created.** `.github/workflows/release.yml` created
+a `v$(date +%Y%m%d%H%M%S)` tag on every promotion. It was deleted on 2026-08-05
+in `ce58765b` along with the rest of the VM release pipeline, because it also
+built and SSH-deployed to a host that no longer serves traffic. Deleting it
+removed the tagging as collateral damage.
+
+Evidence the tagging is gone:
+
+| Event | Timestamp (UTC) |
+|---|---|
+| Last tag created (`v20260805165448`) | 2026-08-05 16:54 |
+| `release.yml` deleted (`ce58765b`) | 2026-08-05 17:09 |
+| Fly release v9 | 2026-08-07 18:02 — no tag |
+| Fly release v10 | 2026-08-07 18:17 — no tag |
+
+This matters more on this fork than it would elsewhere. `guarzo/zoo` is
+regularly rebased onto upstream and has commits squashed, so a deployed commit
+with nothing pointing at it becomes unreachable. Since 2026-08-05 the only
+record of what is in production has been a Fly image ref
+(`registry.fly.io/wanderer:deployment-<hash>`), which is not checkout-able and
+does not survive a rewrite.
+
+## Goal
+
+Make promotion to production a **deliberate, single-click decision** that cannot
+be silently forgotten, and restore an immutable tag on every deploy — where the
+tag means *"this commit served production traffic"*, not merely *"this commit
+was promoted"*.
+
+Explicitly **not** a goal: continuous deployment. "Deploy is a decision" is a
+desired property, not a limitation to remove.
+
+## Decisions (from brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Trigger | Push to `guarzo/zoo` opens a deploy run that waits for approval |
+| Gate | GitHub Environment `production-deploy` with required reviewer |
+| Who talks to Fly | The workflow, via `flyctl deploy` with a scoped token |
+| Fly GitHub integration | Disconnected — replaced, not run alongside |
+| Tag timing | **After** a verified-healthy deploy, never before |
+| `guarzo/release` | Retained as a CI-owned bookmark of what is in production |
+| Preconditions | `Test Suite` must be green on the SHA before approval is offered |
+| Rollback | `workflow_dispatch` with a `ref` input (tag or SHA) |
+
+### Rejected alternatives
+
+- **Gate promotes `guarzo/release`, Fly's webhook still deploys.** Smaller
+  change, but the workflow hands off to a webhook and never learns whether the
+  deploy succeeded — so the tag would still only mean "approved". It also
+  depends on Fly's integration firing on a force-push, which is unverified and
+  becomes necessary the moment `guarzo/zoo` is rebased.
+- **`workflow_dispatch`-only, no push trigger.** Simplest, but does not solve
+  problem 1: it remains an action that can be forgotten. The pending-approval
+  run appearing after every merge is precisely what makes this work.
+- **Auto-deploy every merge to `guarzo/zoo`.** Removes the failure mode
+  entirely, but discards the "deploy is a decision" property, which is wanted.
+
+## Architecture
+
+One new workflow, `.github/workflows/zoo-deploy.yml`. The deleted `release.yml`
+(recoverable at `ce58765b^`) is the starting point — it already carries the
+tag-and-push logic, SHA-pinned actions, and a concurrency group.
+
+### Trigger and gate
+
+```yaml
+on:
+  push:
+    branches: [guarzo/zoo]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag or SHA to deploy (defaults to guarzo/zoo HEAD)'
+        required: false
+```
+
+- **`concurrency: {group: zoo-deploy, cancel-in-progress: true}`.** Merging
+  three PRs before approving leaves one pending approval for the newest SHA, not
+  three stale runs queued in order. Deploying an intermediate commit that was
+  already superseded is never the intent.
+- **`environment: production-deploy`** on the deploying job. Nothing runs until
+  approved. GitHub holds a pending run for 30 days, so a run may wait as long as
+  needed. The repository is public, so environment protection rules are
+  available at no cost, and GitHub permits a reviewer to approve their own
+  deployment run.
+- **Precondition:** the `Test Suite` check must be green on the exact SHA before
+  approval is offered. Approval is a judgment about timing, not about whether
+  the code works. `test.yml` already runs on every push to `guarzo/zoo`.
+
+### Post-approval sequence
+
+Strictly linear; each step runs only if the previous one succeeded. That
+ordering is what makes the tag trustworthy.
+
+1. **Checkout the approved SHA** with `fetch-depth: 0` (annotated tagging needs
+   full history).
+2. **`flyctl deploy --app wanderer`** authenticated with `FLY_API_TOKEN`. Fly
+   runs `release_command` first (`fly.toml:29` — migrations against
+   `DIRECT_DATABASE_URL`), so a failed migration fails the deploy before new
+   code serves traffic.
+3. **Wait for healthy.** Under `strategy = 'rolling'` (`fly.toml:30`),
+   `flyctl deploy` blocks on the `/health` check (`fly.toml:84-88`;
+   route at `lib/wanderer_app_web/router.ex:391`). An unhealthy machine fails
+   the step.
+4. **Tag the SHA** — `v$(date +%Y%m%d%H%M%S)`, annotated, message recording the
+   short SHA and the Fly release version. Push the tag.
+5. **Move `guarzo/release`** to that SHA. This is a force-push: a `guarzo/zoo`
+   rebase makes the update non-fast-forward, and the branch is a mirror by
+   definition.
+
+### Failure semantics
+
+A failed deploy produces no tag and does not move the bookmark. `guarzo/release`
+and the newest tag both continue to point at the last commit that actually
+served traffic.
+
+This is a real improvement over the current process, where `guarzo/release` is
+moved *before* Fly attempts anything — so a failed deploy leaves the branch
+asserting a success that never happened.
+
+### `guarzo/release` becomes CI-owned
+
+It stops being the deploy trigger and becomes the answer to "what is in
+production right now". A repository ruleset restricts direct pushes to the
+workflow's actor, so the existing hard-reset-and-push habit is **refused** rather
+than silently accepted and ignored — the loud failure that was missing. A
+ruleset already exists on `guarzo/zoo`, so this follows an established pattern.
+
+### Rollback
+
+`workflow_dispatch` with `ref: v20260805165448`, approved, deploys that exact
+tag. This capability does not currently exist: since 2026-08-05 no deployed
+commit has had a checkout-able reference, so a bad deploy following a
+`guarzo/zoo` rebase could strand the previous good commit as an orphan.
+
+## Rollout
+
+Order matters. Fly's integration is disconnected **first** so that no window
+exists in which both it and the workflow deploy — on this app a deploy is a full
+restart of the single machine with a user-visible gap (see the constraint
+comment at the top of `fly.toml`), so a double-deploy is two outages for one
+release. During the gap, `flyctl deploy` from a workstation remains a working
+deploy path.
+
+Manual steps, in order:
+
+1. **Disconnect Fly's GitHub integration** for app `wanderer` (Fly dashboard →
+   app → Settings).
+2. **Create a deploy-scoped token** — `fly tokens create deploy -a wanderer` —
+   stored as repository secret `FLY_API_TOKEN`. Deploy-scoped rather than a
+   personal org token, so a compromised runner cannot reach `kills`,
+   `route-builder`, or other apps in the org.
+3. **Create environment `production-deploy`** with the repository owner as
+   required reviewer.
+4. **Add a ruleset on `guarzo/release`** restricting direct pushes.
+
+Then land `.github/workflows/zoo-deploy.yml`.
+
+### Validation
+
+First run is a `workflow_dispatch` against current `guarzo/zoo` HEAD. Approve
+it, then confirm:
+
+- the Fly release counter increments,
+- `/health` passes and the machine stays up,
+- a `v2026...` tag exists pointing at the expected SHA,
+- `guarzo/release` has moved to that SHA.
+
+This costs one deliberate restart to prove the pipeline, which is preferable to
+discovering a broken pipeline during a real change.
+
+### Reverting the whole design
+
+Reconnect Fly's GitHub integration and delete the ruleset. `guarzo/release`
+still tracks the same commits, so the current process resumes unchanged.
+
+## Assumptions and unresolved risks
+
+- **Unverified: interaction between the existing `production` environment and
+  the new `production-deploy`.** A `production` environment exists (created
+  2026-08-05, no protection rules), most likely by Fly's integration for its own
+  deployment records. Using a separate name is the mitigation; the interaction
+  itself has not been tested.
+- **Unverified: whether disconnecting the GitHub integration affects anything
+  else on the Fly app.** It is understood to be a build trigger rather than
+  runtime configuration, but this has not been confirmed.
+- **Assumed: `flyctl deploy` exits non-zero when the release fails its health
+  check.** Steps 4 and 5 depend on this. To be confirmed during validation; if
+  it does not hold, an explicit `flyctl status` / `/health` poll is needed
+  before tagging.
+- **Not addressed: migration rollback.** `release_command` runs migrations
+  forward. Deploying an older tag does not revert a schema change, so a
+  destructive migration is still a manual recovery. Unchanged from today.
+
+## Out of scope
+
+- Staging or preview environments.
+- Multi-machine or blue/green deploys — `fly.toml` documents the single-machine
+  constraint, and lifting it requires cluster-aware map state.
+- Changes to `test.yml` beyond consuming its result as a precondition.
+- Upstream (`wanderer-industries`) workflows: `build.yml`, `build-develop.yml`,
+  `advanced-test.yml`, `release_actions.yml` are untouched.

--- a/docs/superpowers/specs/2026-08-07-deploy-approval-gate-design.md
+++ b/docs/superpowers/specs/2026-08-07-deploy-approval-gate-design.md
@@ -57,7 +57,7 @@ desired property, not a limitation to remove.
 | Fly GitHub integration | Disconnected — replaced, not run alongside |
 | Tag timing | **After** a verified-healthy deploy, never before |
 | `guarzo/release` | Retained as a CI-owned bookmark of what is in production |
-| Concurrency | Two groups: approvals coalesce and cancel; deploys serialize and are **not** cancellable |
+| Concurrency | One non-cancellable deploy job (`cancel-in-progress: false`); stale approvals are neutralized by a post-approval staleness guard, not by cancellation |
 | Deploy credential | Stored as an **environment** secret on `production-deploy`, not a repository secret |
 | Rollback | `workflow_dispatch` with a `ref` input (tag or SHA) |
 
@@ -81,7 +81,12 @@ desired property, not a limitation to remove.
 - **A single concurrency group with `cancel-in-progress: true`.** Also from the
   first draft. It correctly coalesces pending approvals but also cancels a run
   that is mid-deploy, which changes production without tagging or bookmarking
-  it. Replaced by two groups.
+  it. Replaced by a non-cancellable job plus a staleness guard.
+- **Two jobs: a gate job and a separate deploy job.** Proposed while applying
+  the review findings, then rejected: a protected environment gates every job
+  referencing it (two approval prompts), and the environment-scoped
+  `FLY_API_TOKEN` cannot be read by a job outside the environment or passed in
+  from one. Replaced by a single gated job.
 
 ## Architecture
 
@@ -129,26 +134,46 @@ any conclusion other than `success` (`failure`, `cancelled`, `timed_out`,
 `skipped`) produces no deploy run. Silence therefore means "not shippable",
 never "shipped without checking".
 
-### Concurrency: coalesce approvals, serialize deploys
+### Concurrency: one non-cancellable job, with a staleness guard
 
-Two jobs with **different** concurrency groups. Collapsing them into one group
-is a correctness bug, not a simplification.
+A **single** `deploy` job carries both the environment gate and all the work,
+with job-level `concurrency: {group: zoo-deploy-run, cancel-in-progress: false}`.
 
-| Job | Concurrency | Rationale |
-|---|---|---|
-| `await-approval` (gate only) | `group: zoo-deploy-approval`, `cancel-in-progress: true` | Merging three PRs before approving leaves one pending approval for the newest SHA, not three stale runs queued in order. Deploying an already-superseded intermediate commit is never the intent. |
-| `deploy` (everything after approval) | `group: zoo-deploy-run`, `cancel-in-progress: false` | Once approved, the run must not be interruptible. |
+**Why not split gate and deploy into two jobs.** Two reasons compound:
 
-**Why `cancel-in-progress` must not cover the deploy job.** GitHub's
-cancellation applies to *running* jobs, not only to runs waiting on approval. A
-merge landing mid-`flyctl deploy` would cancel the workflow while Fly's builder
-continues remotely — production changes, and the tag and bookmark steps never
-run. That is precisely the failure this design exists to prevent, reintroduced
-by the mechanism meant to tidy the approval queue.
+1. A protected environment gates **every job that references it**, so a
+   `await-approval` job plus a `deploy` job produces two approval prompts per
+   release.
+2. `FLY_API_TOKEN` is an environment secret (see Rollout), readable only by a
+   job declaring `environment: production-deploy`. The deploy job must therefore
+   reference the environment — it cannot delegate the gate to a predecessor.
+   Secrets cannot be passed between jobs via outputs.
 
-`cancel-in-progress: false` on the deploy group also serializes deploys: a
-second approved run queues behind the first rather than racing it onto the
-single machine.
+The approval-scoped credential is what forces the deploy work inside the gated
+job. Accepting two prompts to keep a tidy job graph is the wrong trade.
+
+**Why `cancel-in-progress: false`.** GitHub's cancellation applies to *running*
+jobs, not only to runs waiting on approval. A merge landing mid-`flyctl deploy`
+would cancel the workflow while Fly's builder continues remotely — production
+changes, and the tag and bookmark steps never run. That is precisely the failure
+this design exists to prevent, reintroduced by the mechanism meant to tidy the
+approval queue. `false` also serializes deploys: a second approved run queues
+behind the first rather than racing it onto the single machine.
+
+**Staleness guard replaces cancellation.** Because runs are never cancelled,
+approving an old pending run would otherwise deploy a superseded commit. The
+first step after approval compares the resolved SHA against the current
+`origin/guarzo/zoo` tip and **exits successfully without deploying** when they
+differ. Approving a stale run is then a no-op rather than a regression.
+
+The guard applies to `workflow_run` runs only. Under `workflow_dispatch` it is
+skipped entirely — deploying a ref that is *not* the branch tip is exactly what
+rollback is for.
+
+**Accepted cost:** stale pending approvals accumulate in the Actions tab instead
+of auto-cancelling, and are dismissed manually. In exchange: one approval per
+deploy, and no cancellation path into a running deploy.
+
 
 ### The approval gate
 
@@ -342,6 +367,11 @@ the current process resumes unchanged.
 - **Unverified: that a ruleset bypass actor can force-push to `guarzo/release`.**
   Required by step 5, and failing there leaves production deployed but
   unbookmarked. Also in the validation checklist.
+- **Unverified: that a protected environment gates every job referencing it.**
+  The single-job design assumes it does. If one approval in fact covers all jobs
+  in a run, splitting gate and deploy becomes viable again — but the
+  environment-scoped credential would still force the deploy work inside the
+  gated job, so the single-job shape stands either way. Low-stakes to confirm.
 - **Assumed: `flyctl deploy` exits non-zero when the release fails its health
   check.** Steps 4 and 5 depend on this. To be confirmed during validation; if
   it does not hold, an explicit `flyctl status` / `/health` poll is needed


### PR DESCRIPTION
Replaces the "hard-reset `guarzo/release` and hope you remembered" promotion step with an approval-gated GitHub Actions deploy.

## What changes

**`.github/workflows/zoo-deploy.yml` (new).** Triggered by `🧪 Test Suite` completing on `guarzo/zoo`, or manually via `workflow_dispatch` with an optional `ref` for rollback. A single job:

1. resolves the ref (`workflow_run.head_sha`, not `github.ref` — the latter is the branch tip at trigger time, which may not be the tested commit),
2. waits on the `production-deploy` environment gate (one required reviewer),
3. re-checks that `guarzo/zoo` has not moved since approval, and bails with a job summary if it has,
4. `flyctl deploy --app wanderer --remote-only`,
5. tags the deployed commit `vYYYYMMDDHHMMSS`, convergently — a recovery re-run reuses the existing tag rather than minting a second one.

The gate and the deploy live in **one job** deliberately: a protected environment gates every job that references it, so splitting them would prompt twice, and the Fly token is an *environment* secret that only a job inside the environment can read.

`if:` skips the job on a red suite and on non-`push` events — `workflow_run` has no conclusion filter, and this is a public fork whose default branch is named `guarzo/zoo`, so a fork PR from a same-named branch could otherwise raise a production approval request for a commit the requester controls.

`cancel-in-progress` is `false` on purpose. Cancelling a *running* deploy would kill the job while Fly's builder keeps going — production changes with no tag, which is the exact failure this workflow exists to prevent.

**`guarzo/release` is retired.** It no longer moves and deploys nothing; a ruleset now rejects pushes to it, so the old habit fails loudly instead of silently doing nothing. The newest `v20*` tag is the only record of what is in production — no branch tracks it, by design, since `guarzo/zoo` is rebased and squashed against upstream.

**Credential.** `FLY_DEPLOY_TOKEN`, a deploy-scoped Fly token, stored as an environment secret on `production-deploy` — not a repository secret, which any workflow on a trusted branch could read. The name is deliberately *not* `FLY_API_TOKEN`: `advanced-test.yml` reads an ungated secret of that name for the separate `wanderer-test` app, and distinct names mean this production credential can never be picked up there.

## Docs

`docs/ZOO-FORK.md` gains the new promotion path, the tag-based "what have I written but not deployed" command, half-deploy recovery, and the credential note. The spec and plan are included for the record; the spec carries an amendment recording the `guarzo/release` retirement and why.

## Verification

Ruleset, environment, reviewer, and secret placement all verified live against the GitHub and Fly APIs. The old habit is confirmed blocked (`GH013 Cannot update this protected ref`). The Fly-side GitHub integration is disconnected.

Not yet exercised: a real gated deploy and a skipped-job run. Both are done after merge, since `workflow_run`/`workflow_dispatch` only see workflows on the default branch.
