### PR TITLE
docs(fork): refresh ZOO-FORK.md and add parallel-session follow-up prompts

### DIFF
--- a/docs/ZOO-FORK.md
+++ b/docs/ZOO-FORK.md
@@ -53,7 +53,10 @@ for upstream contribution.
 
 ## Database Schema Extensions
 
-The fork adds 2 tables and 10 columns, across 15 migration files.
+The fork adds 2 tables and 8 columns to upstream tables, across 15 migration files (13 new,
+2 modified in place). A further 4 columns are added by later migrations to the fork's *own*
+new tables — the three route-alert columns and `mention_targets` below — which is why the
+tables above list more columns than the "8" here counts.
 
 ### New tables
 
@@ -123,7 +126,7 @@ route alerts, and system events can target different channels.
 
 ### Migration files
 
-```
+```text
 priv/repo/migrations/
 ├── 20250122214138_add_zoo_flags.exs
 ├── 20250204223853_add_system_owners.exs
@@ -135,16 +138,20 @@ priv/repo/migrations/
 ├── 20260801234058_add_map_discord_notifications.exs
 ├── 20260803202833_create_map_discord_webhooks.exs
 ├── 20260803210357_split_discord_webhooks.exs         # hand-edited
-├── 20260804180000_add_map_chain_locked_by_fkey.exs
+├── 20260804180000_add_map_chain_locked_by_fkey.exs    # constraint only, no column
 ├── 20260807203452_add_route_alert_config.exs
 └── 20260807203453_add_webhook_mention_targets.exs
 ```
 
+`20260804180000_add_map_chain_locked_by_fkey.exs` adds **no column**. It creates the
+`map_chain_v1_locked_by_id_fkey` constraint on the existing `locked_by_id` reference, which
+`MapConnection`'s `belongs_to :locked_by` has always implied but no database has ever had.
+
 Two upstream migrations are also **modified in place** — `20260331192521` and `20260406213852`
 each change `default: '{wormholes}'` to `default: ~c"{wormholes}"` to silence the Elixir
 single-quoted-charlist deprecation. The emitted DDL is identical, so this is cosmetic, but it
-means those two files will conflict on every upstream merge until the same change lands
-upstream.
+means those two files can conflict whenever upstream changes them, until the equivalent change
+lands upstream.
 
 > **⚠ `20260801200000_fix_maps_scopes_default.exs` is not an upstream migration.**
 > Commit `1b4970ffb` (#122) describes it as "upstream's", but it exists on neither
@@ -171,6 +178,8 @@ ALTER TABLE map_system_structures_v1 DROP COLUMN IF EXISTS inherited_from_map_id
 
 DROP TABLE IF EXISTS map_discord_webhooks_v1;
 DROP TABLE IF EXISTS map_discord_notifications_v1;
+
+ALTER TABLE map_chain_v1 DROP CONSTRAINT IF EXISTS map_chain_v1_locked_by_id_fkey;
 ```
 
 ---
@@ -435,7 +444,7 @@ config :wanderer_app, :signature_cleanup, max_age_hours: 24
 
 Fork-only work uses **`zoo(<type>): <summary>`**:
 
-```
+```text
 zoo(feat): add voice-channel mentions to route alerts
 zoo(fix): stop one slow static lookup from killing the whole request
 zoo(chore): drop the dead fleet-readiness flag
@@ -603,7 +612,7 @@ its own before/after write-up since it changes emitted payloads.
 
 ### Frontend (Zoo-Specific)
 
-```
+```text
 assets/js/hooks/Mapper/
 ├── components/map/
 │   ├── styles/zoo-theme.scss
@@ -619,7 +628,7 @@ assets/js/hooks/Mapper/
 
 ### Backend (Zoo-Specific)
 
-```
+```text
 lib/wanderer_app/
 ├── external_events/
 │   ├── discord_dispatcher.ex
@@ -646,7 +655,7 @@ lib/wanderer_app_web/
 
 ### Design docs
 
-```
+```text
 docs/superpowers/
 ├── specs/2026-08-02-flyio-migration-design.md
 ├── specs/2026-08-07-deploy-approval-gate-design.md
@@ -676,10 +685,17 @@ When merging upstream, watch for conflicts in:
 
 ```bash
 git fetch upstream --prune
-git rev-list --left-right --count upstream/main...origin/guarzo/zoo   # behind / ahead
+
+# behind / ahead, against both upstream branches -- they diverge, so check each
+for ref in upstream/main upstream/develop; do
+  printf '%-18s ' "$ref"
+  git rev-list --left-right --count "$ref"...origin/guarzo/zoo   # behind<TAB>ahead
+done
 ```
 
-As of this document the fork is 0 behind both `upstream/main` and `upstream/develop`.
+The first column is how many commits the fork is **behind** that ref; the second is how many
+it is **ahead**. As of this document the fork is 0 behind both `upstream/main` and
+`upstream/develop`.
 
 ### Testing
 

--- a/docs/ZOO-FORK.md
+++ b/docs/ZOO-FORK.md
@@ -1,9 +1,13 @@
 # Zoo Fork Documentation
 
 **Branch:** `guarzo/zoo`
-**Last Updated:** 2025-11-30
+**Upstream baseline:** `wanderer-industries/wanderer` — `main` @ `b7ddbc486`, `develop` @ `35ea4e5f1`
+**Divergence:** 58 commits / 312 files / ~43.5k insertions ahead; 0 commits behind either upstream branch
+**Last Updated:** 2026-08-08
 
-This document describes the zoo fork's extensions to upstream Wanderer, including database schema changes, frontend themes, and features suitable for upstream contribution.
+This document describes the zoo fork's extensions to upstream Wanderer: database schema
+changes, backend subsystems, frontend themes, deployment, and which changes are candidates
+for upstream contribution.
 
 ---
 
@@ -11,35 +15,85 @@ This document describes the zoo fork's extensions to upstream Wanderer, includin
 
 1. [Overview](#overview)
 2. [Database Schema Extensions](#database-schema-extensions)
-3. [Theme System](#theme-system)
-4. [Label System](#label-system)
-5. [Signature Cleanup](#signature-cleanup)
-6. [Fleet Readiness](#fleet-readiness)
-7. [Upstream PR Recommendations](#upstream-pr-recommendations)
-8. [Deployment](#deployment)
+3. [Discord Notifications](#discord-notifications)
+4. [Intel Sharing](#intel-sharing)
+5. [Theme System](#theme-system)
+6. [Label System](#label-system)
+7. [Signature Cleanup](#signature-cleanup)
+8. [Fleet Readiness](#fleet-readiness)
+9. [Deployment (Fly.io)](#deployment-flyio)
+10. [CI](#ci)
+11. [Configuration Reference](#configuration-reference)
+12. [Upstream PR Recommendations](#upstream-pr-recommendations)
+13. [Key Files Reference](#key-files-reference)
+14. [Maintenance Notes](#maintenance-notes)
 
 ---
 
 ## Overview
 
-The zoo fork adds EVE Online wormhole-specific features to Wanderer:
-
-| Feature | Purpose | Zoo-Only? |
-|---------|---------|-----------|
-| Zoo Theme | Custom visual styling for wormhole mapping | Yes |
-| Label Semantics | EVE-specific label meanings (EOL, Crit, etc.) | Yes |
-| System Ownership | Track corp/alliance ownership of systems | Yes |
-| Fleet Readiness | Mark characters ready for fleet operations | Yes |
-| On-Demand Signature Cleanup | Configurable automatic signature expiration | No (PR candidate) |
-| Connection Loop Type | Self-connecting wormhole support | Yes |
+| Feature | Purpose | Upstream candidate? |
+|---------|---------|---------------------|
+| Discord kill notifications | Per-map killmail embeds to Discord webhooks | Yes — large, needs discussion |
+| Discord route alerts | Alert when a kill lands within N jumps of home | With the above |
+| Discord voice mentions | Mention users in the map's voice channel | With the above |
+| Intel sharing between maps | Copy system intel from a source map to subscribers | Yes — Tier 2 |
+| Zoo theme | Custom visual styling for wormhole mapping | No |
+| Label semantics | EVE-specific label meanings (EOL, Crit, etc.) | No |
+| System ownership | Track corp/alliance ownership of systems | No |
+| Fleet readiness | Mark characters ready for fleet operations | Tier 2 (generalize first) |
+| On-demand signature cleanup | Configurable automatic signature expiration | Yes |
+| Connection loop type | Self-connecting wormhole support | No |
+| Fly.io deployment | Config, IPv6 transports, `/health`, gated deploy | Partly — see Tier 1 |
+| Parallel CI | 4-way partitioned test suite, fixed caches | Yes |
+| Upstream bug fixes | See [Tier 1](#tier-1-strongly-recommend) | Yes |
 
 ---
 
 ## Database Schema Extensions
 
-The zoo fork adds 5 columns across 2 tables:
+The fork adds 2 tables and 10 columns, across 15 migration files.
 
-### map_system_v1
+### New tables
+
+#### `map_discord_notifications_v1`
+
+Per-map Discord notification config. One row per map (unique index on `map_id`).
+
+| Column | Type | Purpose |
+|--------|------|---------|
+| `enabled?` | boolean | Master switch for the map |
+| `wh_only` | boolean | Restrict notifications to wormhole systems |
+| `excluded_systems` | bigint[] | Solar system IDs to never notify on |
+| `route_alerts_enabled?` | boolean | Enable proximity route alerts |
+| `home_system_id` | bigint | Origin for route-alert jump distance |
+| `route_max_jumps` | bigint | Alert threshold in jumps (default 5) |
+| `last_delivery_at` / `last_error` / `last_error_at` / `consecutive_failures` | — | Delivery health |
+
+`encrypted_webhook_url` existed on this table originally and was moved to the child table
+by `20260803210357_split_discord_webhooks`.
+
+#### `map_discord_webhooks_v1`
+
+One webhook destination per `(notification_id, role)`. Roles split delivery so kills,
+route alerts, and system events can target different channels.
+
+| Column | Type | Purpose |
+|--------|------|---------|
+| `role` | text | Destination role (e.g. `system`) |
+| `encrypted_webhook_url` | binary | AshCloak-encrypted webhook URL |
+| `enabled?` | boolean | Per-destination switch |
+| `mention_targets` | text[] | Roles/users to mention on delivery (`20260807203453`) |
+| `last_delivery_at` / `last_error` / `last_error_at` / `consecutive_failures` | — | Delivery health |
+
+> `20260803210357_split_discord_webhooks.exs` is **hand-edited** after generation: it copies
+> existing rows into the new table rather than dropping them, and strips four unrelated
+> resources the generator picked up from stale snapshots. Read its `@moduledoc` before
+> touching it — the ciphertext-copy reasoning and the `enabled?` semantics are load-bearing.
+
+### Added columns
+
+#### `map_system_v1`
 
 | Column | Type | Purpose | Migration |
 |--------|------|---------|-----------|
@@ -48,40 +102,132 @@ The zoo fork adds 5 columns across 2 tables:
 | `owner_type` | text | Entity type: 'corp' or 'alliance' | `20250204223853` |
 | `owner_ticker` | text | Display ticker [TICKER] | `20250307165740` |
 
-### map_user_settings_v1
+#### `map_user_settings_v1`
 
 | Column | Type | Purpose | Migration |
 |--------|------|---------|-----------|
 | `ready_characters` | text[] | Character EVE IDs marked as fleet-ready | `20250625024813` |
 
-### Migration Files
+#### `maps_v1`
+
+| Column | Type | Purpose | Migration |
+|--------|------|---------|-----------|
+| `intel_source_map_id` | uuid FK (self, `nilify_all`) | Map that provides intel to this one | `20260209100000` |
+
+#### `map_system_comments_v1`, `map_system_structures_v1`
+
+| Column | Type | Purpose | Migration |
+|--------|------|---------|-----------|
+| `inherited_from_map_id` | uuid | Marks rows copied in by intel sync | `20260209100001` |
+
+### Migration files
 
 ```
 priv/repo/migrations/
 ├── 20250122214138_add_zoo_flags.exs
 ├── 20250204223853_add_system_owners.exs
 ├── 20250307165740_add_owner_ticker.exs
-└── 20250625024813_add_fleet_readiness_ready_characters.exs
+├── 20250625024813_add_fleet_readiness_ready_characters.exs
+├── 20260209100000_add_intel_source_map_id.exs
+├── 20260209100001_add_inherited_from_map_id.exs
+├── 20260801200000_fix_maps_scopes_default.exs        # see warning below
+├── 20260801234058_add_map_discord_notifications.exs
+├── 20260803202833_create_map_discord_webhooks.exs
+├── 20260803210357_split_discord_webhooks.exs         # hand-edited
+├── 20260804180000_add_map_chain_locked_by_fkey.exs
+├── 20260807203452_add_route_alert_config.exs
+└── 20260807203453_add_webhook_mention_targets.exs
 ```
+
+Two upstream migrations are also **modified in place** — `20260331192521` and `20260406213852`
+each change `default: '{wormholes}'` to `default: ~c"{wormholes}"` to silence the Elixir
+single-quoted-charlist deprecation. The emitted DDL is identical, so this is cosmetic, but it
+means those two files will conflict on every upstream merge until the same change lands
+upstream.
+
+> **⚠ `20260801200000_fix_maps_scopes_default.exs` is not an upstream migration.**
+> Commit `1b4970ffb` (#122) describes it as "upstream's", but it exists on neither
+> `upstream/main` nor `upstream/develop` — it came in via #118, which pulled from an
+> unmerged upstream PR. The fork's own equivalent (`20260804190000`, from #102) was deleted
+> to resolve an `Ecto.MigrationError: migration name fix_maps_scopes_default is duplicated`
+> that aborted the entire migrator. **If upstream later merges that fix under a different
+> timestamp, the duplicate-module-name collision returns.** Check for a
+> `FixMapsScopesDefault` module on every upstream merge.
 
 ### Rollback SQL (if needed)
 
 ```sql
--- Remove zoo columns from map_system_v1
 ALTER TABLE map_system_v1 DROP COLUMN IF EXISTS custom_flags;
 ALTER TABLE map_system_v1 DROP COLUMN IF EXISTS owner_id;
 ALTER TABLE map_system_v1 DROP COLUMN IF EXISTS owner_type;
 ALTER TABLE map_system_v1 DROP COLUMN IF EXISTS owner_ticker;
 
--- Remove zoo columns from map_user_settings_v1
 ALTER TABLE map_user_settings_v1 DROP COLUMN IF EXISTS ready_characters;
+
+ALTER TABLE maps_v1 DROP COLUMN IF EXISTS intel_source_map_id;
+ALTER TABLE map_system_comments_v1 DROP COLUMN IF EXISTS inherited_from_map_id;
+ALTER TABLE map_system_structures_v1 DROP COLUMN IF EXISTS inherited_from_map_id;
+
+DROP TABLE IF EXISTS map_discord_webhooks_v1;
+DROP TABLE IF EXISTS map_discord_notifications_v1;
 ```
+
+---
+
+## Discord Notifications
+
+The largest fork subsystem (~4,600 lines under `lib/wanderer_app/external_events/discord/`
+plus `discord_dispatcher.ex`). It sits alongside upstream's `webhook_dispatcher.ex` and
+consumes the same external-events stream.
+
+### Modules
+
+| Module | Purpose |
+|--------|---------|
+| `discord_dispatcher.ex` | Entry point; owns delivery decisions and per-map state |
+| `discord/worker.ex`, `worker_supervisor.ex` | Per-map delivery workers |
+| `discord/router.ex` | Routes an event to the right webhook role |
+| `discord/matcher.ex` | Decides whether a killmail concerns a given map |
+| `discord/embed_formatter.ex` | Builds the Discord embed |
+| `discord/notable_items.ex` | Enriches embeds with high-value dropped items (ESI, concurrent) |
+| `discord/corp_tickers.ex` | Resolves missing corporation tickers from ESI |
+| `discord/mentions.ex` | Mention budget and formatting |
+| `discord/voice_gateway.ex`, `voice_participants.ex` | Nostrum gateway; mentions users in voice |
+| `discord/route_watcher.ex`, `route_watcher_supervisor.ex` | Proximity route alerts |
+| `discord/system_name.ex` | System name resolution for embeds |
+| `discord/http_client.ex` | Webhook HTTP transport (dedicated Finch pool) |
+
+### Voice mentions and Nostrum
+
+`nostrum` is declared `runtime: false` in `mix.exs` and listed as `nostrum: :load` in the
+release, so the code ships but does not auto-start. `VoiceGateway` starts it at boot **only**
+when a bot token and guild ID are configured. `config/runtime.exs` never configures Nostrum
+in `:test` — the suite must stay hermetic.
+
+### Route alerts
+
+`lib/wanderer_app/map/route_alert/evaluator.ex` computes jump distance from the map's
+configured `home_system_id`; `route_watcher.ex` drives the per-map watch loop and posts to
+the route-alert webhook role when a kill lands within `route_max_jumps`.
+
+---
+
+## Intel Sharing
+
+`lib/wanderer_app/map/intel_sync.ex` copies intel from a source map to a subscriber map for
+a given solar system, either on visibility or on a manual re-sync.
+
+- **Wiring:** `maps_v1.intel_source_map_id` designates the source map.
+- **Fields copied:** `custom_name`, `description`, `tag`, `temporary_name`, `labels`, `status`.
+- **Also copied:** system comments and structures, tagged with `inherited_from_map_id`.
+- **Flag:** `WANDERER_INTEL_SHARING_ENABLED` (default `false`). When off, `sync_system/3`
+  returns `{:ok, :disabled}` without touching the database.
 
 ---
 
 ## Theme System
 
-Zoo adds a `zoo` theme alongside `default` and `pathfinder`.
+Zoo adds a `zoo` theme alongside `default`, `pathfinder`, and the accessible themes.
 
 ### Key Files
 
@@ -89,6 +235,7 @@ Zoo adds a `zoo` theme alongside `default` and `pathfinder`.
 |------|---------|
 | `assets/js/hooks/Mapper/components/map/styles/zoo-theme.scss` | Zoo theme styles |
 | `assets/js/hooks/Mapper/components/map/components/SolarSystemNode/SolarSystemNodeZoo.tsx` | Zoo node component |
+| `assets/js/hooks/Mapper/components/map/components/SolarSystemNode/SolarSystemNodeZoo.module.scss` | Zoo node styles |
 | `assets/js/hooks/Mapper/components/map/labelIconMap.tsx` | Label icons and mappings |
 
 ### Theme Characteristics
@@ -113,7 +260,8 @@ Zoo-specific CSS classes use the `eve-zoo-` prefix:
 
 ## Label System
 
-The zoo fork repurposes upstream's generic labels (A/B/C/1/2/3) with EVE Online wormhole-specific meanings.
+The zoo fork repurposes upstream's generic labels (A/B/C/1/2/3) with EVE Online
+wormhole-specific meanings.
 
 ### Label Mappings
 
@@ -128,7 +276,8 @@ The zoo fork repurposes upstream's generic labels (A/B/C/1/2/3) with EVE Online 
 
 ### Storage
 
-Labels are stored in the database using the original upstream keys (`la`, `lb`, etc.) but displayed with zoo-specific names and icons when the zoo theme is active.
+Labels are stored in the database using the original upstream keys (`la`, `lb`, etc.) but
+displayed with zoo-specific names and icons when the zoo theme is active.
 
 ### Files
 
@@ -140,40 +289,19 @@ Labels are stored in the database using the original upstream keys (`la`, `lb`, 
 
 ## Signature Cleanup
 
-Zoo implements on-demand signature cleanup in addition to upstream's daily batch cleanup.
+Zoo implements on-demand signature cleanup (`lib/wanderer_app/map/signature_cleanup.ex`,
+driven from `map_signatures_event_handler.ex`) in addition to upstream's daily batch cleanup.
 
 ### Comparison
 
 | Aspect | Upstream GarbageCollector | Zoo On-Demand Cleanup |
 |--------|---------------------------|----------------------|
-| **Location** | `map_garbage_collector.ex` | `map_signatures_event_handler.ex` |
+| **Location** | `map_garbage_collector.ex` | `signature_cleanup.ex` |
 | **Trigger** | Daily via Quantum scheduler | When user views/updates signatures |
 | **Scope** | All signatures globally | Per-system |
 | **Wormhole Expiration** | 14 days (hardcoded) | 24 hours (configurable) |
 | **Other Signatures** | 14 days (hardcoded) | 72 hours (configurable) |
 | **Preserve Connected** | No | Yes (configurable) |
-
-### Configuration
-
-```elixir
-# config/config.exs
-config :wanderer_app, :signatures,
-  wormhole_expiration_hours: 24,   # env: SIGNATURE_WORMHOLE_EXPIRATION_HOURS
-  default_expiration_hours: 72,    # env: SIGNATURE_DEFAULT_EXPIRATION_HOURS
-  preserve_connected: true
-
-config :wanderer_app, :signature_cleanup,
-  max_age_hours: 24
-```
-
-### Environment Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SIGNATURE_WORMHOLE_EXPIRATION_HOURS` | 24 | Hours until wormhole signatures expire |
-| `SIGNATURE_DEFAULT_EXPIRATION_HOURS` | 72 | Hours until non-wormhole signatures expire |
-
-Set to `0` to disable automatic cleanup for that signature type.
 
 ### How They Interact
 
@@ -181,6 +309,9 @@ Set to `0` to disable automatic cleanup for that signature type.
 2. Upstream cleanup runs daily as a safety net
 3. No conflict: zoo deletes before upstream sees the signatures
 4. Upstream catches signatures in never-accessed systems
+
+The fork also hardened the upstream collector itself — see
+[Tier 1](#tier-1-strongly-recommend).
 
 ---
 
@@ -203,138 +334,212 @@ Allows users to mark characters as "ready for fleet" operations.
 | Ash Resource | `lib/wanderer_app/api/map_user_settings.ex` (update_ready_characters action) |
 | Repository | `lib/wanderer_app/repositories/map_user_settings_repo.ex` |
 
+> **Known gap:** `WANDERER_FLEET_READINESS_ENABLED` is parsed in `config/runtime.exs` and
+> stored under `:wanderer_app, :fleet_readiness_enabled`, but **nothing reads it** — there is
+> no `Env` accessor and no call site. The feature is unconditionally on. Either wire the flag
+> up (mirroring `Env.intel_sharing_enabled?/0`) or delete it from `runtime.exs`.
+
+---
+
+## Deployment (Fly.io)
+
+The fork deploys to Fly.io; upstream's VM release pipeline was dropped (`ce58765b9`).
+
+### Fly-specific behaviour
+
+| Concern | Handling |
+|---------|----------|
+| Hostname | `ConfigHelpers.resolve_host/2` — `PHX_HOST` wins, `FLY_APP_NAME` is the fallback |
+| Base URL | `ConfigHelpers.resolve_web_app_url/4` — `WEB_APP_URL` wins, https assumed on Fly |
+| Route builder over 6PN | `RouteBuilderClient.connect_opts/0` sets `inet6: true` (IPv4 fallback retained) |
+| Kills websocket over 6PN | `WANDERER_KILLS_IPV6` (default `false`), mirrors the `ECTO_IPV6` precedent |
+| Health check | `GET /health` → `HealthController` |
+
+> The `/health` route's **position in `router.ex` is load-bearing**: it must stay above
+> `live "/:slug", MapLive, :index`, or the wildcard swallows it and returns a 302 to
+> `/welcome`. Its pipeline is deliberately minimal — no `CheckApiDisabled`, no auth, no rate
+> limiting — because Fly kills a machine that fails its health check and there is one machine.
+
+### Gated deploy
+
+`.github/workflows/zoo-deploy.yml` implements an approval-gated deploy for `guarzo/zoo`.
+Design and plan: `docs/superpowers/specs/2026-08-07-deploy-approval-gate-design.md` and
+`docs/superpowers/plans/2026-08-07-deploy-approval-gate.md`. The Fly credential is read from
+`FLY_DEPLOY_TOKEN` (not `FLY_API_TOKEN`), and the release number is read from `.Version`.
+
+---
+
+## CI
+
+`.github/workflows/test.yml` was restructured (`e815c2283`, #121) from upstream's single
+monolithic job into:
+
+- `setup` — one dependency install/compile, cached for the rest
+- `tests` — 4-way `mix test --partitions` matrix (`PARTITIONS` env must match `config/test.exs`)
+- `static` — format, warning count, Credo
+- `dialyzer` — PLT build + run
+- `coverage` — coverage report and PR comment
+
+The workflows also run on `guarzo/zoo` pull requests (`2e6487a84`, #117).
+
+---
+
+## Configuration Reference
+
+### Compile-time (`config/config.exs`)
+
+```elixir
+config :wanderer_app, :signatures,
+  wormhole_expiration_hours: 24,
+  default_expiration_hours: 72,
+  preserve_connected: true
+
+config :wanderer_app, :signature_cleanup, max_age_hours: 24
+```
+
+### Runtime environment variables (`config/runtime.exs`)
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `WANDERER_INTEL_SHARING_ENABLED` | `false` | Enable cross-map intel sync |
+| `WANDERER_FLEET_READINESS_ENABLED` | `false` | **Currently unused — see Fleet Readiness** |
+| `WANDERER_KILLS_IPV6` | `false` | Resolve the kills websocket host over IPv6 |
+| `DISCORD_BOT_TOKEN` | — | Nostrum bot token; blank is treated as unset |
+| `DISCORD_GUILD_ID` | — | Guild for voice-participant lookups |
+| `WANDERER_DISCORD_MENTIONS_ENABLED` | `true` | Master switch for mentions |
+| `WANDERER_DISCORD_MAX_KILLMAIL_AGE_SECONDS` | `3600` | Drop killmails older than this |
+| `WANDERER_DISCORD_POOL_SIZE` | `10` | Finch pool size for webhook delivery |
+| `WANDERER_NOTABLE_ITEMS_ENABLED` | `false` | Enrich embeds with high-value drops |
+| `WANDERER_NOTABLE_ITEMS_THRESHOLD_ISK` | `50000000` | Minimum item value to list |
+| `WANDERER_NOTABLE_ITEMS_LIMIT` | `5` | Max items per embed |
+| `WANDERER_NOTABLE_ITEMS_TIMEOUT_MS` | `1500` | Per-batch ESI budget |
+| `WANDERER_CORP_TICKERS_ENABLED` | `true` | Resolve missing corp tickers from ESI |
+| `WANDERER_CORP_TICKERS_TIMEOUT_MS` | `1500` | Per-element ESI budget |
+| `SIGNATURE_WORMHOLE_EXPIRATION_HOURS` | `24` | Hours until wormhole signatures expire (`0` disables) |
+| `SIGNATURE_DEFAULT_EXPIRATION_HOURS` | `72` | Hours until other signatures expire (`0` disables) |
+
+### Pinned dependencies
+
+| Dependency | Constraint | Reason |
+|------------|-----------|--------|
+| `phoenix_gen_socket_client` | `== 4.0.0` | `Kills.Transport.WebSocketClient` depends on its private handler-state shape |
+| `gettext` | `~> 0.26` | `WandererAppWeb.Gettext` uses `Gettext.Backend`, absent before 0.26 |
+| `nostrum` | `~> 0.10`, `runtime: false` | Voice mentions only; `:load` in the release |
+
 ---
 
 ## Upstream PR Recommendations
 
 ### Tier 1: Strongly Recommend
 
-These features are well-implemented, low-risk, and provide universal value:
+Generic bug fixes and infrastructure with no zoo coupling. Each is independently PR-able.
 
-#### 1. On-Demand Signature Cleanup
+#### 1. Route static-data lookups can kill the caller (crash fix)
 
-**Why:** All Wanderer users deal with signature clutter. This is configurable, disabled by default, and complements the existing GarbageCollector.
+`Task.async_stream/3` was used on default options in `map_routes.ex` and `routes_by.ex`.
+The default is `on_timeout: :exit`, and `async_stream` links its tasks, so a single
+`CachedInfo.get_system_static_info/1` overrunning the 5s default killed the **calling**
+process. For `Routes.find/5` the caller is a plain `Task.async` linked to the LiveView,
+which does not trap exits — so one slow lookup remounted the user's whole map session. The
+`Enum.map(fn {:ok, val} -> val end)` collector also FunctionClauseErrors on `{:exit, _}`.
 
-**Scope:**
-- `map_signatures_event_handler.ex` (cleanup_expired_signatures/1 function)
-- `config/config.exs` (signature cleanup configuration)
-- ~80 lines of code, no breaking changes
+**Upstream still has both sites unfixed** (`map_routes.ex:59`, `routes_by.ex:165`).
+**Scope:** `cached_info.ex`, `map_routes.ex`, `routes_by.ex`, new `route_static_data.ex`, tests.
+**Commit:** `03454f669` (#127).
 
-**Suggested PR Title:** "feat: Add configurable on-demand signature cleanup"
+#### 2. ESI access-token checks raise on characters with no token
 
-#### 2. Corporation/Alliance Ticker Fetching
+`is_access_token_expired?/1` did `{:ok, %{expires_at: expires_at}} = get_character(id)` and
+then arithmetic on `expires_at`. `expires_at` is nullable, and `get_character/1` answers
+`{:ok, nil}` / `{:error, :not_found}` — so unauthenticated or unknown characters raised
+MatchError/ArithmeticError on **every** authenticated ESI call (location, online, ship,
+wallet, search), not just the corporation search where it was noticed. `time_since_expiry/1`
+had the same `DateTime.from_unix!(nil)` problem.
 
-**Why:** Generic utility that any feature showing corp/alliance info could use. Minimal footprint, uses existing ESI infrastructure.
+**Scope:** `lib/wanderer_app/esi/api_client.ex` + tests. **Commit:** within `cb2b8d024` (#103).
 
-**Scope:**
-- `map_systems_event_handler.ex` (get_corporation_ticker, get_alliance_ticker handlers)
-- ~30 lines of code, no breaking changes
+#### 3. GarbageCollector aborts on stale records
 
-**Suggested PR Title:** "feat: Add corporation/alliance ticker lookup via UI events"
+`Ash.bulk_destroy!` raises when a concurrently-deleted row turns up, killing the whole
+scheduled cleanup. The fork switches to `Ash.bulk_destroy/4` with `return_errors?: true`,
+filters `Ash.Error.Changes.StaleRecord`, and logs the rest.
 
-#### 3. Idempotent Migration Pattern
+**Scope:** `lib/wanderer_app/map/map_garbage_collector.ex`.
+**Note:** a code comment references a tuple-matching `case` that only ever existed on zoo —
+reword it before submitting.
 
-**Why:** Best practice documentation. Migrations should be safe to re-run.
+#### 4. Map duplication copies non-acceptable attributes
 
-**Scope:** Documentation PR only
+`copy_single_system/2` and `copy_single_connection/3` built attribute maps by
+`Map.from_struct |> Map.drop(denylist)`. Any attribute added to the resource and not added to
+the denylist leaks into `create`. Replaced with an allowlist derived from what the target Ash
+action actually accepts.
 
-**Pattern:**
-```elixir
-def up do
-  execute("ALTER TABLE table_name ADD COLUMN IF NOT EXISTS col text")
-end
+**Scope:** `lib/wanderer_app/map/operations/duplication.ex`.
 
-def down do
-  execute("ALTER TABLE table_name DROP COLUMN IF EXISTS col")
-end
-```
+#### 5. Parallel, correctly-cached CI
+
+Upstream runs one job doing format + compile + test + coverage + Credo + Dialyzer serially.
+The fork splits it into `setup` / 4-way partitioned `tests` / `static` / `dialyzer` /
+`coverage` and fixes the dependency caches. This is a straight wall-clock win for upstream.
+
+**Scope:** `.github/workflows/test.yml`, `config/test.exs` (partition count).
+**Commit:** `e815c2283` (#121).
+
+#### 6. Charlist deprecation in two migrations
+
+`default: '{wormholes}'` → `default: ~c"{wormholes}"` in `20260331192521` and `20260406213852`.
+Identical emitted DDL; removes a deprecation warning. Two-line PR that also removes a
+permanent merge-conflict point for every fork.
+
+#### 7. IPv6-reachable route builder
+
+`RouteBuilderClient` sets `inet6: true` (Mint keeps `inet4: true`, so IPv4 hosts still work
+after one failed resolution). Makes the route builder reachable on IPv6-only internal
+networks. Frame the PR as "support IPv6 route-builder hosts", not as a Fly change.
+
+**Scope:** `lib/wanderer_app/route_builder_client.ex`, `lib/wanderer_app/esi/api_client.ex`.
+
+#### 8. On-demand signature cleanup
+
+Configurable, complements the existing GarbageCollector rather than replacing it.
+
+**Scope:** `signature_cleanup.ex`, `map_signatures_event_handler.ex`, `config/config.exs`.
+
+#### 9. `GET /api/acls/:acl_id/members/:member_id`
+
+The ACL member API supports create/update/delete but not read. The fork adds `show` with a
+full OpenApiSpex schema covering the 404/409/500 branches `with_membership/4` can produce.
+
+**Scope:** `access_list_member_api_controller.ex`, `router.ex`. Drop the `*_v1` alias
+functions — those exist only for the fork's versioned router.
+
+#### 10. `JsonApiFormatter` payload contract
+
+`fix(json-api): correct JsonApiFormatter payload contract against real producers` (#105)
+reworked ~575 lines of `external_events/json_api_formatter.ex` against what the actual event
+producers emit. This is an upstream file with upstream consumers — worth a PR, but it needs
+its own before/after write-up since it changes emitted payloads.
 
 ### Tier 2: Consider with Modifications
 
-#### Configurable Label System
-
-The pattern of theme-configurable labels is valuable, but requires refactoring to make labels theme-aware. Better suited for discussion issue first.
-
-#### Fleet Readiness / Character Tagging
-
-Could be generalized to a "character tags" system. Requires significant refactoring.
+| Feature | Blocker |
+|---------|---------|
+| Discord notifications | ~4,600 lines, 2 tables, a new dependency, and a Nostrum gateway. Open a design issue before writing the PR; consider splitting delivery (worker/router/embed) from voice mentions and route alerts. |
+| Intel sharing | Generally useful, but needs upstream buy-in on the `intel_source_map_id` model and the `inherited_from_map_id` marker before the schema lands. |
+| Fleet readiness | Generalize to a "character tags" system first. |
+| Configurable label system | Needs labels to become theme-aware; discussion issue first. |
+| `/health` endpoint | Trivially useful, but the router-ordering constraint and the deliberately unprotected pipeline need to be explained, not just merged. |
 
 ### Tier 3: Keep Zoo-Only
 
 | Feature | Reason |
 |---------|--------|
-| Zoo Theme | Highly specific to EVE wormhole gameplay |
-| System Ownership | Specific to tracking wormhole space occupation |
-| Custom Flags | Generic "store anything" field lacks structure |
-| Connection Loop Type | Niche EVE mechanic |
-
----
-
-## Deployment
-
-Production is the Fly app `wanderer` (single machine — see the constraint
-comment at the top of `fly.toml`).
-
-**How a change reaches production:**
-
-1. Merge to `guarzo/zoo`.
-2. `🧪 Test Suite` runs. If it fails, a `🚀 Zoo Deploy` run still appears in the
-   Actions tab but its only job is **skipped** — no approval is requested and
-   nothing can be deployed. Skipped deploy runs after a red suite are normal.
-3. On success, `🚀 Zoo Deploy` opens a run that **waits for approval** in the
-   `production-deploy` environment. GitHub emails an approval request; the run
-   also shows as pending in the Actions tab.
-4. Approving it deploys to Fly, then tags the commit `v<UTC timestamp>`.
-
-**The newest `v20*` tag is the record of what is in production.** No branch
-tracks it. To see what you have written but not yet deployed:
-
-```bash
-git fetch origin --tags
-git log --oneline "$(git tag -l 'v20*' | sort | tail -1)"..guarzo/zoo
-```
-
-**`guarzo/release` is retired.** It used to be the deploy trigger — hard-resetting
-and pushing it was how you shipped. It no longer moves, deploys nothing, and is
-frozen by a ruleset that rejects pushes to it, so the old habit fails loudly
-instead of silently doing nothing. It survives only as a marker of where the
-old process stopped.
-
-**Nothing deploys without approval**, including a run that has been sitting
-pending. Pending approvals expire after 30 days.
-
-**To roll back**, run `🚀 Zoo Deploy` manually with `ref` set to a previous tag
-and approve it. Note that migrations only run forward — a rollback does not
-revert a schema change.
-
-**Approving a stale run is safe.** If `guarzo/zoo` has moved on since the run
-was created, the workflow exits without deploying and says so.
-
-**If a deploy half-succeeded.** The deploy and the tag push are two separate
-steps, not one atomic operation. If the deploy step fails, nothing else runs and
-production is unchanged (or partially migrated if the `release_command`
-succeeded before the health check failed — see `fly.toml`). If the tag push
-fails after a successful deploy, that is the dangerous case: production is now
-running a commit that carries **no tag**, and the tag is the only record of what
-is live. If `guarzo/zoo` is rebased or squashed before this is fixed, that commit
-becomes unreachable from any ref — the exact loss this whole mechanism exists to
-prevent. Recover by running `🚀 Zoo Deploy` manually (`workflow_dispatch`) with
-`ref` set to the deployed commit's explicit SHA and approving it: this skips the
-staleness guard, so it works even after `guarzo/zoo` has moved on, and it
-redeploys and tags the commit. The only cost is one extra machine restart,
-because the app runs exactly one machine. Simply re-running (or re-approving)
-the automatic path does **not** recover this — once `guarzo/zoo` has moved, the
-staleness guard blocks it.
-
-**`FLY_DEPLOY_TOKEN` must stay an environment secret on `production-deploy`, never
-a repository secret** — an environment secret is released only to a job that
-has cleared the approval gate, which is the entire point. The name is
-deliberately not `FLY_API_TOKEN`: `advanced-test.yml` reads a secret of that
-name with no environment gate, targeting the separate `wanderer-test` app.
-Keeping the names distinct means this production credential can never be picked
-up by that ungated workflow, whatever gets added to repository secrets later.
-The workflow maps it onto the `FLY_API_TOKEN` env var that `flyctl` itself
-reads.
+| Zoo theme | Highly specific to EVE wormhole gameplay |
+| System ownership | Specific to tracking wormhole space occupation |
+| Custom flags | Generic "store anything" field lacks structure |
+| Connection loop type | Niche EVE mechanic |
+| Fly.io deployment / gated deploy workflow | Deployment-target specific |
 
 ---
 
@@ -350,6 +555,7 @@ assets/js/hooks/Mapper/
 │   ├── constants.ts (modified)
 │   └── components/
 │       ├── SolarSystemNode/SolarSystemNodeZoo.tsx
+│       ├── SolarSystemNode/SolarSystemNodeZoo.module.scss
 │       └── ZooIcons/
 ├── components/mapRootContent/components/FleetReadiness/
 └── types/connection.ts (ConnectionType.loop added)
@@ -359,6 +565,14 @@ assets/js/hooks/Mapper/
 
 ```
 lib/wanderer_app/
+├── external_events/
+│   ├── discord_dispatcher.ex
+│   └── discord/                       # 14 modules, see Discord Notifications
+├── map/
+│   ├── intel_sync.ex
+│   ├── signature_cleanup.ex
+│   ├── route_alert/evaluator.ex
+│   └── route_static_data.ex           # extracted by the routes timeout fix
 ├── api/
 │   ├── map_system.ex (owner_*, custom_flags attributes)
 │   └── map_user_settings.ex (ready_characters attribute)
@@ -366,26 +580,23 @@ lib/wanderer_app/
     ├── map_system_repo.ex (update_owner function)
     └── map_user_settings_repo.ex (ready_characters functions)
 
-lib/wanderer_app_web/live/map/event_handlers/
-├── map_systems_event_handler.ex (ticker fetching)
-├── map_signatures_event_handler.ex (cleanup_expired_signatures)
-└── map_characters_event_handler.ex (fleet readiness)
+lib/wanderer_app_web/
+├── controllers/health_controller.ex
+└── live/map/event_handlers/
+    ├── map_systems_event_handler.ex (ticker fetching)
+    ├── map_signatures_event_handler.ex (cleanup_expired_signatures)
+    └── map_characters_event_handler.ex (fleet readiness)
 ```
 
-### Migrations
+### Design docs
 
 ```
-priv/repo/migrations/
-├── 20250122214138_add_zoo_flags.exs
-├── 20250204223853_add_system_owners.exs
-├── 20250307165740_add_owner_ticker.exs
-└── 20250625024813_add_fleet_readiness_ready_characters.exs
-```
-
-### Configuration
-
-```
-config/config.exs (signature cleanup configuration, lines 149-159)
+docs/superpowers/
+├── specs/2026-08-02-flyio-migration-design.md
+├── specs/2026-08-07-deploy-approval-gate-design.md
+├── specs/2026-08-07-discord-route-alerts-design.md
+├── specs/2026-08-07-discord-voice-mentions-design.md
+└── plans/…                            # one plan per spec
 ```
 
 ---
@@ -396,9 +607,23 @@ config/config.exs (signature cleanup configuration, lines 149-159)
 
 When merging upstream, watch for conflicts in:
 
-1. `constants.ts` - Label and bookmark style changes
-2. `map_system.ex` - Attribute additions
-3. `config/config.exs` - Configuration additions
+1. `priv/repo/migrations/` — especially any upstream `FixMapsScopesDefault`; see the warning above
+2. `config/runtime.exs` — the fork adds ~65 lines at the tail and rewrites the host/URL block
+3. `mix.exs` — pinned `phoenix_gen_socket_client`, `gettext` floor, `nostrum`, release applications
+4. `lib/wanderer_app_web/router.ex` — the `/health` scope's position
+5. `lib/wanderer_app/external_events/json_api_formatter.ex` — heavily rewritten
+6. `assets/…/map/constants.ts` — label and bookmark style changes
+7. `lib/wanderer_app/api/map_system.ex` — attribute additions
+8. `priv/resource_snapshots/` — regenerate rather than merge
+
+### Keeping the fork current
+
+```bash
+git fetch upstream --prune
+git rev-list --left-right --count upstream/main...origin/guarzo/zoo   # behind / ahead
+```
+
+As of this document the fork is 0 behind both `upstream/main` and `upstream/develop`.
 
 ### Testing
 

--- a/docs/ZOO-FORK.md
+++ b/docs/ZOO-FORK.md
@@ -24,9 +24,10 @@ for upstream contribution.
 9. [Deployment (Fly.io)](#deployment-flyio)
 10. [CI](#ci)
 11. [Configuration Reference](#configuration-reference)
-12. [Upstream PR Recommendations](#upstream-pr-recommendations)
-13. [Key Files Reference](#key-files-reference)
-14. [Maintenance Notes](#maintenance-notes)
+12. [Commit Convention](#commit-convention)
+13. [Upstream PR Recommendations](#upstream-pr-recommendations)
+14. [Key Files Reference](#key-files-reference)
+15. [Maintenance Notes](#maintenance-notes)
 
 ---
 
@@ -427,6 +428,59 @@ config :wanderer_app, :signature_cleanup, max_age_hours: 24
 | `phoenix_gen_socket_client` | `== 4.0.0` | `Kills.Transport.WebSocketClient` depends on its private handler-state shape |
 | `gettext` | `~> 0.26` | `WandererAppWeb.Gettext` uses `Gettext.Backend`, absent before 0.26 |
 | `nostrum` | `~> 0.10`, `runtime: false` | Voice mentions only; `:load` in the release |
+
+---
+
+## Commit Convention
+
+Fork-only work uses **`zoo(<type>): <summary>`**:
+
+```
+zoo(feat): add voice-channel mentions to route alerts
+zoo(fix): stop one slow static lookup from killing the whole request
+zoo(chore): drop the dead fleet-readiness flag
+zoo(docs): document the intel-sharing config surface
+```
+
+Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`.
+
+### Why the type sits in the scope position
+
+This inverts the Angular format in `.gitmessage`, which is `<type>(<scope>)`. That is
+deliberate. The fork's dominant recurring question is *"which commits are ours?"* — every
+upstream merge, every extraction for an upstream PR, and every `git blame` into a diverged
+subsystem needs that answer. Putting `zoo` first makes it a prefix match:
+
+```bash
+git log --grep '^zoo(' upstream/main..HEAD      # everything fork-only
+git log --grep -v '^zoo(' upstream/main..HEAD   # candidates to send upstream
+```
+
+With `feat(zoo):` the marker is buried mid-subject and the same query needs a regex that also
+matches `fix(zoo)`, `chore(zoo)`, and so on.
+
+### When *not* to use it
+
+**Anything intended for upstream keeps the plain Angular format** — `fix(routes): …`,
+`feat(api): …`. The `zoo(` prefix is the signal that a commit is *not* upstreamable, so
+applying it to a commit you plan to send upstream defeats the whole mechanism and means the
+message has to be rewritten at extraction time.
+
+If a change is partly both, split it: the upstreamable part gets a plain-format commit, the
+fork-specific remainder gets `zoo(…)`.
+
+### Everything else from `.gitmessage` still applies
+
+100-character wrapping, imperative present tense, and a body explaining *why* rather than
+restating the diff. The body is mandatory except for `docs`, and at least 20 characters when
+required.
+
+### Enforcement
+
+None currently — the repo has no commitlint or husky config, so this is convention only. A
+`commit-msg` hook rejecting subjects that match neither `^zoo\((feat|fix|chore|docs|refactor|perf|test|build|ci)\):`
+nor the plain Angular pattern would enforce it, at the cost of imposing a hook on every
+contributor. Not added yet.
 
 ---
 

--- a/docs/ZOO-FORK.md
+++ b/docs/ZOO-FORK.md
@@ -375,7 +375,9 @@ Design and plan: `docs/superpowers/specs/2026-08-07-deploy-approval-gate-design.
 monolithic job into:
 
 - `setup` — one dependency install/compile, cached for the rest
-- `tests` — 4-way `mix test --partitions` matrix (`PARTITIONS` env must match `config/test.exs`)
+- `tests` — 4-way `mix test --partitions` matrix (the `PARTITIONS` env var must match the
+  `partition` matrix list; `config/test.exs` already suffixes the database name with
+  `MIX_TEST_PARTITION`, which is upstream's default)
 - `static` — format, warning count, Credo
 - `dialyzer` — PLT build + run
 - `coverage` — coverage report and PR comment

--- a/docs/prompts-2026-08-08.md
+++ b/docs/prompts-2026-08-08.md
@@ -1,0 +1,801 @@
+# Fork Follow-Up Prompts
+
+Generated 2026-08-08 from a review of `guarzo/zoo` against `wanderer-industries/wanderer`.
+
+Each numbered prompt below is **self-contained** and written for a fresh session with no
+prior context. Start one with:
+
+> read `docs/prompts-2026-08-08.md`, work on prompt 3
+
+Do not paraphrase the prompt to the session — the whole point is that it reads the file
+itself, including the shared context and ground rules.
+
+---
+
+## Shared context (every prompt depends on this)
+
+| Fact | Value |
+|------|-------|
+| Fork repo | `guarzo/wanderer` — remote `origin` |
+| Upstream repo | `wanderer-industries/wanderer` — remote `upstream` |
+| Fork branch | `guarzo/zoo` |
+| Upstream baseline at review time | `upstream/main` @ `b7ddbc486`, `upstream/develop` @ `35ea4e5f1` |
+| Divergence at review time | 58 commits / 312 files ahead; 0 behind either upstream branch |
+| Fork documentation | `docs/ZOO-FORK.md` — read the relevant section before starting |
+
+Re-verify the baseline before you start, because it moves:
+
+```bash
+git fetch upstream --prune
+git rev-list --left-right --count upstream/main...origin/guarzo/zoo   # behind<TAB>ahead
+```
+
+If the fork is now *behind* upstream, say so and stop — several of these prompts assume the
+upstream code still contains the bug being fixed, and that assumption needs rechecking.
+
+---
+
+## Ground rules for every prompt
+
+1. **Work in a linked worktree.** Do not write to the primary checkout. One worktree per
+   prompt — that is what makes these safe to run in parallel.
+2. **Never push and never open a PR without asking.** Prompts 1–10 end at "branch is ready,
+   PR body is drafted". Opening a PR against someone else's repository is the human's call.
+   Prepare everything, show the diff and the draft body, then stop.
+3. **Do not use the git stash.** The stash stack is shared across worktrees and other
+   sessions may be using it. Use a WIP commit instead.
+4. **Verify before claiming.** Run the checks listed in the prompt and report actual output.
+   If a check fails or you could not run it, say which one and why. Never report a command
+   as passing that you did not run.
+5. **Stay in scope.** These are deliberately small. If you find an adjacent problem, write it
+   down in your report rather than fixing it.
+
+### Useful commands
+
+```bash
+mix format --check-formatted
+mix credo
+mix test                              # full suite: ~1595 tests at review time
+mix test test/unit/some_test.exs      # focused
+mix dialyzer                          # 153 pre-existing lib warnings is the known baseline
+make format                           # = mix format
+cd assets && yarn build               # frontend
+```
+
+---
+
+## ⚠ The single most important warning
+
+**Most of these changes cannot be cherry-picked.** They are either buried inside three
+undescriptive mega-commits, or they share a file with fork-only work. A naive
+`git cherry-pick` or a path-scoped `git diff upstream/main...origin/guarzo/zoo -- <path>`
+will drag zoo-only code into what is supposed to be a clean upstream PR.
+
+Worked example — `lib/wanderer_app/map/map_routes.ex` diverges from upstream by ~135 lines,
+but only ~37 of those are the timeout fix in prompt 1. The rest is `find_strict/5`, which
+exists solely to serve zoo's Discord route alerts and must **not** go upstream.
+
+So for every extraction prompt: start from the path diff to *find* the change, then
+hand-assemble the minimal patch, then confirm the result compiles and tests against
+`upstream/main` **without** any zoo module in scope.
+
+---
+
+## Parallel-safety matrix
+
+Prompts that touch a shared file must not run at the same time. Everything else is
+independent.
+
+| Prompt | Primary files | Conflicts with |
+|--------|---------------|----------------|
+| 1 | `map_routes.ex`, `routes_by.ex`, `cached_info.ex`, `route_static_data.ex` | — |
+| 2 | `esi/api_client.ex` | **7** |
+| 3 | `map_garbage_collector.ex` | — |
+| 4 | `map/operations/duplication.ex` | — |
+| 5 | `.github/workflows/test.yml` | — |
+| 6 | two migration files | — |
+| 7 | `route_builder_client.ex`, `esi/api_client.ex` | **2** |
+| 8 | `signature_cleanup.ex`, `map_signatures_event_handler.ex`, `config/config.exs` | — |
+| 9 | `access_list_member_api_controller.ex`, `router.ex` | — |
+| 10 | `external_events/json_api_formatter.ex` | — |
+| 11 | `config/runtime.exs`, `docs/ZOO-FORK.md` (fork branch) | **13**, **14** |
+| 12 | none (investigation + doc) | — |
+| 13 | `docs/ZOO-FORK.md` (fork branch) | **11**, **14** |
+| 14 | `docs/ZOO-FORK.md` (fork branch) | **11**, **13** |
+| 15 | none (branch deletion) | — |
+
+**Prompts 2 and 7 both edit `lib/wanderer_app/esi/api_client.ex`.** Run 2 first, then 7 —
+or run them together under prompt 2's instructions and split into two commits.
+
+Prompts 1–10 each produce an independent branch off `upstream/main`, so they never conflict
+with each other in the fork. Prompts 11, 13, 14 branch off `origin/guarzo/zoo`.
+
+---
+
+# Group A — Upstream PR candidates (prompts 1–10)
+
+Every prompt in this group has the same shape:
+
+1. Create a worktree and branch **from `upstream/main`**, not from `guarzo/zoo`.
+2. Reconstruct the minimal change (see the warning above).
+3. Confirm the bug/gap still exists upstream before writing the fix. If upstream has already
+   fixed it, stop and report that — do not open a redundant PR.
+4. Include tests. Upstream will not take an unproven crash fix.
+5. Run `mix format --check-formatted`, `mix credo`, and the relevant tests.
+6. Draft the PR title and body. Explain the failure mode, not the patch.
+7. **Stop. Show the diff and the draft. Ask before pushing.**
+
+---
+
+## Prompt 1 — Route static-data lookups can kill the calling process
+
+**This is the highest-value item in the list. Do it first if you only do one.**
+
+### The bug
+
+`Task.async_stream/3` is called with default options in two places. The default is
+`on_timeout: :exit`, and `async_stream` **links** its tasks — so a single
+`WandererApp.CachedInfo.get_system_static_info/1` call that overruns the 5-second default
+kills the *calling* process, not just the one lookup.
+
+For `Routes.find/5` the caller is a plain `Task.async` linked to the LiveView, which does not
+trap exits. One slow lookup therefore remounts the user's entire map session. Separately, the
+collector `Enum.map(fn {:ok, val} -> val end)` raises FunctionClauseError the moment any
+element yields `{:exit, _}`.
+
+### Verified upstream locations
+
+- `lib/wanderer_app/map/map_routes.ex:59`
+- `lib/wanderer_app/map/routes_by.ex:165` (inside `fetch_systems_static_data/1`)
+
+Confirm both are still present on the current `upstream/main` before proceeding.
+
+### Where the fix lives on the fork
+
+Commit `03454f669` (#127) — **this one is unusually clean**. `cached_info.ex` and
+`routes_by.ex` are touched by that commit and nothing else, so those two files can be taken
+almost as-is.
+
+`map_routes.ex` **cannot**. It also carries `find_strict/5`, which exists only for zoo's
+Discord route alerts. Take the `hydrate_static_data/2` extraction and the `find/5` changes;
+leave `find_strict/5` behind.
+
+`lib/wanderer_app/map/route_static_data.ex` is a new module introduced by that commit. Decide
+whether upstream wants the extraction or just the inline fix — the extraction is cleaner but
+it is a bigger ask. Presenting the inline fix as the PR and mentioning the extraction as a
+follow-up is the safer play.
+
+### Approach
+
+Switch to `on_timeout: :kill_task` and pair it with a collector that handles `{:exit, _}` as
+well as `{:ok, _}`, dropping the timed-out entries rather than failing the batch.
+
+### Tests
+
+`test/unit/cached_info_static_info_test.exs` and
+`test/unit/map/map_routes_find_strict_test.exs` on the fork cover this. Port the parts that
+apply to `find/5`; the `find_strict/5` tests are zoo-only. Make sure a test actually blocks a
+named system long enough to trigger the timeout path — that is the assertion that fails
+without the fix.
+
+### Done when
+
+The reconstructed branch compiles against `upstream/main` with no reference to any zoo
+module, a test demonstrably fails without the fix and passes with it, and the PR body
+explains the LiveView-remount failure mode in user-visible terms.
+
+---
+
+## Prompt 2 — `is_access_token_expired?/1` raises for characters without a token
+
+⚠ **Conflicts with prompt 7** (same file). Run this one first.
+
+### The bug
+
+In `lib/wanderer_app/esi/api_client.ex`, upstream has:
+
+```elixir
+defp is_access_token_expired?(character_id) do
+  {:ok, %{expires_at: expires_at} = _character} =
+    WandererApp.Character.get_character(character_id)
+
+  now = DateTime.utc_now() |> DateTime.to_unix()
+  expires_at - now <= 0
+end
+```
+
+Three ways this blows up:
+
+- `expires_at` is nullable on `WandererApp.Api.Character`, so a character that never completed
+  an OAuth exchange carries `nil` → ArithmeticError.
+- `WandererApp.Character.get_character/1` answers `{:ok, nil}` for a nil id → MatchError.
+- …and `{:error, :not_found}` for an id not in the cache or the DB → MatchError.
+
+This fires on **every** authenticated ESI call — location, online, ship, wallet, search — not
+just the corporation search where it was originally noticed.
+
+`time_since_expiry/1` in the same module has the matching `DateTime.from_unix!(nil)` problem.
+
+### Where the fix lives on the fork
+
+Inside squash commit `cb2b8d024` (#103), which also contains unrelated corporation-typeahead
+work. **Extract, do not cherry-pick.** The file is also touched by `c32c9ca87` (#112, the
+IPv6 change — that is prompt 7) and by the `e791d4e10` mega-commit.
+
+### Approach
+
+Only an integer `expires_at` in the future counts as not-expired. Every other shape means
+validity cannot be proven, so report expired and let the caller take the refresh-and-retry
+path. `time_since_expiry/1` is diagnostic only and must degrade to `nil` rather than raise —
+timing instrumentation must never be the thing that fails a request.
+
+Note the fork made both functions public with `@doc false` purely so tests could reach them.
+Flag that to upstream rather than doing it silently; they may prefer a different test seam.
+
+### Done when
+
+A test constructs each of the three bad shapes and shows the old code raising and the new
+code returning `true`.
+
+---
+
+## Prompt 3 — GarbageCollector aborts the whole run on a stale record
+
+### The bug
+
+`lib/wanderer_app/map/map_garbage_collector.ex` uses `Ash.bulk_destroy!` for both
+`cleanup_chain_passages/0` and `cleanup_system_signatures/0`. The bang variant raises when a
+concurrently-deleted row turns up, which kills the entire scheduled cleanup — so one racing
+delete means no garbage is collected that day.
+
+### Where the fix lives on the fork
+
+**Only in the mega-commits** (`defb24439`, `e791d4e10`) plus `a91d4943f`. There is no clean
+commit to reference. Reconstruct from the current tree:
+
+```bash
+git diff upstream/main...origin/guarzo/zoo -- lib/wanderer_app/map/map_garbage_collector.ex
+```
+
+### Approach
+
+Switch to non-bang `Ash.bulk_destroy/4` with `return_errors?: true`, filter out
+`Ash.Error.Changes.StaleRecord` (both bare and wrapped in `Ash.Error.Invalid`), log the rest
+as warnings, and count only the stale ones as race conditions.
+
+### ⚠ Fix before submitting
+
+The fork's version carries this comment:
+
+> `Ash.bulk_destroy/4` returns a bare `%Ash.BulkResult{}`, never an `{:ok, _}` / `{:error, _}`
+> tuple, so the previous tuple-matching `case` raised CaseClauseError on every run.
+
+That "previous tuple-matching `case`" **only ever existed on zoo**. Upstream goes straight
+from `bulk_destroy!` to the new code, so the comment describes history upstream does not
+have. Reword it before submitting.
+
+---
+
+## Prompt 4 — Map duplication copies attributes the create action does not accept
+
+### The bug
+
+In `lib/wanderer_app/map/operations/duplication.ex`, both `copy_single_system/2` and
+`copy_single_connection/3` build their attribute map as
+`Map.from_struct() |> Map.drop(excluded_fields)` — a hand-maintained denylist of system
+fields and Ash/Ecto metadata.
+
+Any attribute added to `MapSystem` or `MapConnection` that nobody remembers to add to the
+denylist leaks straight into `create`. The denylist is duplicated verbatim in both functions,
+so it can also drift against itself.
+
+### Where the fix lives on the fork
+
+Mega-commits only. Reconstruct from:
+
+```bash
+git diff upstream/main...origin/guarzo/zoo -- lib/wanderer_app/map/operations/duplication.ex
+```
+
+### Approach
+
+Replace the denylist with an allowlist derived from what the target Ash action actually
+accepts (`acceptable_attrs/3` in the fork's version). This inverts the failure mode: a new
+attribute is silently *not* copied until someone opts it in, instead of being silently copied
+into an action that may reject it.
+
+Call that tradeoff out explicitly in the PR body — it is a behaviour change, and a reviewer
+will want to have thought about it.
+
+---
+
+## Prompt 5 — Split the CI test suite into parallel jobs
+
+### The gap
+
+Upstream's `.github/workflows/test.yml` is a single job running format → compile → test →
+coverage → Credo → Dialyzer serially. Everything waits on everything.
+
+### The fork's version
+
+Commit `e815c2283` (#121) restructures it into:
+
+- `setup` — installs and compiles deps once, seeds the shared cache
+- `tests` — a 4-way `mix test --partitions` matrix
+- `static` — format check, warning count, Credo
+- `dialyzer` — PLT build + run
+- `coverage` — coverage report and PR comment
+
+It also fixes the dependency caches, which were the reason the fan-out did not help before.
+
+### ⚠ Strip the zoo-specific parts
+
+`test.yml` is also touched by `2e6487a84` (#117), which added `guarzo/zoo` branch triggers,
+and by `a91d4943f` (#118). The upstream PR must contain **only** the structural change — no
+zoo branch names anywhere in `on:`.
+
+### Coupling to preserve
+
+The `PARTITIONS` env var must match the length of the `partition` matrix list. `config/test.exs`
+already suffixes the database name with `MIX_TEST_PARTITION` (that is upstream's own default),
+so no config change is needed — but say so in the PR body so a reviewer does not go looking.
+
+### Done when
+
+The workflow is valid YAML, contains no zoo references, and the PR body quotes before/after
+wall-clock numbers if you can get them.
+
+---
+
+## Prompt 6 — Charlist deprecation in two migrations
+
+The smallest item here. Good warm-up.
+
+### The change
+
+In both of these files:
+
+- `priv/repo/migrations/20260331192521_add_mass_to_map_chain_passages.exs`
+- `priv/repo/migrations/20260406213852_add_character_description.exs`
+
+change:
+
+```elixir
+modify :scopes, {:array, :text}, default: '{wormholes}'
+```
+
+to:
+
+```elixir
+modify :scopes, {:array, :text}, default: ~c"{wormholes}"
+```
+
+### Why it is worth a PR despite being trivial
+
+The emitted DDL is byte-identical, so there is zero migration risk. It silences the Elixir
+single-quoted-charlist deprecation, and — the actual argument — it removes a file that
+currently conflicts on **every** merge for every downstream fork, because every fork has to
+make this same edit locally.
+
+Lead the PR body with the fork-maintenance argument, not the deprecation warning.
+
+### Note
+
+Editing already-applied migrations is normally a smell. Say explicitly in the PR body that
+the generated SQL is unchanged, so nobody has to work that out for themselves.
+
+---
+
+## Prompt 7 — Support IPv6-reachable route builder hosts
+
+⚠ **Conflicts with prompt 2** (same file). Run prompt 2 first.
+
+### The gap
+
+Mint resolves IPv4-only unless told otherwise. On any deployment where the route builder is
+reachable only over IPv6 — Fly's 6PN `.internal` addresses have no A record at all — every
+request fails with `:nxdomain`. Callers see an ordinary route-lookup failure and the ESI
+fallback reports "no connection" for every hub, so **nothing in the logs names DNS**. That
+diagnostic dead-end is the real cost.
+
+### The fix on the fork
+
+Commit `c32c9ca87` (#112) adds to `lib/wanderer_app/route_builder_client.ex`:
+
+```elixir
+@connect_opts [connect_options: [transport_opts: [inet6: true]]]
+def connect_opts, do: @connect_opts
+```
+
+merged into the existing `@timeout_opts` at each call site, and reused by
+`lib/wanderer_app/esi/api_client.ex` which posts to `/route/multiple` on the same service.
+
+### Why unconditional rather than a flag
+
+`inet6: true` keeps Mint's `inet4: true` default, so it tries IPv6 first and falls back to
+IPv4. Existing IPv4 docker-compose deployments keep working at the cost of one failed
+resolution per new connection. A flag left unset fails silently, which is the exact bug being
+fixed — make that argument in the PR body, because a reviewer will ask for a flag.
+
+### Framing
+
+Present this as "support IPv6 route-builder hosts", **not** as a Fly.io change. Nothing about
+the patch is Fly-specific and framing it that way invites a "we don't use Fly" rejection.
+
+---
+
+## Prompt 8 — Configurable on-demand signature cleanup
+
+### The feature
+
+Upstream expires signatures via a daily batch `GarbageCollector` at a hardcoded 14 days. The
+fork adds `WandererApp.Map.SignatureCleanup` (`lib/wanderer_app/map/signature_cleanup.ex`),
+invoked as `cleanup_async/1` from `map_signatures_event_handler.ex:199` and `:239` when a user
+views or updates signatures. It is per-system, configurable, and can preserve signatures that
+still have connections.
+
+The two mechanisms compose rather than compete: the on-demand pass deletes aggressively on
+interaction, and the daily batch remains the safety net for systems nobody visits.
+
+### Config surface
+
+```elixir
+config :wanderer_app, :signatures,
+  wormhole_expiration_hours: 24,   # env: SIGNATURE_WORMHOLE_EXPIRATION_HOURS
+  default_expiration_hours: 72,    # env: SIGNATURE_DEFAULT_EXPIRATION_HOURS
+  preserve_connected: true
+
+config :wanderer_app, :signature_cleanup, max_age_hours: 24
+```
+
+`0` disables cleanup for that signature type.
+
+### Where it lives
+
+Mega-commits only — reconstruct from the tree. Also read `lib/wanderer_app/map/README.md:52`,
+which documents the interaction and should be part of the PR.
+
+### Before you start
+
+Check whether upstream has since made the GarbageCollector thresholds configurable. If they
+have, this PR probably becomes "make the existing cleanup on-demand" rather than a new module,
+which is a smaller and more likely-to-land change.
+
+### Note on defaults
+
+The fork's 24h/72h defaults are far more aggressive than upstream's 14 days. Propose defaults
+that preserve upstream's current behaviour and let operators opt into the shorter windows —
+a PR that silently makes everyone's signatures vanish sooner will not land.
+
+---
+
+## Prompt 9 — Add `GET /api/acls/:acl_id/members/:member_id`
+
+### The gap
+
+The ACL member API supports create, update-role, and delete, but has no read endpoint. A
+client that just created a member cannot fetch it back.
+
+### The fork's version
+
+Adds a `show/2` action to `lib/wanderer_app_web/controllers/access_list_member_api_controller.ex`
+delegating to the existing `with_membership/4` helper, plus a route in `router.ex`:
+
+```elixir
+get "/:acl_id/members/:member_id", AccessListMemberAPIController, :show
+```
+
+It ships a full OpenApiSpex schema covering all four statuses `with_membership/4` can actually
+produce: 200, 404, 409 (more than one membership matches), 500.
+
+### ⚠ Strip before submitting
+
+The fork's diff also adds `show_v1`, `create_v1`, `update_role_v1`, `delete_v1` alias
+functions. Those exist purely for the fork's versioned API router and must **not** go
+upstream.
+
+### Where it lives
+
+Mega-commits. Reconstruct from the tree.
+
+### Done when
+
+The endpoint has request tests for the 200, 404, and 409 paths, and the OpenAPI spec still
+generates cleanly.
+
+---
+
+## Prompt 10 — `JsonApiFormatter` payload contract
+
+**The riskiest item in this group. Read this whole prompt before starting.**
+
+### What it is
+
+`fix(json-api): correct JsonApiFormatter payload contract against real producers` (`725b44a4d`,
+#105) reworked ~575 lines of `lib/wanderer_app/external_events/json_api_formatter.ex` so the
+emitted payloads match what the event producers actually send, rather than what the formatter
+assumed.
+
+This is an upstream file with upstream consumers — external webhook and SSE subscribers.
+
+### Why it is risky
+
+It **changes emitted payloads**. Anyone consuming the current output may be depending on the
+current (wrong) shape. This cannot be presented as a pure bugfix.
+
+### Good news
+
+`json_api_formatter.ex` is touched by **only** commit `725b44a4d` on the fork, so unlike the
+other prompts this one is a genuine clean cherry-pick candidate. Verify that is still true:
+
+```bash
+git log --oneline upstream/main..origin/guarzo/zoo -- lib/wanderer_app/external_events/json_api_formatter.ex
+```
+
+### What the PR needs that the others do not
+
+- A before/after table of every payload shape that changes.
+- An explicit statement of which changes are breaking for existing consumers.
+- A recommendation on whether upstream should version the event format.
+
+Consider opening a **discussion issue first** with the before/after table and letting upstream
+decide whether they want the PR. That is a legitimate outcome for this prompt — do not force
+it into a PR.
+
+---
+
+# Group B — Fork-side fixes (prompts 11–13)
+
+These branch from `origin/guarzo/zoo` and stay in the fork.
+
+---
+
+## Prompt 11 — Resolve the dead `WANDERER_FLEET_READINESS_ENABLED` flag
+
+### The finding
+
+`config/runtime.exs:86` parses `WANDERER_FLEET_READINESS_ENABLED` (default `"false"`) and
+line 202 stores it as `:wanderer_app, :fleet_readiness_enabled`. **Nothing reads it.** Verify:
+
+```bash
+grep -rn "fleet_readiness" --include='*.ex' --include='*.exs' --include='*.ts' --include='*.tsx' . | grep -v deps/
+```
+
+At review time that returned exactly two hits, both in `config/runtime.exs`.
+
+So the fleet-readiness feature is unconditionally on, and an operator who sets the flag to
+`false` gets no effect and no warning — which is worse than not having the flag.
+
+### Two valid outcomes — decide, then do one
+
+1. **Wire it up.** Add `Env.fleet_readiness_enabled?/0` mirroring
+   `Env.intel_sharing_enabled?/0` (`lib/wanderer_app/env.ex:22`), and gate the feature. Find
+   the real gate points first: the event handler in
+   `map_characters_event_handler.ex`, the `update_ready_characters` action in
+   `lib/wanderer_app/api/map_user_settings.ex`, and the frontend
+   `components/mapRootContent/components/FleetReadiness/`. Decide whether the flag hides the
+   UI, rejects the action, or both — a UI-only gate is not a real feature flag.
+2. **Delete it.** Remove both lines from `config/runtime.exs`. Correct if nobody wants the
+   flag; note that removing it is a silent behaviour no-op since nothing read it anyway.
+
+Default to option 1 only if you can find evidence someone intended to gate this — check
+`docs/ZOO-FORK.md` and the git history of `runtime.exs`. Otherwise option 2 is the honest fix.
+
+### Also update
+
+`docs/ZOO-FORK.md` has a "Known gap" callout under Fleet Readiness and a row in the env-var
+table. Both must reflect whatever you decide. ⚠ Coordinate with prompts 13 and 14 if they
+are running.
+
+---
+
+## Prompt 12 — Guard against the `FixMapsScopesDefault` migration collision
+
+### The finding
+
+`priv/repo/migrations/20260801200000_fix_maps_scopes_default.exs` is on the fork. Commit
+`1b4970ffb` (#122) describes it as upstream's, but it is on **neither** `upstream/main` nor
+`upstream/develop`:
+
+```bash
+git cat-file -e upstream/main:priv/repo/migrations/20260801200000_fix_maps_scopes_default.exs
+git cat-file -e upstream/develop:priv/repo/migrations/20260801200000_fix_maps_scopes_default.exs
+```
+
+Both returned "not in" at review time. It arrived via `a91d4943f` (#118), which pulled from an
+upstream PR that had not merged.
+
+### Why this matters
+
+The fork previously carried its own fix for the same bug at `20260804190000`, also defining
+`WandererApp.Repo.Migrations.FixMapsScopesDefault`. Ecto rejects duplicate migration **names**
+outright:
+
+```
+** (Ecto.MigrationError) migrations can't be executed,
+   migration name fix_maps_scopes_default is duplicated
+```
+
+That aborts the entire migrator — no migration runs at all. It is a hard break, not a warning.
+#122 fixed it by deleting the fork's copy. If upstream later merges the same fix under a
+different timestamp, **the collision comes straight back** on the next upstream merge.
+
+### The task
+
+This is an investigation-and-safeguard prompt, not a code change. In order:
+
+1. Confirm the current state — has upstream merged a `FixMapsScopesDefault` yet, under any
+   timestamp? Check `upstream/main`, `upstream/develop`, and open upstream PRs.
+2. If they have merged it at a different timestamp, **the fork is already broken on the next
+   merge**. Report that immediately and propose the resolution (drop the fork's copy, keep
+   upstream's) before doing anything else.
+3. If they have not, add a safeguard. Options, in rough order of preference:
+   - A CI check that fails when two migration files define the same module name. This catches
+     the whole class of problem, not just this instance, and is maybe 15 lines.
+   - A note in the pre-merge checklist in `docs/ZOO-FORK.md` (already partly there under
+     Merge Conflict Hotspots).
+4. Whatever you choose, verify it actually catches the failure — construct the duplicate
+   locally, confirm the check fires, then remove the test case.
+
+### Also worth checking
+
+The same class of problem applies to the two upstream migrations the fork edits in place
+(`20260331192521`, `20260406213852` — see prompt 6). Those conflict on content rather than
+module name, so the check above will not catch them. Mention this in your report.
+
+---
+
+## Prompt 13 — Audit the label-system section of the fork doc
+
+### Why
+
+`docs/ZOO-FORK.md` was rewritten on 2026-08-08, but the Label System section was carried over
+from the 2025-11-30 version **unverified**. Its six label mappings and the claim about how
+labels are stored have not been checked against the code in nine months.
+
+⚠ Conflicts with prompt 14 (same file).
+
+### What to verify
+
+Against `assets/js/hooks/Mapper/components/map/labelIconMap.tsx`,
+`assets/js/hooks/Mapper/components/map/constants.ts`, and
+`assets/js/hooks/Mapper/components/map/styles/zoo-theme.scss`:
+
+| Claim in the doc | Check |
+|------------------|-------|
+| `la`/`de` = Dead End, Block icon | Key, name, and icon all still match? |
+| `lb`/`gas` = Gas Site, Industry icon | " |
+| `lc`/`eol` = End of Life, Hourglass icon | " |
+| `l1`/`crit` = Critical Mass, Fire icon | " |
+| `l2`/`structure` = Structure, Warning icon | " |
+| `l3`/`steve` = Steve/Danger, Skull icon | " |
+| Labels stored under upstream keys, displayed with zoo names | Still true? |
+| Zoo CSS uses the `eve-zoo-` prefix, four listed colours | Hex values still current? |
+| `MARKER_BOOKMARK_BG_STYLES` lives in `constants.ts` | Still there, still that name? |
+
+Also check whether any labels have been **added** since — the doc lists exactly six.
+
+### Done when
+
+Every row is either confirmed or corrected in `docs/ZOO-FORK.md`, and your report says
+explicitly which ones were wrong. "All correct" is a fine outcome; say so plainly.
+
+---
+
+# Group C — Repository hygiene (prompts 14–15)
+
+---
+
+## Prompt 14 — Settle the merge strategy and write it down
+
+⚠ Conflicts with prompt 13 (same file).
+
+### The finding
+
+55 of the 58 fork commits are squash-merged PRs. Three are real merge commits — #124, #125,
+#128 — and those three leaked roughly 15 WIP commits onto the mainline (`review: …`,
+`polish: …`, `docs: …`, `fix(deps): restore original lock`) where every other feature
+contributed exactly one commit.
+
+The repo has a `.gitmessage` template specifying 100-character wrapping, and the recent commit
+messages follow it well. What is missing is a stated **merge** policy.
+
+### The task
+
+1. Confirm the current numbers:
+   ```bash
+   git rev-list --merges --count upstream/main..origin/guarzo/zoo
+   git rev-list --count upstream/main..origin/guarzo/zoo
+   ```
+2. Pick a policy. Squash matches existing practice 55-to-3 and is the recommended default.
+3. Enforce it where it will actually hold: the repository's "Allow merge commits" setting on
+   GitHub is more reliable than a documented convention.
+4. Document it — a short "Contributing / merge policy" section in `docs/ZOO-FORK.md`, or a
+   `CONTRIBUTING.md` if you prefer it discoverable from the repo root.
+
+### Explicitly out of scope
+
+**Do not rewrite existing history.** The three mega-commits (`defb24439` "zoo: custom", 145
+files; `e791d4e10` "zoo: killmail notifications", 98 files; `045388354` "share intel between
+maps", 42 files) carry roughly 20k lines with no recoverable rationale, and `git blame` into
+the theme, ownership, label, and Discord subsystems dead-ends there.
+
+That information is already lost. A rebase would not recover it — it would only invalidate
+every published branch and every open worktree. `docs/ZOO-FORK.md` now serves as the map into
+that region instead. Leave the history alone.
+
+### Minor note
+
+`8b866fc0b` ("temporary failing test to validate the deploy gate on a red commit") is a
+deliberately-red commit on the mainline, reverted cleanly by `febcf9d4a` — verified as an
+empty diff across the pair. It is a small `git bisect` landmine and it is documented in
+`docs/superpowers/plans/2026-08-07-deploy-approval-gate.md`. Worth a sentence in the merge
+policy saying not to do this again; not worth fixing retroactively.
+
+---
+
+## Prompt 15 — Prune merged branches
+
+### The finding
+
+At review time: **85 local branches, 219 remote branches.** Of those, **85 remote branches are
+already fully merged into `guarzo/zoo`**, as are 32 local ones. The backup branches
+(`backup/guarzo-zoo-prerebase`, `zoo-backup-prerebase`, `backup-pre-rebase-102`) are **not**
+being kept deliberately — they simply have not been cleaned up yet, and can go.
+
+### The task
+
+Deleting branches is destructive and easy to get wrong, so work in this order and **show the
+list before deleting anything**.
+
+1. Refresh, then build the candidate lists:
+   ```bash
+   git fetch origin --prune
+   git fetch upstream --prune
+   git branch -r --merged origin/guarzo/zoo | grep -v 'origin/guarzo/zoo$'
+   git branch   --merged origin/guarzo/zoo | grep -v 'guarzo/zoo$'
+   ```
+2. **Exclude from both lists**, regardless of merge status: `origin/main`, `origin/develop`,
+   `origin/HEAD`, `guarzo/zoo`, anything currently checked out in a worktree
+   (`git worktree list`), and anything with an open PR (`gh pr list --state open`).
+3. Show the human the final list and the count. **Get explicit confirmation before deleting.**
+   Do not proceed on inferred approval.
+4. Delete locals first — they are trivially recoverable from reflog:
+   ```bash
+   git branch -d <name>          # -d, never -D: -d refuses if not merged
+   ```
+5. Then remotes, in small batches so a mistake is containable:
+   ```bash
+   git push origin --delete <name> ...
+   ```
+6. Report the before/after counts.
+
+### Also worth doing
+
+`git worktree list` — prune worktrees whose branches are gone. This session's own
+`guarzo/routes-static-timeout` is fully merged into zoo and is a cleanup candidate.
+
+### Recovery note
+
+Deleted remote branches are **not** in your local reflog. Before step 5, save the mapping so
+any branch can be restored:
+
+```bash
+git branch -r --merged origin/guarzo/zoo --format='%(refname:short) %(objectname)' > /tmp/deleted-branches.txt
+```
+
+Keep that file until the human confirms nothing is missing.
+
+---
+
+## Suggested order
+
+If you are running several sessions at once:
+
+**Start immediately, no conflicts, high value:** 1, 3, 4, 5, 6, 15
+**Start immediately, lower value:** 8, 9, 12
+**Sequence:** 2 → 7 (shared file)
+**Sequence:** 13 → 14, or 14 → 13 (shared file)
+**Do last, needs a decision first:** 10 (may become a discussion issue rather than a PR)
+**Do whenever, but decide the outcome first:** 11 (also touches `docs/ZOO-FORK.md` — sequence
+against 13 and 14)

--- a/docs/prompts-2026-08-08.md
+++ b/docs/prompts-2026-08-08.md
@@ -23,15 +23,27 @@ itself, including the shared context and ground rules.
 | Divergence at review time | 58 commits / 312 files ahead; 0 behind either upstream branch |
 | Fork documentation | `docs/ZOO-FORK.md` — read the relevant section before starting |
 
-Re-verify the baseline before you start, because it moves:
+Re-verify the baseline before you start, because it moves. Check every fact in the table
+above, not just the ahead count:
 
 ```bash
 git fetch upstream --prune
-git rev-list --left-right --count upstream/main...origin/guarzo/zoo   # behind<TAB>ahead
+git fetch origin --prune
+
+# behind / ahead, against both upstream branches -- they diverge, so check each
+for ref in upstream/main upstream/develop; do
+  printf '%-18s ' "$ref"
+  git rev-list --left-right --count "$ref"...origin/guarzo/zoo   # behind<TAB>ahead
+done
+
+# the 312-file claim
+git diff --name-only upstream/main...origin/guarzo/zoo | wc -l
 ```
 
-If the fork is now *behind* upstream, say so and stop — several of these prompts assume the
-upstream code still contains the bug being fixed, and that assumption needs rechecking.
+If any of the three numbers has moved materially, note the new values in your report — later
+prompts quote them. If the fork is now *behind* either upstream branch, say so and stop:
+several of these prompts assume the upstream code still contains the bug being fixed, and that
+assumption needs rechecking first.
 
 ---
 
@@ -99,16 +111,47 @@ independent.
 | 9 | `access_list_member_api_controller.ex`, `router.ex` | — |
 | 10 | `external_events/json_api_formatter.ex` | — |
 | 11 | `config/runtime.exs`, `docs/ZOO-FORK.md` (fork branch) | **13**, **14** |
-| 12 | none (investigation + doc) | — |
-| 13 | `docs/ZOO-FORK.md` (fork branch) | **11**, **14** |
-| 14 | `docs/ZOO-FORK.md` (fork branch) | **11**, **13** |
+| 12 | `.github/` CI check, possibly `docs/ZOO-FORK.md` (fork branch) | **11**, **13**, **14** |
+| 13 | `docs/ZOO-FORK.md` (fork branch) | **11**, **12**, **14** |
+| 14 | `docs/ZOO-FORK.md` (fork branch) | **11**, **12**, **13** |
 | 15 | none (branch deletion) | — |
 
 **Prompts 2 and 7 both edit `lib/wanderer_app/esi/api_client.ex`.** Run 2 first, then 7 —
 or run them together under prompt 2's instructions and split into two commits.
 
-Prompts 1–10 each produce an independent branch off `upstream/main`, so they never conflict
-with each other in the fork. Prompts 11, 13, 14 branch off `origin/guarzo/zoo`.
+**Prompts 11, 12, 13, and 14 can all edit `docs/ZOO-FORK.md`.** Prompt 12 only conflicts if
+it takes the documentation option rather than the CI-check option; prefer the CI check, which
+solves the whole class of problem and keeps 12 independent. If you do take the doc option,
+sequence 12 after 11, 13, and 14.
+
+### Handing off between prompts that share a file
+
+Sequencing is not enough on its own — the second prompt needs the first one's changes, and
+"run 2 first" does not say how they meet. Use **stacked branches**:
+
+```bash
+# session A (prompt 2)
+git worktree add ../wt-p2 -b zoo/p2-esi-token upstream/main
+# ...work, commit, stop...
+
+# session B (prompt 7) starts from A's branch, not from upstream/main
+git worktree add ../wt-p7 -b zoo/p7-ipv6 zoo/p2-esi-token
+```
+
+Prompt 7's branch then contains both commits. When prompt 2's PR merges upstream, rebase
+prompt 7 onto the updated `upstream/main` and its commit stands alone. If prompt 2 is
+*rejected* upstream, prompt 7 must be rebased off it before submission — check that before
+opening the second PR.
+
+The same applies to the `docs/ZOO-FORK.md` group: stack 13 on 11, and 14 on 13.
+
+Do **not** run two shared-file prompts concurrently in separate worktrees and merge afterwards.
+Both will have edited the same region and you will resolve the conflict with no memory of
+either session's reasoning.
+
+Prompts 1–10 each produce an independent branch off `upstream/main` (or off the branch they
+stack on, per above), so they never conflict with each other in the fork. Prompts 11–14 branch
+off `origin/guarzo/zoo`.
 
 ---
 
@@ -234,8 +277,18 @@ Flag that to upstream rather than doing it silently; they may prefer a different
 
 ### Done when
 
-A test constructs each of the three bad shapes and shows the old code raising and the new
-code returning `true`.
+Both public helpers are covered:
+
+- `is_access_token_expired?/1` — a test constructs each of the three bad shapes (`expires_at`
+  is `nil`, `get_character/1` answers `{:ok, nil}`, `get_character/1` answers
+  `{:error, :not_found}`) and shows the old code raising and the new code returning `true`.
+- `time_since_expiry/1` — a test passes `nil` and each non-integer shape from that same list
+  and asserts the function returns `nil` without raising. This helper is diagnostic, so the
+  assertion that matters is *that it does not raise*; the returned value only needs to be
+  `nil` rather than a number.
+
+Leave the existing `is_access_token_expired?/1` coverage as-is if upstream already has some —
+add to it rather than rewriting it.
 
 ---
 
@@ -511,8 +564,9 @@ generates cleanly.
 
 ### What it is
 
-`fix(json-api): correct JsonApiFormatter payload contract against real producers` (`725b44a4d`,
-#105) reworked ~575 lines of `lib/wanderer_app/external_events/json_api_formatter.ex` so the
+`fix(json-api): correct JsonApiFormatter payload contract against real producers`
+(`725b44a4d`, #105) reworked ~575 lines of
+`lib/wanderer_app/external_events/json_api_formatter.ex` so the
 emitted payloads match what the event producers actually send, rather than what the formatter
 assumed.
 
@@ -595,14 +649,19 @@ are running.
 
 `priv/repo/migrations/20260801200000_fix_maps_scopes_default.exs` is on the fork. Commit
 `1b4970ffb` (#122) describes it as upstream's, but it is on **neither** `upstream/main` nor
-`upstream/develop`:
+`upstream/develop`.
+
+Search by **module name**, not by filename — the whole risk here is upstream landing the same
+module under a different timestamp, which a filename check would miss:
 
 ```bash
-git cat-file -e upstream/main:priv/repo/migrations/20260801200000_fix_maps_scopes_default.exs
-git cat-file -e upstream/develop:priv/repo/migrations/20260801200000_fix_maps_scopes_default.exs
+for ref in upstream/main upstream/develop; do
+  echo "=== $ref ==="
+  git grep -n 'FixMapsScopesDefault' "$ref" -- priv/repo/migrations/ || echo "absent"
+done
 ```
 
-Both returned "not in" at review time. It arrived via `a91d4943f` (#118), which pulled from an
+At review time both printed `absent`. It arrived via `a91d4943f` (#118), which pulled from an
 upstream PR that had not merged.
 
 ### Why this matters
@@ -611,14 +670,14 @@ The fork previously carried its own fix for the same bug at `20260804190000`, al
 `WandererApp.Repo.Migrations.FixMapsScopesDefault`. Ecto rejects duplicate migration **names**
 outright:
 
-```
+```text
 ** (Ecto.MigrationError) migrations can't be executed,
    migration name fix_maps_scopes_default is duplicated
 ```
 
-That aborts the entire migrator — no migration runs at all. It is a hard break, not a warning.
-#122 fixed it by deleting the fork's copy. If upstream later merges the same fix under a
-different timestamp, **the collision comes straight back** on the next upstream merge.
+That aborts the entire migrator — no migration runs at all. It is a hard break, not a
+warning. #122 fixed it by deleting the fork's copy. If upstream later merges the same fix
+under a different timestamp, **the collision comes straight back** on the next upstream merge.
 
 ### The task
 
@@ -692,8 +751,8 @@ explicitly which ones were wrong. "All correct" is a fine outcome; say so plainl
 
 ### The finding
 
-55 of the 58 fork commits are squash-merged PRs. Three are real merge commits — #124, #125,
-#128 — and those three leaked roughly 15 WIP commits onto the mainline (`review: …`,
+55 of the 58 fork commits are squash-merged PRs. Three are real merge commits (#124, #125,
+and #128), and those three leaked roughly 15 WIP commits onto the mainline (`review: …`,
 `polish: …`, `docs: …`, `fix(deps): restore original lock`) where every other feature
 contributed exactly one commit.
 
@@ -738,50 +797,99 @@ policy saying not to do this again; not worth fixing retroactively.
 
 ### The finding
 
-At review time: **85 local branches, 219 remote branches.** Of those, **85 remote branches are
-already fully merged into `guarzo/zoo`**, as are 32 local ones. The backup branches
-(`backup/guarzo-zoo-prerebase`, `zoo-backup-prerebase`, `backup-pre-rebase-102`) are **not**
-being kept deliberately — they simply have not been cleaned up yet, and can go.
+At review time, counting only `refs/remotes/origin`: **176 remote branches, 94 local**, of
+which **63 remote refs are already fully merged into `guarzo/zoo`**.
+
+⚠ Re-derive these numbers yourself with the commands below rather than trusting them. An
+earlier draft of this prompt said 85 merged remotes; that figure came from a bare
+`git branch -r --merged`, which also sweeps in `upstream/*` refs that must never be deleted
+from `origin`. The 63 above excludes them. Treat any count you did not produce as stale.
+
+The backup branches (`backup/guarzo-zoo-prerebase`, `zoo-backup-prerebase`,
+`backup-pre-rebase-102`) are **not** being kept deliberately — they simply have not been
+cleaned up yet, and can go.
 
 ### The task
 
 Deleting branches is destructive and easy to get wrong, so work in this order and **show the
 list before deleting anything**.
 
-1. Refresh, then build the candidate lists:
-   ```bash
-   git fetch origin --prune
-   git fetch upstream --prune
-   git branch -r --merged origin/guarzo/zoo | grep -v 'origin/guarzo/zoo$'
-   git branch   --merged origin/guarzo/zoo | grep -v 'guarzo/zoo$'
-   ```
-2. **Exclude from both lists**, regardless of merge status: `origin/main`, `origin/develop`,
-   `origin/HEAD`, `guarzo/zoo`, anything currently checked out in a worktree
-   (`git worktree list`), and anything with an open PR (`gh pr list --state open`).
-3. Show the human the final list and the count. **Get explicit confirmation before deleting.**
-   Do not proceed on inferred approval.
-4. Delete locals first — they are trivially recoverable from reflog:
-   ```bash
-   git branch -d <name>          # -d, never -D: -d refuses if not merged
-   ```
-5. Then remotes, in small batches so a mistake is containable:
-   ```bash
-   git push origin --delete <name> ...
-   ```
-6. Report the before/after counts.
+**1. Refresh, then build the candidate lists.**
+
+Enumerate only refs under `refs/remotes/origin` — a bare `git branch -r --merged` also returns
+`upstream/*` refs, and `git push origin --delete upstream/foo` is nonsense at best. Strip the
+prefix at the same time, so the names are already in the form `push --delete` wants:
+
+```bash
+git fetch origin --prune
+git fetch upstream --prune
+
+# remote candidates: bare branch name + object ID, origin only
+git for-each-ref --merged origin/guarzo/zoo \
+  --format='%(refname:strip=3) %(objectname)' refs/remotes/origin > /tmp/remote-candidates.txt
+
+# local candidates
+git for-each-ref --merged origin/guarzo/zoo \
+  --format='%(refname:strip=2) %(objectname)' refs/heads > /tmp/local-candidates.txt
+```
+
+**2. Apply exclusions — after normalization, so the names match.**
+
+Drop from both lists regardless of merge status: `main`, `develop`, `HEAD`, `guarzo/zoo`,
+anything checked out in a worktree, and anything with an open PR:
+
+```bash
+# branches with an open PR, machine-readable
+gh pr list --state open --limit 500 --json headRefName --jq '.[].headRefName' | sort -u > /tmp/keep-pr.txt
+
+# branches checked out in some worktree
+git worktree list --porcelain | awk '/^branch /{sub("refs/heads/","",$2); print $2}' | sort -u > /tmp/keep-wt.txt
+
+printf '%s\n' main develop HEAD guarzo/zoo >> /tmp/keep-pr.txt
+cat /tmp/keep-pr.txt /tmp/keep-wt.txt | sort -u > /tmp/keep.txt
+
+awk 'NR==FNR{k[$1];next} !($1 in k)' /tmp/keep.txt /tmp/remote-candidates.txt > /tmp/remote-delete.txt
+awk 'NR==FNR{k[$1];next} !($1 in k)' /tmp/keep.txt /tmp/local-candidates.txt  > /tmp/local-delete.txt
+```
+
+**3. Show the human the filtered lists and the counts.** `wc -l` both files and display them.
+**Get explicit confirmation before deleting.** Do not proceed on inferred approval.
+
+**4. Delete locals first** — they are recoverable from reflog:
+
+```bash
+cut -d' ' -f1 /tmp/local-delete.txt | xargs -r -n1 git branch -d   # -d, never -D
+```
+
+`-d` refuses to delete anything not actually merged, so it is a second safety net. If it
+refuses a branch, investigate rather than reaching for `-D`.
+
+**5. Then remotes, in small batches** so a mistake is containable:
+
+```bash
+cut -d' ' -f1 /tmp/remote-delete.txt | head -20 | xargs -r git push origin --delete
+```
+
+**6. Report the before/after counts.**
 
 ### Also worth doing
 
-`git worktree list` — prune worktrees whose branches are gone. This session's own
-`guarzo/routes-static-timeout` is fully merged into zoo and is a cleanup candidate.
+`git worktree list` — prune worktrees whose branches are gone (`git worktree prune`).
+
+⚠ **Do not prune the worktree you are running in**, and do not delete its branch. Run worktree
+cleanup from a separate administrative checkout, and for each target worktree confirm it is
+both clean (`git -C <path> status --porcelain` empty) and inactive (no session working in it)
+before removing it. A worktree whose branch you just deleted becomes a detached, confusing
+mess for whoever is sitting in it.
 
 ### Recovery note
 
-Deleted remote branches are **not** in your local reflog. Before step 5, save the mapping so
-any branch can be restored:
+Deleted remote branches are **not** in your local reflog. `/tmp/remote-delete.txt` from step 2
+is your restore map — it holds the exact filtered set plus each branch's object ID:
 
 ```bash
-git branch -r --merged origin/guarzo/zoo --format='%(refname:short) %(objectname)' > /tmp/deleted-branches.txt
+# restore one
+git push origin <objectname>:refs/heads/<branchname>
 ```
 
 Keep that file until the human confirms nothing is missing.


### PR DESCRIPTION
## Why

`docs/ZOO-FORK.md` was last updated 2025-11-30. Since then the fork has grown Discord
notifications, intel sharing, Fly.io deployment, and a restructured CI pipeline, none of which
were documented. It described 5 columns and 2 tables; the fork now carries 10 columns and 2
tables across 15 migrations. Anyone using the doc to plan an upstream merge was working from a
map that no longer matched the territory.

This PR is documentation only. No code changes, no behaviour changes.

## What changed

**`docs/ZOO-FORK.md`** — rewritten against the current branch.

- Header now states the measured divergence: 58 commits / 312 files / ~43.5k insertions ahead
  of `upstream/main` @ `b7ddbc486`, 0 commits behind either upstream branch.
- New sections: Discord Notifications (14 modules), Intel Sharing, Fly.io deployment, CI, and
  a configuration reference table for every fork-added env var.
- DB schema section expanded to cover the 2 added tables and 10 added columns.
- Upstream PR candidates rewritten as 10 tiered items, each verified against upstream's actual
  source rather than against our own commit messages.

Three warnings added inline, because each of them is a live foot-gun:

- `20260801200000_fix_maps_scopes_default.exs` is described by #122 as upstream's, but it is on
  **neither** `upstream/main` nor `upstream/develop` — it arrived via #118 from an unmerged
  upstream PR. If upstream later merges the same fix under a different timestamp, the duplicate
  module name returns an `Ecto.MigrationError` that aborts the entire migrator.
- `WANDERER_FLEET_READINESS_ENABLED` is parsed and stored but never read. Fleet readiness is
  unconditionally on, and setting the flag to `false` does nothing and warns about nothing.
- Two upstream migrations are edited in place for the charlist deprecation, so they conflict on
  every merge.

**`docs/prompts-2026-08-08.md`** — new. Fifteen self-contained prompts covering every
recommendation from the review, each written for a fresh session with no prior context:

> read `docs/prompts-2026-08-08.md`, work on prompt 3

Group A (1–10) are upstream PR extractions, Group B (11–13) are fork-side fixes, Group C
(14–15) is repository hygiene. Shared context, verification commands, and ground rules live at
the top so each prompt stays short.

## Reviewer focus

Two things are load-bearing and worth checking:

**The parallel-safety matrix.** Prompts 2 and 7 both edit `lib/wanderer_app/esi/api_client.ex`;
prompts 11, 13, and 14 all edit `docs/ZOO-FORK.md`. Those pairs must be sequenced, and the
matrix is the only thing preventing two sessions from colliding.

**The extraction warnings.** Most of these changes are *not* cleanly cherry-pickable — they are
buried in the three mega-commits, or they share a file with fork-only work. The worst case is
`lib/wanderer_app/map/map_routes.ex`, where roughly 100 of its 135 diverged lines are zoo's
`find_strict/5` for Discord route alerts and must not go upstream. A naive path-scoped diff
would drag all of it into an upstream PR. Every affected prompt says so explicitly; if any of
those warnings is wrong, a session will act on it.

Prompts 10 and 11 deliberately do not end in a PR — 10 changes emitted payloads for external
consumers and may be better as an upstream discussion issue, and 11 requires deciding whether
to wire up or delete the dead flag before any code is written.

## Explicitly out of scope

**No history rewriting.** The three mega-commits (`defb24439`, `e791d4e10`, `045388354` —
~285 files, ~20k lines between them) have no recoverable rationale, and `git blame` into the
theme, ownership, label, and Discord subsystems dead-ends there. That context is already lost;
a rebase would not recover it, only invalidate every published branch and open worktree.
`ZOO-FORK.md` now serves as the map into that region instead.

## Verification

Documentation only — no tests, formatter, or build affected. Every factual claim in both files
was checked against the repository or against `upstream/main` / `upstream/develop` at the SHAs
named in the header. The divergence counts, the migration-absence checks, and the dead-flag
grep are all reproducible from the commands quoted in the docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated fork documentation with current deployment, configuration, CI, migration, rollback, notification, and intel-sharing guidance.
  * Expanded architecture, schema, maintenance, health-check, and upstream recommendation references.
  * Added 15 structured maintenance and review prompts covering testing, migrations, reliability, security, and branch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->