### PR TITLE
fix(notifications): keep the route alerts checkbox ticked on toggle

### DIFF
--- a/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
+++ b/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
@@ -132,14 +132,40 @@ defmodule WandererAppWeb.MapNotificationsComponent do
     {:noreply, put_replacing(socket, parse_role(role), true)}
   end
 
-  # Purely client-display state: which fields are visually shown, driven by
-  # the CHECKBOX's own `phx-change` (not the whole form's) so ticking or
-  # unticking this one box is the only thing that round-trips — typing in the
-  # numeric fields below it does not. Nothing here is persisted; the actual
-  # value is only ever written by "save", same as every other field on this
-  # form.
+  # Which fields are visually shown, driven by the CHECKBOX's own `phx-change`
+  # (not the whole form's) so ticking or unticking this one box is the only
+  # thing that round-trips — typing in the numeric fields below it does not.
+  # Nothing here is persisted; the actual value is only ever written by "save",
+  # same as every other field on this form.
+  #
+  # The form MUST be rebuilt here, not just `:route_toggle`. A checkbox renders
+  # `checked` from its form value, so re-rendering against the unchanged form
+  # emits the box UNCHECKED and LiveView patches the user's ticked box back —
+  # the fields below appear, which reads as "it worked", and then Save posts
+  # `false` and silently stores route alerts as off. It reports "Saved."
+  # because it IS a valid save: with the toggle false the home-system
+  # validation has nothing to complain about.
+  #
+  # Rebuilt from `params` rather than by patching the one key, because those
+  # params are the whole form as the browser has it — anything already typed
+  # into `home_system_id` / `route_max_jumps` is preserved instead of being
+  # reset to the last-saved record on every tick.
+  #
+  # `webhook_url` is forced back to "" rather than carried through. On the
+  # create path that field is rendered (a password input) and the generic
+  # `.input` writes `value=` for every type, password included — so echoing the
+  # submitted params would put a live webhook URL into the server-rendered
+  # HTML, which this module treats as a credential that is only ever rendered
+  # as a masked hint. Blanking it costs nothing: "" is what the field rendered
+  # before this event too, so there is no diff for that input and whatever the
+  # user typed stays in the DOM untouched.
   def handle_event("toggle-route-alerts", %{"notification" => params}, socket) do
-    {:noreply, assign(socket, :route_toggle, checked?(params["route_alerts_enabled"]))}
+    form = params |> Map.put("webhook_url", "") |> to_form(as: :notification)
+
+    {:noreply,
+     socket
+     |> assign(:route_toggle, checked?(params["route_alerts_enabled"]))
+     |> assign(:form, form)}
   end
 
   def handle_event("save-webhook", %{"role" => role, "webhook" => params}, socket) do

--- a/test/wanderer_app_web/live/map_notifications_test.exs
+++ b/test/wanderer_app_web/live/map_notifications_test.exs
@@ -899,6 +899,101 @@ defmodule WandererAppWeb.MapNotificationsTest do
              )
     end
 
+    # The two save tests above hand `render_submit` an explicit params map, so
+    # they never exercise the rendered checkbox — they passed while ticking the
+    # box in a browser did nothing. `checked` is rendered from the form's
+    # value, so a handler that updates only `:route_toggle` re-renders the box
+    # UNCHECKED, and LiveView patches the real one back. The tests below drive
+    # the DOM instead: no params for the checkbox, ever.
+    test "ticking the route alerts box leaves it checked in the re-render", %{
+      conn: conn,
+      map: map
+    } do
+      notification_with_webhooks(map, [:system])
+      view = open_notifications(conn, map)
+
+      refute has_element?(
+               view,
+               "input[name='notification[route_alerts_enabled]'][type='checkbox'][checked]"
+             )
+
+      view
+      |> element("input[name='notification[route_alerts_enabled]'][type='checkbox']")
+      |> render_change(%{"notification" => %{"route_alerts_enabled" => "true"}})
+
+      assert has_element?(
+               view,
+               "input[name='notification[route_alerts_enabled]'][type='checkbox'][checked]"
+             )
+    end
+
+    test "toggling route alerts keeps values already typed into the form", %{
+      conn: conn,
+      map: map
+    } do
+      notification_with_webhooks(map, [:system])
+      view = open_notifications(conn, map)
+
+      # A real browser posts every input in the form with the change event, so
+      # a re-render that rebuilds the form from anything BUT those params
+      # silently discards whatever the user had already typed.
+      view
+      |> element("input[name='notification[route_alerts_enabled]'][type='checkbox']")
+      |> render_change(%{
+        "notification" => %{
+          "route_alerts_enabled" => "true",
+          "home_system_id" => "30000142",
+          "route_max_jumps" => "4"
+        }
+      })
+
+      assert has_element?(view, "input[name='notification[home_system_id]'][value='30000142']")
+      assert has_element?(view, "input[name='notification[route_max_jumps]'][value='4']")
+    end
+
+    test "ticking the box and saving persists the toggle", %{conn: conn, map: map} do
+      notification_with_webhooks(map, [:system])
+      view = open_notifications(conn, map)
+
+      view
+      |> element("input[name='notification[route_alerts_enabled]'][type='checkbox']")
+      |> render_change(%{"notification" => %{"route_alerts_enabled" => "true"}})
+
+      # Only `home_system_id` is supplied — the value the user types. Everything
+      # else, the checkbox included, comes from the rendered DOM, which is the
+      # whole point: this is what the browser actually posts.
+      view
+      |> form("#discord-notification-form", %{
+        "notification" => %{"home_system_id" => "30000142"}
+      })
+      |> render_submit()
+
+      assert {:ok, rec} = MapDiscordNotification.by_map(map.id)
+      assert rec.route_alerts_enabled? == true
+      assert rec.home_system_id == 30_000_142
+    end
+
+    test "toggling route alerts never renders a submitted webhook url", %{conn: conn, map: map} do
+      # No notification yet, so the create path renders the webhook URL field
+      # alongside the route toggle. The change event carries whatever is typed
+      # into it, and the generic `.input` writes `value=` for password inputs
+      # too — so a form rebuilt straight from those params would print a live
+      # credential into the HTML.
+      view = open_notifications(conn, map)
+
+      url = "https://discord.com/api/webhooks/1534657087244603394/supersecrettoken"
+
+      html =
+        view
+        |> element("input[name='notification[route_alerts_enabled]'][type='checkbox']")
+        |> render_change(%{
+          "notification" => %{"route_alerts_enabled" => "true", "webhook_url" => url}
+        })
+
+      refute html =~ "supersecrettoken"
+      refute html =~ url
+    end
+
     test "the route webhook url can be added", %{conn: conn, map: map} do
       rec = notification_with_webhooks(map, [:system])
       view = open_notifications(conn, map)


### PR DESCRIPTION
## Problem

Ticking **Enable route alerts** in Discord notification settings did nothing. The fields below it appeared, Save showed a green "Saved.", and `route_alerts_enabled?` stayed `false` in the database — regardless of filling in the home system.

## Root cause

`handle_event("toggle-route-alerts", ...)` assigned only `:route_toggle` and never rebuilt `@form`. A checkbox renders its `checked` attribute from the form's value, so re-rendering against the unchanged form emitted the box **unchecked** and LiveView patched the user's tick back out. Save then posted `false`.

It reported success because it *was* a valid save: with the toggle false, `validate_home_system_required/2` has nothing to complain about. The home system itself was persisted — only the flag was lost, which matches the report exactly.

## Fix

Rebuild the form from the submitted params in the toggle handler. Using the params (rather than patching the one key on the existing form) also preserves anything already typed into `home_system_id` / `route_max_jumps` instead of resetting those to the last-saved record on every tick.

`webhook_url` is forced back to `""` before building the form. On the create path that field is rendered, and the generic `.input` writes `value=` for every type — password included — so echoing the submitted params would print a live webhook URL into the server-rendered HTML. This module treats webhook URLs as credentials that are only ever rendered as a masked hint.

## Why the existing tests missed it

Both route-alert save tests hand `render_submit` an explicit params map, which bypasses the rendered checkbox entirely. The hidden/shown test asserts only on the wrapper's `hidden` class. All three pass against the broken code.

The four added tests drive the DOM instead — they supply params only for fields the user actually types into, and let the rendered markup provide the rest:

1. the box stays checked through the re-render
2. values already typed survive the toggle
3. tick + save actually persists `route_alerts_enabled? == true`
4. the toggle re-render never echoes a submitted webhook URL

Each fails against the pre-fix handler; #4 was verified by reverting just the `webhook_url` guard.

## Verification

- `test/wanderer_app_web/live/map_notifications_test.exs` — 45 tests, 0 failures
- `test/unit/api/map_discord_notification_test.exs` + `test/unit/external_events/` — 364 tests, 0 failures
- `mix format --check-formatted` — OK
- `mix credo` — no issues

## Reviewer focus

The `Map.put("webhook_url", "")` guard in `map_notifications_component.ex`. Blanking it is safe because `""` is what that input rendered before this event too — there is no diff for it, so whatever the user typed stays in the DOM untouched.
