### PR TITLE
fix(maps): reject unknown and feature-disabled settings tabs server-side

### DIFF
--- a/lib/wanderer_app_web/live/maps/maps_live.ex
+++ b/lib/wanderer_app_web/live/maps/maps_live.ex
@@ -7,6 +7,22 @@ defmodule WandererAppWeb.MapsLive do
 
   @pubsub_client Application.compile_env(:wanderer_app, :pubsub_client)
 
+  # Settings tabs that are always available to anyone who can open the dialog.
+  # The dialog itself is already gated on the `delete_map` permission in
+  # `apply_action(:settings, ...)`, so this list is not a permission boundary —
+  # it stops a crafted `change_settings_tab` event from selecting a tab that was
+  # never rendered, which would otherwise defeat the feature-flag `:if` guards
+  # on the tab list in maps_live.html.heex.
+  @always_available_settings_tabs ~w(general import notifications)
+
+  # Tabs whose availability tracks a deployment feature flag. Each entry mirrors
+  # the `:if` guard on the corresponding <li> in maps_live.html.heex; keep the
+  # two in sync.
+  @subscription_settings_tabs ~w(balance subscription bot)
+  @public_api_settings_tab "public_api"
+
+  @default_settings_tab "general"
+
   @impl true
   def mount(
         _params,
@@ -175,7 +191,7 @@ defmodule WandererAppWeb.MapsLive do
           importing: false,
           show_settings?: true,
           is_topping_up?: false,
-          active_settings_tab: "general",
+          active_settings_tab: @default_settings_tab,
           is_adding_subscription?: false,
           selected_subscription: nil,
           options_form: options_form_data |> to_form(),
@@ -208,6 +224,19 @@ defmodule WandererAppWeb.MapsLive do
         |> push_navigate(to: ~p"/maps")
     end
   end
+
+  defp settings_tab_available?(tab, _assigns)
+       when tab in @always_available_settings_tabs,
+       do: true
+
+  defp settings_tab_available?(tab, %{map_subscriptions_enabled?: subscriptions_enabled?})
+       when tab in @subscription_settings_tabs,
+       do: subscriptions_enabled?
+
+  defp settings_tab_available?(@public_api_settings_tab, _assigns),
+    do: not WandererApp.Env.public_api_disabled?()
+
+  defp settings_tab_available?(_tab, _assigns), do: false
 
   defp allow_map_creation(),
     do: not WandererApp.Env.restrict_maps_creation?() || WandererApp.Cache.take("create_map_once")
@@ -396,8 +425,15 @@ defmodule WandererAppWeb.MapsLive do
   end
 
   @impl true
-  def handle_event("change_settings_tab", %{"tab" => tab}, socket),
-    do: {:noreply, socket |> assign(active_settings_tab: tab)}
+  def handle_event("change_settings_tab", %{"tab" => tab}, socket) do
+    if settings_tab_available?(tab, socket.assigns) do
+      {:noreply, socket |> assign(active_settings_tab: tab)}
+    else
+      # Unknown or feature-disabled tab: keep the current selection rather than
+      # rendering a panel whose <li> was never shown.
+      {:noreply, socket}
+    end
+  end
 
   def handle_event("open_acl", %{"data" => id}, socket) do
     {:noreply,

--- a/test/wanderer_app_web/live/maps_settings_tabs_test.exs
+++ b/test/wanderer_app_web/live/maps_settings_tabs_test.exs
@@ -1,0 +1,153 @@
+defmodule WandererAppWeb.MapsSettingsTabsTest do
+  @moduledoc """
+  The settings dialog's tab list carries `:if` guards that are purely
+  deployment feature flags (`maps_live.html.heex`). Those guards only control
+  what is *rendered* — `change_settings_tab` is a client-pushed event, so
+  without a server-side allowlist a crafted event can select a panel whose
+  `<li>` was never shown.
+
+  These tests are not a permission boundary: the dialog itself is already gated
+  on the `delete_map` permission in `apply_action(:settings, ...)`, so every
+  actor reaching this point is a map owner or ACL admin.
+  """
+  use WandererAppWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias WandererAppWeb.Factory
+
+  setup %{conn: conn} do
+    # `Api.Map.owner_id` points at a CHARACTER, not a user (see
+    # map_notifications_test.exs) — passing a user id fails the foreign key.
+    user = Factory.insert(:user, %{})
+    character = Factory.insert(:character, %{user_id: user.id})
+    map = Factory.insert(:map, %{owner_id: character.id})
+
+    conn =
+      conn
+      |> Plug.Test.init_test_session(%{})
+      |> Plug.Conn.put_session(:user_id, user.id)
+
+    %{conn: conn, map: map}
+  end
+
+  defp open_settings(conn, map) do
+    {:ok, view, _html} = live(conn, ~p"/maps/#{map.slug}/settings")
+    view
+  end
+
+  defp push_tab(view, tab) do
+    render_click(view, "change_settings_tab", %{"tab" => tab})
+  end
+
+  defp selected_tab_count(view, tab) do
+    view
+    |> element("li.p-tabview-selected a[phx-value-tab='#{tab}']")
+    |> has_element?()
+  end
+
+  describe "always-available tabs" do
+    test "a rendered tab can be selected", %{conn: conn, map: map} do
+      view = open_settings(conn, map)
+
+      push_tab(view, "notifications")
+
+      assert selected_tab_count(view, "notifications")
+      assert has_element?(view, "#map-notifications")
+    end
+
+    test "the dialog opens on the general tab", %{conn: conn, map: map} do
+      view = open_settings(conn, map)
+
+      assert selected_tab_count(view, "general")
+    end
+  end
+
+  describe "unknown tab values are ignored" do
+    test "an unrecognised tab leaves the current selection intact", %{conn: conn, map: map} do
+      view = open_settings(conn, map)
+
+      push_tab(view, "definitely-not-a-tab")
+
+      assert selected_tab_count(view, "general")
+      refute has_element?(view, "#map-notifications")
+    end
+
+    test "an unrecognised tab does not clear an existing selection", %{conn: conn, map: map} do
+      view = open_settings(conn, map)
+      push_tab(view, "notifications")
+
+      push_tab(view, "definitely-not-a-tab")
+
+      assert selected_tab_count(view, "notifications")
+    end
+  end
+
+  describe "feature-flagged tabs" do
+    setup do
+      original = Application.get_env(:wanderer_app, :map_subscriptions_enabled)
+      on_exit(fn -> Application.put_env(:wanderer_app, :map_subscriptions_enabled, original) end)
+      :ok
+    end
+
+    test "a subscription tab is rejected when subscriptions are disabled", %{
+      conn: conn,
+      map: map
+    } do
+      Application.put_env(:wanderer_app, :map_subscriptions_enabled, false)
+      view = open_settings(conn, map)
+
+      # The <li> is not rendered ...
+      refute has_element?(view, "a[phx-value-tab='bot']")
+
+      # ... and pushing the event directly must not render the panel either.
+      push_tab(view, "bot")
+
+      refute selected_tab_count(view, "bot")
+      refute render(view) =~ "Bots Integration"
+    end
+
+    test "a subscription tab is selectable when subscriptions are enabled", %{
+      conn: conn,
+      map: map
+    } do
+      Application.put_env(:wanderer_app, :map_subscriptions_enabled, true)
+      view = open_settings(conn, map)
+
+      push_tab(view, "bot")
+
+      assert selected_tab_count(view, "bot")
+      assert render(view) =~ "Bots Integration"
+    end
+  end
+
+  describe "public api tab" do
+    setup do
+      original = Application.get_env(:wanderer_app, :public_api_disabled)
+      on_exit(fn -> Application.put_env(:wanderer_app, :public_api_disabled, original) end)
+      :ok
+    end
+
+    test "is rejected when the public api is disabled", %{conn: conn, map: map} do
+      Application.put_env(:wanderer_app, :public_api_disabled, true)
+      view = open_settings(conn, map)
+
+      push_tab(view, "public_api")
+
+      # Asserting on the public_api <li>/panel would be vacuous here: both carry
+      # their own `:if` on the same flag, so neither renders either way. The
+      # meaningful signal is that the selection did not move off general.
+      assert selected_tab_count(view, "general")
+      refute selected_tab_count(view, "public_api")
+    end
+
+    test "is selectable when the public api is enabled", %{conn: conn, map: map} do
+      Application.put_env(:wanderer_app, :public_api_disabled, false)
+      view = open_settings(conn, map)
+
+      push_tab(view, "public_api")
+
+      assert selected_tab_count(view, "public_api")
+    end
+  end
+end


### PR DESCRIPTION
## What

`change_settings_tab` assigned whatever tab string the client pushed:

```elixir
def handle_event("change_settings_tab", %{"tab" => tab}, socket),
  do: {:noreply, socket |> assign(active_settings_tab: tab)}
```

No allowlist. So the `:if` guards on the settings tab list in `maps_live.html.heex` were cosmetic — a crafted event rendered the Balance, Subscription or Bots panel even with `map_subscriptions_enabled?` false. Public Api was the only tab carrying a defence-in-depth re-check on its panel body (`maps_live.html.heex:578-583`).

This gates the handler on an allowlist that mirrors those template guards, keeping the current selection when a tab is unknown or its feature flag is off.

## Severity: feature-flag bypass, not privilege escalation

Worth being precise, because the diff looks security-shaped and isn't quite.

The settings dialog is already gated in `apply_action(:settings, ...)` (`maps_live.ex:154`) by `WandererApp.Maps.check_user_can_delete_map/2`. That checks the `delete_map` bit, which appears only in `@admin_role` (`lib/wanderer_app/permissions.ex:32`) — `@manager_role` does not carry it. **Every actor reaching this handler is already a map owner or ACL admin, acting on their own map.** No data crosses a permission boundary either before or after this change.

What it does fix is that a feature flag intended to keep a panel off a deployment could be defeated from the client.

### Related finding, deliberately not changed here

The Notifications `<li>` (`maps_live.html.heex:423`) carries no `:if`, unlike Public Api and Bots. This looks like an oversight and isn't: those sibling guards are **deployment feature flags, not permission checks**, and General and Import/Export are likewise unguarded. The dialog's entry gate is the permission boundary. Adding an `:if` there would cargo-cult a feature-flag pattern into a permission slot.

## Named constants

Per checklist §3, the tab sets are module attributes rather than inline literals, and each is commented as mirroring a specific template guard so the two stay in sync. The bare `"general"` literal is now `@default_settings_tab`.

## Verification

- `mix compile --warnings-as-errors` — clean
- New `test/wanderer_app_web/live/maps_settings_tabs_test.exs`, 8 tests — pass
- `mix test test/wanderer_app_web/` — 101 tests, 0 failures
- `mix format --check-formatted` — clean
- `mix credo --strict` — 3 findings on `maps_live.ex`, all **pre-existing on the base commit** (same three `Enum.map |> Enum.join` at lines 245/334/354 pre-change, shifted by the added lines). Verified against base per checklist §13, not merely assumed.

### The tests are not vacuous — checked

Stubbed the guard to `if true or settings_tab_available?(...)` and confirmed 3 tests fail without it. That exposed a 4th that passed either way: the public_api rejection case, because both its `<li>` and its panel body carry their own `:if` on the same flag, so neither renders regardless. Rewrote it to assert the selection stays on `general`, which does fail without the guard. The comment in the test records why.

## No screenshots

Checklist §9 asks for them on UI PRs. There is no visual change to show — this is a server-side guard on an event handler; every rendered state is byte-identical. The behavioural difference is only observable by pushing a crafted event, which the tests cover.