### PR TITLE
feat(components): give button/1 primary/secondary/ghost/danger variants

### DIFF
--- a/lib/wanderer_app_web/components/core_components.ex
+++ b/lib/wanderer_app_web/components/core_components.ex
@@ -274,6 +274,28 @@ defmodule WandererAppWeb.CoreComponents do
     """
   end
 
+  # Structural PrimeReact classes every button carries, kept separate from the
+  # variant modifier so the composed string for the default variant is
+  # byte-for-byte what this component rendered before variants existed.
+  @button_base_class "phx-submit-loading:opacity-75 p-button p-component"
+  @button_size_class "p-button-sm"
+
+  # Variant -> PrimeReact severity modifier. The app loads the full PrimeReact
+  # theme (assets/css/app.css) on top of the local overrides in
+  # assets/js/hooks/Mapper/common-styles/prime-fixes/theme.scss, so these
+  # classes are already themed and stay in step with every React button on the
+  # map canvas. A parallel Tailwind palette here would drift from both.
+  #
+  # :primary carries no modifier on purpose — bare `.p-button` *is* PrimeReact's
+  # filled primary style. (`p-button-primary`, passed ad hoc at a few call
+  # sites, is not defined by either stylesheet and styles nothing.)
+  @button_variant_classes %{
+    primary: nil,
+    secondary: "p-button-outlined",
+    ghost: "p-button-text p-button-plain",
+    danger: "p-button-danger"
+  }
+
   @doc """
   Renders a button.
 
@@ -281,28 +303,42 @@ defmodule WandererAppWeb.CoreComponents do
 
       <.button>Send!</.button>
       <.button phx-click="go" class="ml-2">Send!</.button>
+      <.button variant={:primary} type="submit">Save</.button>
+      <.button variant={:danger} phx-click="delete-everything">Remove all</.button>
   """
   attr(:type, :string, default: nil)
   attr(:class, :string, default: nil)
+
+  attr(:variant, :atom,
+    values: [:primary, :secondary, :ghost, :danger],
+    default: :secondary,
+    doc: """
+    visual weight of the button: `:primary` is filled and belongs on a form's
+    single submit; `:secondary` is the default outlined style; `:ghost` is for
+    inline row actions such as Replace or removing a chip; `:danger` is
+    reserved for actions that destroy persisted state
+    """
+  )
+
   attr(:data, :any, default: nil)
   attr(:rest, :global, include: ~w(disabled form name value))
 
   slot(:inner_block, required: true)
 
   def button(assigns) do
+    assigns = assign(assigns, :variant_class, button_class(assigns.variant))
+
     ~H"""
-    <button
-      type={@type}
-      class={[
-        "phx-submit-loading:opacity-75 p-button p-component p-button-outlined p-button-sm",
-        @class
-      ]}
-      data={@data}
-      {@rest}
-    >
+    <button type={@type} class={[@variant_class, @class]} data={@data} {@rest}>
       {render_slot(@inner_block)}
     </button>
     """
+  end
+
+  defp button_class(variant) do
+    [@button_base_class, Map.fetch!(@button_variant_classes, variant), @button_size_class]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" ")
   end
 
   @doc """

--- a/test/wanderer_app_web/components/core_components_test.exs
+++ b/test/wanderer_app_web/components/core_components_test.exs
@@ -1,0 +1,104 @@
+defmodule WandererAppWeb.CoreComponentsTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias WandererAppWeb.CoreComponents
+
+  # The class string button/1 rendered before it grew a variant system. Every
+  # existing call site relies on the default staying exactly this, so it is
+  # asserted literally rather than composed from the module's own attributes.
+  @legacy_class "phx-submit-loading:opacity-75 p-button p-component p-button-outlined p-button-sm"
+
+  defp button(assigns) do
+    render_component(&CoreComponents.button/1, assigns)
+  end
+
+  defp class_of(html) do
+    [_, class] = Regex.run(~r/class="([^"]*)"/, html)
+    class
+  end
+
+  describe "button/1 default variant" do
+    test "renders the pre-variant class string unchanged" do
+      assert class_of(button(%{inner_block: slot("Save")})) == @legacy_class
+    end
+
+    test "is identical to an explicit :secondary" do
+      assert button(%{inner_block: slot("Save")}) ==
+               button(%{variant: :secondary, inner_block: slot("Save")})
+    end
+
+    test "still appends a caller-supplied class after the base classes" do
+      html = button(%{class: "p-button-danger self-start", inner_block: slot("Remove")})
+
+      assert class_of(html) == @legacy_class <> " p-button-danger self-start"
+    end
+  end
+
+  describe "button/1 variants" do
+    test ":primary is filled — it carries no outline or severity modifier" do
+      class = class_of(button(%{variant: :primary, inner_block: slot("Save")}))
+
+      assert class == "phx-submit-loading:opacity-75 p-button p-component p-button-sm"
+      refute class =~ "p-button-outlined"
+      refute class =~ "p-button-text"
+    end
+
+    test ":ghost is borderless and muted" do
+      class = class_of(button(%{variant: :ghost, inner_block: slot("Replace")}))
+
+      assert class =~ "p-button-text"
+      assert class =~ "p-button-plain"
+      refute class =~ "p-button-outlined"
+    end
+
+    test ":danger is filled, not merely a tinted outline" do
+      class = class_of(button(%{variant: :danger, inner_block: slot("Remove all")}))
+
+      assert class =~ "p-button-danger"
+      refute class =~ "p-button-outlined"
+      refute class =~ "p-button-text"
+    end
+
+    test "every variant keeps the shared structural classes" do
+      for variant <- [:primary, :secondary, :ghost, :danger] do
+        class = class_of(button(%{variant: variant, inner_block: slot("Go")}))
+
+        assert class =~ "phx-submit-loading:opacity-75"
+        assert class =~ "p-button p-component"
+        assert class =~ "p-button-sm"
+      end
+    end
+
+    # `attr :variant, values: [...]` rejects a literal bad variant at compile
+    # time, so real call sites can never reach this. A dynamically-passed one
+    # still has to fail loudly rather than render an unstyled button.
+    test "rejects an unknown variant passed dynamically" do
+      assert_raise KeyError, fn ->
+        button(%{variant: :destructive, inner_block: slot("Boom")})
+      end
+    end
+  end
+
+  describe "button/1 passthrough" do
+    test "keeps type, data and global attributes" do
+      html =
+        button(%{
+          type: "submit",
+          data: [confirm: "Sure?"],
+          disabled: true,
+          inner_block: slot("Save")
+        })
+
+      assert html =~ ~s(type="submit")
+      assert html =~ ~s(data-confirm="Sure?")
+      assert html =~ "disabled"
+      assert html =~ "Save"
+    end
+  end
+
+  defp slot(text) do
+    [%{__slot__: :inner_block, inner_block: fn _, _ -> text end}]
+  end
+end


### PR DESCRIPTION
Prompt B of the notifications-tab rework. Adds a `variant` attr to `CoreComponents.button/1` so the notifications tab (prompt D) has buttons with distinct visual weights to consume.

## Signature for downstream prompts

```elixir
attr(:variant, :atom,
  values: [:primary, :secondary, :ghost, :danger],
  default: :secondary
)
```

| variant | modifier emitted | effective style |
|---|---|---|
| `:primary` | *(none)* | filled — bare `.p-button` is PrimeReact's filled primary |
| `:secondary` | `p-button-outlined` | byte-for-byte today's look |
| `:ghost` | `p-button-text p-button-plain` | transparent, borderless, muted |
| `:danger` | `p-button-danger` | filled, dark label — structurally distinct from `:ghost`, not a red tint |

Composed order is `"phx-submit-loading:opacity-75 p-button p-component"` + variant modifier + `"p-button-sm"`, then the caller's `class`.

## Compatibility

All 47 existing `<.button` call sites were audited; none passes `variant`, so all get `:secondary`. The default reproduces the original token string exactly — asserted literally in the test rather than composed from the module's own constants, so a future edit to those constants can't silently redefine "unchanged". The two `map_notifications_component.ex` sites passing `class="p-button-danger self-start"` still compose to outlined-danger.

## Two notes for review

**No new CSS.** The brief asked for OKLCH colors tinted to the theme hue. All four styles already exist in the loaded PrimeReact theme (`arya-blue` under `layer(primereact)`, overridden by the unlayered `prime-fixes/theme.scss`), so `variant` maps onto existing classes with zero new declarations. I read §2 (match existing codestyle, don't build a parallel system) as outranking the color instruction here. A bespoke palette would be a deliberate follow-up.

**`.p-button-primary` styles nothing.** Defined in neither stylesheet, but passed ad hoc at `access_lists_live.html.heex:208`, `sponsors_live.html.heex:52`, `maps_live.html.heex:607`, and `character_profile_live.html.heex:59/72/115/123`. That's why `:primary` emits no modifier. Left alone — out of scope.

## Verification

| Check | Result |
|---|---|
| `mix format --check-formatted` (whole repo) | exit 0 |
| `mix compile --warnings-as-errors` | exit 0, no warnings |
| `mix test test/wanderer_app_web/components/core_components_test.exs` | 9 tests, 0 failures |
| `mix credo` (both files) | no issues |

`map_notifications_component.ex` was read only, never edited — prompt D owns it.
