### PR TITLE
fix(codegen): clear the maps_v1 scopes drift and gate codegen in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,6 +170,15 @@ jobs:
           echo "warnings=${warnings:-0}" >> "$GITHUB_OUTPUT"
           exit $status
 
+      # Gating, like formatting above. Runs after the compile step so a genuine
+      # compile error reports as a compile error rather than as codegen noise.
+      # Catches resources that have drifted from priv/resource_snapshots —
+      # typically after a dependency bump changes how a default is serialized,
+      # which is otherwise invisible until someone runs `mix ash.codegen`
+      # locally and gets an unrelated diff mixed into their feature branch.
+      - name: Check Ash codegen is up to date
+        run: mix ash.codegen --check
+
       - name: Run Credo
         id: credo
         continue-on-error: true

--- a/priv/repo/migrations/20260808172034_normalize_map_scopes_default.exs
+++ b/priv/repo/migrations/20260808172034_normalize_map_scopes_default.exs
@@ -1,0 +1,32 @@
+defmodule WandererApp.Repo.Migrations.NormalizeMapScopesDefault do
+  @moduledoc ~S"""
+  Re-records the `maps_v1.scopes` default in the resource snapshot so
+  `mix ash.codegen --check` stops reporting pending changes.
+
+  `20260406213852_add_character_description.exs` wrote the default as the
+  charlist literal `'{wormholes}'`, which is how ash_postgres serialized array
+  defaults at the time. Current ash_postgres renders the same default as the
+  Elixir list `["wormholes"]`, so every codegen run since has seen a diff that
+  nobody committed.
+
+  This is a no-op against the database. Both forms compile to the identical
+  column default (`ARRAY['wormholes']` and `'{wormholes}'` are the same
+  `text[]` value), and the type is unchanged, so Postgres takes a brief
+  ACCESS EXCLUSIVE lock without rewriting the table. It is committed only so
+  the snapshot on disk matches what codegen generates.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    alter table(:maps_v1) do
+      modify :scopes, {:array, :text}, default: ["wormholes"]
+    end
+  end
+
+  def down do
+    alter table(:maps_v1) do
+      modify :scopes, {:array, :text}, default: ~c"{wormholes}"
+    end
+  end
+end

--- a/priv/resource_snapshots/repo/maps_v1/20260808172034.json
+++ b/priv/resource_snapshots/repo/maps_v1/20260808172034.json
@@ -1,0 +1,308 @@
+{
+  "attributes": [
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"gen_random_uuid()\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": true,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "name",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "slug",
+      "type": "text"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "description",
+      "type": "text"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "personal_note",
+      "type": "text"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "public_api_key",
+      "type": "text"
+    },
+    {
+      "allow_nil?": true,
+      "default": "[]",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "hubs",
+      "type": [
+        "array",
+        "text"
+      ]
+    },
+    {
+      "allow_nil?": false,
+      "default": "\"wormholes\"",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "scope",
+      "type": "text"
+    },
+    {
+      "allow_nil?": true,
+      "default": "false",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "deleted",
+      "type": "boolean"
+    },
+    {
+      "allow_nil?": true,
+      "default": "false",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "only_tracked_characters",
+      "type": "boolean"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "options",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "false",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "webhooks_enabled",
+      "type": "boolean"
+    },
+    {
+      "allow_nil?": false,
+      "default": "false",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "sse_enabled",
+      "type": "boolean"
+    },
+    {
+      "allow_nil?": true,
+      "default": "[\"wormholes\"]",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "scopes",
+      "type": [
+        "array",
+        "text"
+      ]
+    },
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "inserted_at",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "updated_at",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": null,
+          "global": null,
+          "strategy": null
+        },
+        "name": "maps_v1_owner_id_fkey",
+        "on_delete": null,
+        "on_update": null,
+        "primary_key?": true,
+        "schema": null,
+        "table": "character_v1"
+      },
+      "scale": null,
+      "size": null,
+      "source": "owner_id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": null,
+          "global": null,
+          "strategy": null
+        },
+        "name": "maps_v1_intel_source_map_id_fkey",
+        "on_delete": null,
+        "on_update": null,
+        "primary_key?": true,
+        "schema": null,
+        "table": "maps_v1"
+      },
+      "scale": null,
+      "size": null,
+      "source": "intel_source_map_id",
+      "type": "uuid"
+    }
+  ],
+  "base_filter": null,
+  "check_constraints": [],
+  "custom_indexes": [],
+  "custom_statements": [],
+  "has_create_action": true,
+  "hash": "28EFCF19A87D6AF229DF5E7E0F8921087D834DB01EE8505F5A018BDDF91030DE",
+  "identities": [
+    {
+      "all_tenants?": false,
+      "base_filter": null,
+      "index_name": "maps_v1_unique_public_api_key_index",
+      "keys": [
+        {
+          "type": "atom",
+          "value": "public_api_key"
+        }
+      ],
+      "name": "unique_public_api_key",
+      "nils_distinct?": true,
+      "where": null
+    },
+    {
+      "all_tenants?": false,
+      "base_filter": null,
+      "index_name": "maps_v1_unique_slug_index",
+      "keys": [
+        {
+          "type": "atom",
+          "value": "slug"
+        }
+      ],
+      "name": "unique_slug",
+      "nils_distinct?": true,
+      "where": null
+    }
+  ],
+  "multitenancy": {
+    "attribute": null,
+    "global": null,
+    "strategy": null
+  },
+  "repo": "Elixir.WandererApp.Repo",
+  "schema": null,
+  "table": "maps_v1"
+}


### PR DESCRIPTION
A separate session flagged that CI does not enforce codegen, so pre-existing drift never reddens a PR. That is correct, and this fixes both halves.

## The gap

`grep` across all seven workflows finds `mix format --check-formatted`, `mix compile`, `mix credo`, `mix dialyzer` and `mix ecto.migrate` — and nothing that runs `mix ash.codegen --check`. Resource/snapshot drift is invisible to CI.

It is not hypothetical. On a clean checkout of `guarzo/zoo`:

```
$ mix ash.codegen --check
** (Mix) Pending Code Generation Detected for 2 files
```

## The drift

Cosmetic, and it is ours only in the sense that we inherited it. `20260406213852_add_character_description.exs` recorded the `maps_v1.scopes` default as the charlist `'{wormholes}'`, which is how ash_postgres serialized array defaults at the time. Current ash_postgres (2.6.25) renders the same default as the Elixir list `["wormholes"]`, so codegen has reported a diff on every run since.

Both forms are the same `text[]` value and the column type is unchanged, so the migration is a no-op beyond a brief `ACCESS EXCLUSIVE` lock — no table rewrite, no backfill.

Why bother committing a no-op: the drift leaks. The next person to run `mix ash.codegen` for an unrelated resource picks this diff up and either commits it as unexplained noise or burns time deciding whether it is theirs.

## The check

Gating, matching the formatting check in the same `static` job, and placed after the compile step so a genuine compile error still reports as a compile error rather than as codegen noise.

The two halves have to ship together — the gate alone would turn CI red immediately.

## Verification

- `mix ash.codegen --check` exits 0 on this branch (exits 1 on `guarzo/zoo`)
- `mix format --check-formatted` exits 0 repo-wide
- Against the dev database: migration applies (0.0s), `mix ecto.rollback --step 1` succeeds, re-applies cleanly
- Workflow YAML parses

## Related

The equivalent fix for upstream is a **different and more serious** change — upstream still has the `map_chain_v1.locked_by_id` FK drift that `20260804180000_add_map_chain_locked_by_fkey.exs` already closed here. Filed separately against `wanderer-industries/wanderer`.