### PR TITLE
zoo: fork hygiene — dead flag, label docs, duplicate-migration guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,32 @@ jobs:
       - name: Run tests
         run: mix test --partitions ${{ env.PARTITIONS }}
 
+  # Two migration files defining the same module is not a compile error: the
+  # later definition replaces the earlier one, so a migration silently never
+  # runs and the schema drift only surfaces much later. That happened once
+  # already (#122). Pure shell with no BEAM or deps, so it reports in seconds
+  # instead of waiting on `setup`.
+  migrations:
+    name: Migration hygiene
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for duplicate migration module names
+        run: |
+          dupes=$(grep -h '^defmodule' priv/repo/migrations/*.exs \
+            | awk '{print $2}' | sort | uniq -d)
+          if [ -n "$dupes" ]; then
+            echo "::error::Duplicate migration module names found"
+            printf '%s\n' "$dupes" | while read -r mod; do
+              echo "$mod is defined in:"
+              grep -lF "defmodule $mod do" priv/repo/migrations/*.exs | sed 's/^/  /'
+            done
+            exit 1
+          fi
+          echo "No duplicate migration module names."
+
   static:
     name: Static analysis
     runs-on: ubuntu-latest
@@ -344,15 +370,18 @@ jobs:
   gate:
     name: Test Suite
     runs-on: ubuntu-latest
-    needs: [tests, static]
+    needs: [tests, static, migrations]
     if: always()
 
     steps:
       - name: Verify required jobs succeeded
         run: |
-          echo "tests:  ${{ needs.tests.result }}"
-          echo "static: ${{ needs.static.result }}"
-          if [ "${{ needs.tests.result }}" != "success" ] || [ "${{ needs.static.result }}" != "success" ]; then
+          echo "tests:      ${{ needs.tests.result }}"
+          echo "static:     ${{ needs.static.result }}"
+          echo "migrations: ${{ needs.migrations.result }}"
+          if [ "${{ needs.tests.result }}" != "success" ] || \
+             [ "${{ needs.static.result }}" != "success" ] || \
+             [ "${{ needs.migrations.result }}" != "success" ]; then
             echo "::error::Required jobs did not pass"
             exit 1
           fi

--- a/assets/js/hooks/Mapper/components/map/labelIconMap.tsx
+++ b/assets/js/hooks/Mapper/components/map/labelIconMap.tsx
@@ -7,17 +7,18 @@ import { FaIndustry, FaHourglassEnd, FaExclamationTriangle, FaSkull } from 'reac
  * The zoo fork repurposes upstream's generic labels (A/B/C/1/2/3) with
  * EVE Online wormhole-specific meanings:
  *
- * | Key    | Upstream | Zoo Meaning        | Use Case                           |
- * |--------|----------|--------------------|------------------------------------|
- * | la/de  | Label A  | Dead End           | System with no exit wormholes      |
- * | lb/gas | Label B  | Gas Site           | System has harvestable gas sites   |
- * | lc/eol | Label C  | End of Life        | Wormhole about to collapse (<4h)   |
- * | l1/crit| Label 1  | Critical Mass      | Wormhole at mass verge             |
- * | l2/structure | Label 2 | Structure     | System has attackable structure    |
- * | l3/steve | Label 3 | Steve/Danger      | High danger (historic: player named Steve) |
+ * | Stored key | Enum member | Upstream | Zoo Meaning   | Use Case                           |
+ * |------------|-------------|----------|---------------|------------------------------------|
+ * | de         | la          | Label A  | Dead End      | System with no exit wormholes      |
+ * | gas        | lb          | Label B  | Gas Site      | System has harvestable gas sites   |
+ * | eol        | lc          | Label C  | End of Life   | Wormhole about to collapse (<4h)   |
+ * | crit       | l1          | Label 1  | Critical Mass | Wormhole at mass verge             |
+ * | structure  | l2          | Label 2  | Structure     | System has attackable structure    |
+ * | steve      | l3          | Label 3  | Steve/Danger  | High danger (historic: player named Steve) |
  *
- * Note: These labels are stored in the database using the original keys (la, lb, etc.)
- * but displayed with zoo-specific names and icons.
+ * Note: it is the enum *value* that is persisted, so `system.labels` contains `de`, `gas`,
+ * `eol`, `crit`, `structure`, `steve` -- never `la`, `lb`, `lc`. The `la`..`l3` member names
+ * exist only to keep the mapping back to upstream legible and never leave the frontend.
  *
  * @see constants.ts for MARKER_BOOKMARK_BG_STYLES using these labels
  * @see zoo-theme.scss for corresponding CSS classes

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -83,11 +83,6 @@ intel_sharing_enabled =
   |> get_var_from_path_or_env("WANDERER_INTEL_SHARING_ENABLED", "false")
   |> String.to_existing_atom()
 
-fleet_readiness_enabled =
-  config_dir
-  |> get_var_from_path_or_env("WANDERER_FLEET_READINESS_ENABLED", "false")
-  |> String.to_existing_atom()
-
 map_subscription_characters_limit =
   config_dir
   |> get_int_from_path_or_env("WANDERER_MAP_SUBSCRIPTION_CHARACTERS_LIMIT", 10_000)
@@ -199,7 +194,6 @@ config :wanderer_app,
   intel_sharing_enabled: intel_sharing_enabled,
   restrict_maps_creation: restrict_maps_creation,
   restrict_acls_creation: restrict_acls_creation,
-  fleet_readiness_enabled: fleet_readiness_enabled,
   subscription_settings: %{
     plans: [
       %{

--- a/docs/ZOO-FORK.md
+++ b/docs/ZOO-FORK.md
@@ -275,25 +275,47 @@ wormhole-specific meanings.
 
 ### Label Mappings
 
-| Key | Upstream | Zoo Meaning | Icon | Use Case |
-|-----|----------|-------------|------|----------|
-| `la`/`de` | Label A | Dead End | Block | System with no exit wormholes |
-| `lb`/`gas` | Label B | Gas Site | Industry | System has harvestable gas sites |
-| `lc`/`eol` | Label C | End of Life | Hourglass | Wormhole about to collapse (<4h) |
-| `l1`/`crit` | Label 1 | Critical Mass | Fire | Wormhole at mass verge |
-| `l2`/`structure` | Label 2 | Structure | Warning | System has attackable structure |
-| `l3`/`steve` | Label 3 | Steve/Danger | Skull | High danger (historic name) |
+`Key` is the value actually written to `system.labels`. `Enum` is the TypeScript member name
+in `LABELS`, which never leaves the frontend. `Badge` is the `shortName` rendered on the node.
+
+| Key | Enum | Upstream | Zoo Meaning | Badge | Icon (`react-icons`) | Use Case |
+|-----|------|----------|-------------|-------|----------------------|----------|
+| `de` | `la` | Label A | Dead End | `DE` | `MdOutlineBlock` | System with no exit wormholes |
+| `gas` | `lb` | Label B | Gas Site | `GAS` | `FaIndustry` | System has harvestable gas sites |
+| `eol` | `lc` | Label C | End of Life | `EOL` | `FaHourglassEnd` | Wormhole about to collapse (<4h) |
+| `crit` | `l1` | Label 1 | Critical Mass | `CRIT` | `FaExclamationTriangle` | Wormhole at mass verge |
+| `structure` | `l2` | Label 2 | Structure | `LP` | `MdLocalFireDepartment` | System has attackable structure |
+| `steve` | `l3` | Label 3 | Steve/Danger | `DB` | `FaSkull` | High danger (historic name) |
+
+The `LP` and `DB` badges are inherited oddities, not typos. `LP` is "low power" — the
+`structure` label is commented as "Low Power Structure" in `labelIconMap.tsx`. `DB` has no
+expansion anywhere in the source; treat it as historic. The `name` field in `LABELS_INFO`
+("Structure", "Steve") is what the context menu shows; `shortName` is what the node badge
+shows.
 
 ### Storage
 
-Labels are stored in the database using the original upstream keys (`la`, `lb`, etc.) but
-displayed with zoo-specific names and icons when the zoo theme is active.
+Labels are stored as the **zoo keys** — `de`, `gas`, `eol`, `crit`, `structure`, `steve` —
+not the upstream `la`/`lb`/`lc` keys. `LABELS` is a TypeScript enum whose *member names* are
+`la`…`l3` but whose *values* are the zoo keys, and it is the value that
+`LabelsManager.toggleLabel/1` stores and `LabelsManager.toString/0` serializes into the JSON
+written to `system.labels`. Querying the database for `la` will not match anything.
+
+The backend treats `labels` as an opaque string; the frontend is the only producer and
+consumer of these keys.
 
 ### Files
 
-- **Definition:** `assets/js/hooks/Mapper/components/map/labelIconMap.tsx`
-- **Styles:** `assets/js/hooks/Mapper/components/map/constants.ts` (MARKER_BOOKMARK_BG_STYLES)
+- **Definition:** `assets/js/hooks/Mapper/components/map/labelIconMap.tsx` — `LABELS`,
+  `LABELS_INFO`, `LABELS_ORDER`, `LABEL_ICON_MAP`
+- **Zoo styles:** `assets/js/hooks/Mapper/components/map/zooConstants.ts` —
+  `ZOO_BOOKMARK_STYLES` / `ZOO_TEXT_STYLES`, spread into `MARKER_BOOKMARK_BG_STYLES` by
+  `constants.ts`. Note these cover `de`, `gas`, `eol` and `crit` only; `structure` and
+  `steve` fall through to the upstream `wd-marker-bookmark-color-l2`/`-l3` classes.
+- **Re-export:** `assets/js/hooks/Mapper/components/map/constants.ts` — merges the above
 - **CSS:** `assets/js/hooks/Mapper/components/map/styles/zoo-theme.scss`
+- **Serialization:** `assets/js/hooks/Mapper/utils/labelsManager.ts`
+- **Render:** `SolarSystemNodeZoo.tsx` (node badges), `useLabelsMenu.ts` (context menu)
 
 ---
 

--- a/docs/ZOO-FORK.md
+++ b/docs/ZOO-FORK.md
@@ -344,10 +344,12 @@ Allows users to mark characters as "ready for fleet" operations.
 | Ash Resource | `lib/wanderer_app/api/map_user_settings.ex` (update_ready_characters action) |
 | Repository | `lib/wanderer_app/repositories/map_user_settings_repo.ex` |
 
-> **Known gap:** `WANDERER_FLEET_READINESS_ENABLED` is parsed in `config/runtime.exs` and
-> stored under `:wanderer_app, :fleet_readiness_enabled`, but **nothing reads it** — there is
-> no `Env` accessor and no call site. The feature is unconditionally on. Either wire the flag
-> up (mirroring `Env.intel_sharing_enabled?/0`) or delete it from `runtime.exs`.
+> **No feature flag.** Fleet readiness is unconditionally on. A
+> `WANDERER_FLEET_READINESS_ENABLED` variable was parsed in `config/runtime.exs` and stored
+> under `:wanderer_app, :fleet_readiness_enabled`, but no `Env` accessor or call site was ever
+> written for it in any branch, so setting it had no effect. It was removed rather than wired
+> up: gating it at the default of `false` would have switched the feature off for every
+> existing deployment.
 
 ---
 
@@ -414,7 +416,6 @@ config :wanderer_app, :signature_cleanup, max_age_hours: 24
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `WANDERER_INTEL_SHARING_ENABLED` | `false` | Enable cross-map intel sync |
-| `WANDERER_FLEET_READINESS_ENABLED` | `false` | **Currently unused — see Fleet Readiness** |
 | `WANDERER_KILLS_IPV6` | `false` | Resolve the kills websocket host over IPv6 |
 | `DISCORD_BOT_TOKEN` | — | Nostrum bot token; blank is treated as unset |
 | `DISCORD_GUILD_ID` | — | Guild for voice-participant lookups |


### PR DESCRIPTION
Three independent fork-hygiene items, one commit each. No behaviour change in any of them.

### `zoo(ci)`: fail the build on duplicate migration module names

Two migration files defining the same module is not a compile error — the later definition replaces the earlier one, so a migration silently never runs and the missing schema change surfaces much later. #122 was exactly this, with two files both defining `WandererApp.Repo.Migrations.FixMapsScopesDefault`, and nothing in CI would have caught it. (`mix ecto.migrate` rejects duplicate *version numbers*, which is why that class has never landed, but duplicate module names with distinct timestamps pass every existing check.)

It is its own job rather than a step in `static` because it needs neither the BEAM nor deps — it reports in seconds instead of queuing behind `setup`. It joins `gate`'s `needs` so it blocks merges through the `Test Suite` context the ruleset already requires; a job outside that list would go red without stopping anything.

Verified both directions: exit 0 on the current tree, and against the pre-#122 tree it exits 1 naming the module and both offending files.

### `zoo(chore)`: drop the dead fleet-readiness flag

`WANDERER_FLEET_READINESS_ENABLED` was parsed and stored under `:wanderer_app, :fleet_readiness_enabled`, but nothing read it — no `Env` accessor, no call site. Setting it to `false` had no effect and produced no warning.

Deleted rather than wired up. `git log -S fleet_readiness --all -- lib/ assets/` returns nothing: the flag arrived dead in `defb2443` and no gate was ever written in any branch. Wiring it at its existing `false` default would have switched fleet readiness off for every deployment currently running it; flipping the default to `true` to avoid that adds a config surface nobody asked for.

### `zoo(docs)`: correct the label system section against the code

Audited against `labelIconMap.tsx`, `zooConstants.ts`, `constants.ts`, `labelsManager.ts` and `zoo-theme.scss`. Three errors:

- **`crit` and `structure` icons were swapped.** Code has `crit` = `FaExclamationTriangle`, `structure` = `MdLocalFireDepartment`. The inline comments in `LABEL_ICON_MAP` were already right; only the doc had them crossed.
- **The storage claim was backwards.** The doc said labels are stored as the upstream `la`/`lb`/`lc` keys. `LABELS` member names are `la`..`l3` but its *values* are `de`/`gas`/`eol`/`crit`/`structure`/`steve`, and the value is what `LabelsManager` persists into `system.labels`. Searching the database for `la` matches nothing. The same false claim was in `labelIconMap.tsx`'s header — where the doc copied it from — so both are fixed.
- **The styles pointer was one file short.** Zoo styles live in `zooConstants.ts` as `ZOO_BOOKMARK_STYLES` and are only spread into `MARKER_BOOKMARK_BG_STYLES`. That set covers `de`, `gas`, `eol`, `crit` only — `structure` and `steve` fall through to the upstream `-l2`/`-l3` classes, which is easy to mistake for a missing style.

Also documents the `shortName` badges, since those are what render on the node and neither matches its menu label: `structure` shows `LP`, `steve` shows `DB`. `LP` is "low power" per the source comment; `DB` has no expansion anywhere in the tree, so it is described as historic rather than guessed at.

### Verification

- `mix compile` — generates the app
- `mix format --check-formatted` — passes
- `prettier --check` on the edited `.tsx` — passes
- `yarn build` — succeeds
- new duplicate-migration check — exit 0 on this tree, exit 1 on the pre-#122 tree

### Review focus

The CI change is the only one with teeth. Worth confirming the `gate` wiring is right, since a mistake there fails open rather than loud.
