### PR TITLE
feat(notifications): restructure the Notifications tab around its two features

### DIFF
--- a/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
+++ b/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
@@ -11,6 +11,23 @@ defmodule WandererAppWeb.MapNotificationsComponent do
 
   Webhook URLs are credentials: stored encrypted, only ever rendered as a masked
   hint with a replace flow, like a password field.
+
+  The tab is organised around TWO features rather than three peer destinations,
+  because that is what the schema actually models: kill notifications (system
+  channel, required; optional character-channel split; filters) and route
+  alerts (a separate feature borrowing the same webhook plumbing — its own
+  toggle, channel, home system, max jumps and mentions). Four progressive
+  disclosure levels:
+
+    L0 (no record)  — one URL field, one Connect button.
+    L1 (configured) — status, the wormhole-only toggle, and two collapsed
+                       disclosures (below) plus the danger action.
+    L2 (disclosure) — "Filters and routing": excluded systems, corporation
+                       filter, and the optional character channel.
+    L3 (disclosure) — "Route alerts": toggle, channel, home system, max jumps,
+                       mentions — all in one self-contained section, so its
+                       toggle and its channel can never again end up hundreds
+                       of pixels apart.
   """
 
   use WandererAppWeb, :live_component
@@ -21,6 +38,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   alias WandererApp.Api.MapDiscordWebhook
   alias WandererApp.Api.MapSolarSystem
   alias WandererApp.Esi.CorporationSearch
+  alias WandererApp.ExternalEvents.Discord.ChannelInfo
   alias WandererApp.ExternalEvents.Discord.Mentions
 
   @excluded_select_id "excluded_system_live_select_component"
@@ -30,6 +48,14 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   @max_search_results 20
 
   @roles [:system, :character, :route]
+
+  # Mirrors the resource's own default (map_discord_notification.ex:166), so a
+  # blank/non-numeric max-jumps input falls back to the same number a brand new
+  # record would get rather than an unrelated magic value.
+  @default_route_max_jumps 5
+  # Mirrors the resource's `constraints min: 1, max: 20` (map_discord_notification.ex:173).
+  @min_route_max_jumps 1
+  @max_route_max_jumps 20
 
   # Shown under the corporation box when the lookup itself failed, as opposed to
   # succeeding with no matches.
@@ -83,6 +109,8 @@ defmodule WandererAppWeb.MapNotificationsComponent do
      |> assign(:focus_corp_select_id, @focus_corp_select_id)
      |> assign(:home_system_select_id, @home_system_select_id)
      |> assign(:min_search_length, @min_search_length)
+     |> assign(:min_route_max_jumps, @min_route_max_jumps)
+     |> assign(:max_route_max_jumps, @max_route_max_jumps)
      |> assign(:corp_min_search_length, CorporationSearch.min_search_length())
      |> assign_new(:system_options, fn -> [] end)
      |> assign_new(:system_search_error, fn -> nil end)
@@ -90,82 +118,173 @@ defmodule WandererAppWeb.MapNotificationsComponent do
      |> assign_new(:home_system_error, fn -> nil end)
      |> assign_new(:corp_options, fn -> [] end)
      |> assign_new(:corp_search_error, fn -> nil end)
-     |> assign_new(:error, fn -> nil end)
-     |> assign_new(:flash_message, fn -> nil end)
+     |> assign_new(:message, fn -> nil end)
      |> assign_notification(notification)}
   end
 
+  # --- Kill-notification settings (`#discord-notification-form`) ---------
+
+  # Handles BOTH the L0 create submit (webhook_url present, notification nil)
+  # and the L1 settings submit (wh_only only). `notification_attrs/1` reading
+  # `params` rather than a hardcoded field list is what makes this safe for
+  # both: L0's form never renders wh_only, so it is simply absent from
+  # `params` and the resource default (`wh_only: true`) applies untouched. See
+  # `notification_attrs/1`.
   @impl true
   def handle_event("save", %{"notification" => params}, socket) do
-    case resolve_home_system(params) do
-      {:ok, home_system_id} -> save_notification(socket, params, home_system_id)
-      {:error, message} -> {:noreply, put_home_system_error(socket, message)}
+    attrs = notification_attrs(params)
+
+    result =
+      case socket.assigns.notification do
+        nil ->
+          create_with_system_webhook(socket.assigns.map_id, attrs, params["webhook_url"])
+
+        rec ->
+          # Deliberately NOT `webhook_url`: that moved to the child resource and
+          # is no longer an accepted input here — passing it raises NoSuchInput
+          # at runtime. URLs are saved through "save-webhook".
+          MapDiscordNotification.update(rec, attrs)
+      end
+
+    case result do
+      {:ok, rec} ->
+        {:noreply, socket |> assign_notification(rec) |> put_message(:kills, :info, "Saved.")}
+
+      {:error, error} ->
+        {:noreply, put_message(socket, :kills, :error, humanize_error(error))}
     end
   end
+
+  # Purely client-display dirty tracking for the L1 settings form: the only
+  # signal Save needs is "does this differ from the persisted record", so it
+  # is computed here rather than persisted. Fires on every keystroke/tick in
+  # `#discord-notification-form`, which at L1 holds only `wh_only`.
+  #
+  # The form is rebuilt from `params`, not left alone — #130. A checkbox
+  # renders `checked` from its form value, so re-rendering against the
+  # unchanged form emits the box UNCHECKED and LiveView patches the user's
+  # tick straight back out. Nothing here is persisted; `wh_only` is still
+  # only ever written by "save".
+  #
+  # Unlike #130 this needs no `webhook_url` blanking: the L1 form does not
+  # render that field at all. The credential lives on the mutually exclusive
+  # L0 create form (`is_nil(@notification)`), which deliberately carries no
+  # `phx-change`, so no submitted params containing a webhook URL ever reach
+  # a `to_form/2` call.
+  def handle_event("kills-form-change", %{"notification" => params}, socket) do
+    rec = socket.assigns.notification
+
+    dirty? =
+      changed?(params, "enabled", rec.enabled?, &checked?/1) or
+        changed?(params, "wh_only", rec.wh_only, &checked?/1)
+
+    {:noreply,
+     socket
+     |> assign(:form, rebuild_form(params, kills_form_values(rec)))
+     |> assign(:dirty, Map.put(socket.assigns.dirty, :kills, dirty?))}
+  end
+
+  # --- Route alerts (`#route-alerts-form`) --------------------------------
+
+  def handle_event("save-route", %{"notification" => params}, socket) do
+    case socket.assigns.notification do
+      nil ->
+        {:noreply,
+         put_message(socket, :route, :error, "Save the map's kill notification settings first.")}
+
+      rec ->
+        case resolve_home_system(params) do
+          {:ok, params} -> save_route(socket, rec, params)
+          {:error, message} -> {:noreply, put_home_system_error(socket, message)}
+        end
+    end
+  end
+
+  # Three jobs on every change of the route form: keep `route_toggle` (which
+  # fields below are enabled — D4, disable rather than hide) in step with the
+  # unsaved checkbox state, rebuild the form so the tick survives the
+  # round-trip (#130 — a checkbox renders `checked` from its form value, so
+  # re-rendering against the unchanged form patches the user's tick back out
+  # and Save then posts `false`), and keep the route Save button's dirty gate
+  # honest. All three are purely client-display; the persisted values only
+  # ever change through "save-route".
+  #
+  # Rebuilt from `params` rather than by patching one key, so anything already
+  # typed into `home_system_id` / `route_max_jumps` is preserved instead of
+  # being reset to the last-saved record on every tick. This form carries no
+  # `webhook_url`, so #130's credential-blanking step has nothing to do here.
+  def handle_event("route-form-change", %{"notification" => params}, socket) do
+    rec = socket.assigns.notification
+
+    dirty? =
+      changed?(params, "route_alerts_enabled", rec.route_alerts_enabled?, &checked?/1) or
+        changed?(params, "home_system_id", rec.home_system_id, &parse_home_system_id/1) or
+        changed?(params, "route_max_jumps", rec.route_max_jumps, &parse_route_max_jumps/1)
+
+    {:noreply,
+     socket
+     |> assign(:route_toggle, checked?(params["route_alerts_enabled"]))
+     |> assign(:route_form, rebuild_form(params, route_form_values(rec)))
+     |> assign(:dirty, Map.put(socket.assigns.dirty, :route, dirty?))}
+  end
+
+  # The inline remedy on the "switched off, but this channel is configured"
+  # warning (D4.2): saves immediately rather than only flipping the unsaved
+  # checkbox, because the warning exists precisely because a config can sit in
+  # this state indefinitely without anyone pressing Save. If `home_system_id`
+  # is nil the Ash "required when enabled" validation fires and lands in the
+  # route panel — that is correct, not a bug: enabling from here does not
+  # bypass the same validation the settings form is subject to.
+  def handle_event("enable-route-alerts", _params, socket) do
+    case socket.assigns.notification do
+      nil ->
+        {:noreply, socket}
+
+      rec ->
+        case MapDiscordNotification.update(rec, %{route_alerts_enabled?: true}) do
+          {:ok, updated} ->
+            {:noreply,
+             socket
+             |> assign_notification(updated)
+             |> put_message(:route, :info, "Route alerts enabled.")}
+
+          {:error, error} ->
+            {:noreply, put_message(socket, :route, :error, humanize_error(error))}
+        end
+    end
+  end
+
+  # --- Webhook destinations (system / character / route rows) ------------
 
   def handle_event("replace-url", %{"role" => role}, socket) do
     {:noreply, put_replacing(socket, parse_role(role), true)}
   end
 
-  # Which fields are visually shown, driven by the CHECKBOX's own `phx-change`
-  # rather than the form's, so this box keeps its dedicated handler even though
-  # the form now has a `phx-change` of its own (see "notification-changed").
-  # Nothing here is persisted; the actual value is only ever written by "save",
-  # same as every other field on this form.
-  #
-  # The form MUST be rebuilt here, not just `:route_toggle`. A checkbox renders
-  # `checked` from its form value, so re-rendering against the unchanged form
-  # emits the box UNCHECKED and LiveView patches the user's ticked box back —
-  # the fields below appear, which reads as "it worked", and then Save posts
-  # `false` and silently stores route alerts as off. It reports "Saved."
-  # because it IS a valid save: with the toggle false the home-system
-  # validation has nothing to complain about.
-  #
-  # Rebuilt from `params` rather than by patching the one key, because those
-  # params are the whole form as the browser has it — the home system already
-  # picked and anything typed into `route_max_jumps` are preserved instead of
-  # being reset to the last-saved record on every tick.
-  def handle_event("toggle-route-alerts", %{"notification" => params}, socket) do
-    {:noreply, rebuild_form(socket, params)}
-  end
-
-  # The FORM's own `phx-change`, which the checkbox above never reaches: an
-  # input that declares `phx-change` itself wins over its form's
-  # (`phoenix_live_view.esm.js`, `bindForms`: `inputEvent || formEvent`), so
-  # ticking the box still runs "toggle-route-alerts" and only that.
-  #
-  # This exists for the home-system picker. LiveSelect keeps the selection in
-  # its OWN component state and re-derives it from `field.value` on every
-  # re-render (`live_select/component.ex:153-170`), so a parent re-render while
-  # `@form` still holds the old value — searching the excluded-systems box,
-  # saving a webhook, any flash — wipes the user's pick and blanks the hidden
-  # input with it. On selection LiveSelect's JS hook dispatches a bubbling
-  # `input` event on that hidden input (`live_select.min.js`, `inputEvent`),
-  # which has no `phx-change` of its own, so it lands here: the form is rebuilt
-  # WITH the chosen id and every later re-render re-derives the same selection.
-  #
-  # Nothing here is persisted, same as the toggle — "save" is still the only
-  # writer.
-  def handle_event("notification-changed", %{"notification" => params}, socket) do
-    {:noreply, rebuild_form(socket, params)}
+  # Undoes "replace-url" without saving anything. Before this existed, a
+  # misclick on Edit/Replace discarded the masked view with no way back short
+  # of re-pasting a credential the user does not have on hand, or closing and
+  # reopening the whole dialog.
+  def handle_event("cancel-replace", %{"role" => role}, socket) do
+    {:noreply, put_replacing(socket, parse_role(role), false)}
   end
 
   def handle_event("save-webhook", %{"role" => role, "webhook" => params}, socket) do
     role = parse_role(role)
+    scope = webhook_scope(role)
 
     with %{} = rec <- socket.assigns.notification,
          {:ok, _} <- save_webhook(rec, socket.assigns.webhooks[role], role, params) do
       {:noreply,
        socket
        |> assign_notification(reload_notification(socket.assigns.map_id))
-       |> assign(:error, nil)
-       |> assign(:flash_message, "Saved.")}
+       |> put_message(scope, :info, "Saved.")}
     else
       {:error, error} ->
-        {:noreply, socket |> assign(:error, humanize_error(error)) |> assign(:flash_message, nil)}
+        {:noreply, put_message(socket, scope, :error, humanize_error(error))}
 
       _ ->
-        {:noreply, assign(socket, :error, "Save the map's notification settings first.")}
+        {:noreply,
+         put_message(socket, scope, :error, "Save the map's notification settings first.")}
     end
   end
 
@@ -176,6 +295,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
     # NOT — route alerts stop entirely, because the Router deliberately has no
     # fallback for chain topology.
     role = parse_role(role)
+    scope = webhook_scope(role)
 
     case {role, socket.assigns.webhooks[role]} do
       {role, %{} = webhook} when role in [:character, :route] ->
@@ -184,17 +304,38 @@ defmodule WandererAppWeb.MapNotificationsComponent do
             {:noreply,
              socket
              |> assign_notification(reload_notification(socket.assigns.map_id))
-             |> assign(:error, nil)
-             |> assign(:flash_message, "#{role_label(role)} destination removed.")}
+             |> put_message(scope, :info, "#{role_label(role)} destination removed.")}
 
           {:error, error} ->
-            {:noreply,
-             socket |> assign(:error, humanize_error(error)) |> assign(:flash_message, nil)}
+            {:noreply, put_message(socket, scope, :error, humanize_error(error))}
         end
 
       _ ->
-        {:noreply, assign(socket, :error, "The system destination cannot be removed.")}
+        {:noreply,
+         put_message(socket, scope, :error, "The system destination cannot be removed.")}
     end
+  end
+
+  # Field-level validation for the mentions box (Minors: validated on change,
+  # not only on submit). Purely advisory — nothing here saves anything; the
+  # actual save still runs `parse_mention_targets/1` inside `save_webhook/4`
+  # and would reject the same input. `phx-target={@myself}` on the input
+  # keeps this in this component, same as every other event on this form.
+  def handle_event(
+        "validate-mentions",
+        %{"role" => role, "webhook" => %{"mention_targets" => raw}},
+        socket
+      ) do
+    role = parse_role(role)
+
+    error =
+      case parse_mention_targets(raw) do
+        {:ok, _targets} -> nil
+        {:error, message} -> message
+      end
+
+    {:noreply,
+     assign(socket, :mention_errors, Map.put(socket.assigns.mention_errors, role, error))}
   end
 
   # LiveSelect's search callback: users know systems and corporations by name,
@@ -205,7 +346,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   # options. `phx-target={@myself}` on each live_select is what keeps the event
   # in this component.
   #
-  # Two pickers now share this handler, so it MUST dispatch on the id that
+  # Three pickers share this handler, so it MUST dispatch on the id that
   # fired. Answering unconditionally with system options would fill the
   # corporation dropdown with solar systems.
   def handle_event("live_select_change", %{"id" => @focus_corp_select_id, "text" => text}, socket) do
@@ -230,6 +371,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         socket
       ) do
     {options, home_system_search_error} = search_systems(text)
+    options = maybe_prepend_numeric_system(options, text)
 
     send_update(LiveSelect.Component, id: @home_system_select_id, options: options)
 
@@ -256,7 +398,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
          {id, ""} <- Integer.parse(to_string(raw)) do
       update_excluded(socket, rec, Enum.uniq([id | rec.excluded_systems]))
     else
-      _ -> {:noreply, assign(socket, :error, "Pick a system from the list.")}
+      _ -> {:noreply, put_message(socket, :filters, :error, "Pick a system from the list.")}
     end
   end
 
@@ -268,7 +410,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
          {id, ""} <- Integer.parse(to_string(raw)) do
       update_excluded(socket, rec, Enum.reject(rec.excluded_systems, &(&1 == id)))
     else
-      _ -> {:noreply, assign(socket, :error, "Could not remove that system.")}
+      _ -> {:noreply, put_message(socket, :filters, :error, "Could not remove that system.")}
     end
   end
 
@@ -281,7 +423,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
          {id, ""} <- Integer.parse(to_string(raw)) do
       update_focus_corps(socket, rec, Enum.uniq(rec.focus_corp_ids ++ [id]))
     else
-      _ -> {:noreply, assign(socket, :error, "Pick a corporation from the list.")}
+      _ -> {:noreply, put_message(socket, :filters, :error, "Pick a corporation from the list.")}
     end
   end
 
@@ -290,43 +432,43 @@ defmodule WandererAppWeb.MapNotificationsComponent do
          {id, ""} <- Integer.parse(to_string(raw)) do
       update_focus_corps(socket, rec, Enum.reject(rec.focus_corp_ids, &(&1 == id)))
     else
-      _ -> {:noreply, assign(socket, :error, "Could not remove that corporation.")}
+      _ -> {:noreply, put_message(socket, :filters, :error, "Could not remove that corporation.")}
     end
   end
 
   def handle_event("send-test", %{"webhook_id" => webhook_id}, socket) do
+    scope = webhook_scope(role_for_webhook_id(socket.assigns.webhooks, webhook_id))
+
     case send_test(socket, webhook_id) do
       # `:ok` means the message was ENQUEUED — the last hop is an async cast, so
       # this must not claim Discord accepted it.
       :ok ->
-        {:noreply,
-         socket |> assign(:flash_message, "Test message queued.") |> assign(:error, nil)}
+        {:noreply, put_message(socket, scope, :info, "Test message queued.")}
 
       {:error, :notifications_disabled} ->
         {:noreply,
-         socket
-         |> assign(
+         put_message(
+           socket,
+           scope,
            :error,
            "Discord notifications are disabled on this server. Ask an administrator to enable them."
-         )
-         |> assign(:flash_message, nil)}
+         )}
 
       {:error, :webhook_disabled} ->
         {:noreply,
-         socket
-         |> assign(
+         put_message(
+           socket,
+           scope,
            :error,
            "This destination is disabled. Enable it and save before sending a test message."
-         )
-         |> assign(:flash_message, nil)}
+         )}
 
       # Two distinct dispatcher answers, one message on purpose: "no such row"
       # and "row with no usable URL" are worth telling apart in a log or a test,
       # but a user can do nothing about either except save a URL, and this
       # wording is brief-mandated verbatim.
       {:error, reason} when reason in [:webhook_not_found, :webhook_url_missing] ->
-        {:noreply,
-         socket |> assign(:error, "Save a webhook URL first.") |> assign(:flash_message, nil)}
+        {:noreply, put_message(socket, scope, :error, "Save a webhook URL first.")}
 
       {:error, other} ->
         # `inspect(other)` here put the raw failure term — which can carry the
@@ -334,9 +476,12 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         Logger.warning("[MapNotifications] test message failed: #{error_summary(other)}")
 
         {:noreply,
-         socket
-         |> assign(:error, "Could not send a test message. Check the webhook URL and try again.")
-         |> assign(:flash_message, nil)}
+         put_message(
+           socket,
+           scope,
+           :error,
+           "Could not send a test message. Check the webhook URL and try again."
+         )}
     end
   end
 
@@ -351,16 +496,16 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         case WandererApp.Api.MapDiscordNotification.destroy(rec) do
           :ok ->
             {:noreply,
-             socket
-             |> assign_notification(nil)
-             |> assign(:error, nil)
-             |> assign(:flash_message, "Removed.")}
+             socket |> assign_notification(nil) |> put_message(:kills, :info, "Removed.")}
 
           {:error, error} ->
-            {:noreply,
-             socket |> assign(:error, humanize_error(error)) |> assign(:flash_message, nil)}
+            {:noreply, put_message(socket, :kills, :error, humanize_error(error))}
         end
     end
+  end
+
+  defp put_message(socket, scope, kind, text) do
+    assign(socket, :message, %{scope: scope, kind: kind, text: text})
   end
 
   # `webhook_id` arrives from the client as `phx-value-webhook_id`, and
@@ -386,6 +531,24 @@ defmodule WandererAppWeb.MapNotificationsComponent do
       _webhook -> WandererApp.ExternalEvents.DiscordDispatcher.send_test_message(webhook_id)
     end
   end
+
+  # Which role a webhook id belongs to, so a message produced by "send-test"
+  # (which only receives the id) lands in the panel that contains that
+  # destination. `nil` (id not found / not yet known) falls back to the kills
+  # panel — every send-test button is reachable from a row that lives inside
+  # either the kills card or one of its disclosures, and the kills panel is
+  # the only one always on screen.
+  defp role_for_webhook_id(webhooks, webhook_id) do
+    Enum.find_value(webhooks, fn {role, wh} -> match?(%{id: ^webhook_id}, wh) && role end)
+  end
+
+  # Maps a destination to the message panel that contains it (D2): a
+  # channel's own save/test/remove result must land where the user is looking,
+  # not at the top of a two-thousand-pixel page.
+  defp webhook_scope(:system), do: :kills
+  defp webhook_scope(:character), do: :filters
+  defp webhook_scope(:route), do: :route
+  defp webhook_scope(nil), do: :kills
 
   defp save_webhook(rec, nil, role, %{"webhook_url" => url} = params)
        when is_binary(url) and url != "" do
@@ -452,59 +615,6 @@ defmodule WandererAppWeb.MapNotificationsComponent do
 
   defp parse_mention_targets(_), do: {:ok, []}
 
-  # `webhook_url` is forced back to "" rather than carried through. On the
-  # create path that field is rendered (a password input) and the generic
-  # `.input` writes `value=` for every type, password included — so echoing the
-  # submitted params would put a live webhook URL into the server-rendered
-  # HTML, which this module treats as a credential that is only ever rendered
-  # as a masked hint. Blanking it costs nothing: "" is what the field rendered
-  # before this event too, so there is no diff for that input and whatever the
-  # user typed stays in the DOM untouched.
-  defp rebuild_form(socket, params) do
-    form = params |> Map.put("webhook_url", "") |> to_form(as: :notification)
-
-    socket
-    |> assign(:route_toggle, checked?(params["route_alerts_enabled"]))
-    |> assign(:form, form)
-  end
-
-  # `.input type="checkbox"` renders a hidden "false" before the box, so a
-  # rendered field always submits a value and Phoenix keeps the last one.
-  defp save_notification(socket, params, home_system_id) do
-    attrs = %{
-      wh_only: checked?(params["wh_only"]),
-      enabled?: checked?(params["enabled"]),
-      route_alerts_enabled?: checked?(params["route_alerts_enabled"]),
-      home_system_id: home_system_id,
-      route_max_jumps: parse_route_max_jumps(params["route_max_jumps"])
-    }
-
-    result =
-      case socket.assigns.notification do
-        nil ->
-          create_with_system_webhook(socket.assigns.map_id, attrs, params["webhook_url"])
-
-        rec ->
-          # Deliberately NOT `webhook_url`: that moved to the child resource and
-          # is no longer an accepted input here — passing it raises NoSuchInput
-          # at runtime. URLs are saved through "save-webhook".
-          MapDiscordNotification.update(rec, attrs)
-      end
-
-    case result do
-      {:ok, rec} ->
-        {:noreply,
-         socket
-         |> assign_notification(rec)
-         |> assign(:error, nil)
-         |> assign(:home_system_error, nil)
-         |> assign(:flash_message, "Saved.")}
-
-      {:error, error} ->
-        {:noreply, socket |> assign(:error, humanize_error(error)) |> assign(:flash_message, nil)}
-    end
-  end
-
   # Creating the config and its required `:system` destination is one user
   # action. Task 2's `create` takes `webhook_url` as a required argument and
   # creates the `:system` child through `manage_relationship` in the SAME
@@ -551,37 +661,75 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   defp update_excluded(socket, rec, excluded) do
     case MapDiscordNotification.update(rec, %{excluded_systems: excluded}) do
       {:ok, updated} ->
-        {:noreply, socket |> assign_notification(updated) |> assign(:error, nil)}
+        {:noreply, assign_notification(socket, updated)}
 
       {:error, error} ->
-        {:noreply, assign(socket, :error, humanize_error(error))}
+        {:noreply, put_message(socket, :filters, :error, humanize_error(error))}
     end
   end
 
   defp update_focus_corps(socket, rec, corp_ids) do
     case MapDiscordNotification.update(rec, %{focus_corp_ids: corp_ids}) do
       {:ok, updated} ->
-        {:noreply, socket |> assign_notification(updated) |> assign(:error, nil)}
+        {:noreply, assign_notification(socket, updated)}
 
       {:error, error} ->
-        {:noreply, assign(socket, :error, humanize_error(error))}
+        {:noreply, put_message(socket, :filters, :error, humanize_error(error))}
     end
   end
 
+  # D1 — the single most load-bearing change in this rework. Two independent
+  # callers need "absent key means keep current, never clear":
+  #
+  #   * The route settings form's fields are `disabled={not @route_toggle}`
+  #     rather than hidden (D4) — but a rendered-and-disabled input still
+  #     submits NOTHING, same as an unrendered one. The old blanket
+  #     `params["home_system_id"]` read would parse that absence as `nil` and
+  #     wipe a saved home system on every Save made with route alerts off.
+  #   * L0's create form has no `wh_only`/`enabled` checkboxes at all (moved to
+  #     L1). `checked?(nil)` is `false`, which is exactly the regression this
+  #     guards against — every new config being born disabled with no visible
+  #     control to contradict it.
+  #
+  # Present-but-blank still clears: that is the user emptying a field, which
+  # is a different thing from the field never having been on the page.
+  defp notification_attrs(params) do
+    %{}
+    |> put_param(params, "wh_only", :wh_only, &checked?/1)
+    |> put_param(params, "enabled", :enabled?, &checked?/1)
+    |> put_param(params, "route_alerts_enabled", :route_alerts_enabled?, &checked?/1)
+    |> put_param(params, "home_system_id", :home_system_id, &parse_home_system_id/1)
+    |> put_param(params, "route_max_jumps", :route_max_jumps, &parse_route_max_jumps/1)
+  end
+
+  defp put_param(attrs, params, key, attr, parse) do
+    if Map.has_key?(params, key), do: Map.put(attrs, attr, parse.(params[key])), else: attrs
+  end
+
+  defp changed?(params, key, current, parse),
+    do: Map.has_key?(params, key) and parse.(params[key]) != current
+
   # Resolves excluded-system names and focus-corporation labels once per change,
   # not once per render: both run lookups, and the template re-renders on every
-  # live_select keystroke. Also rebuilds every form so values follow the record.
+  # live_select keystroke. Also rebuilds every form so values follow the record,
+  # and resets the purely-client dirty/mention-error state: a freshly (re)loaded
+  # record is by definition not dirty against itself, and any mention-field
+  # complaint was about input that either just got saved or just got replaced.
   defp assign_notification(socket, notification) do
     webhooks = load_webhooks(notification)
 
     socket
     |> assign(:notification, notification)
     |> assign(:webhooks, webhooks)
+    |> assign(:collisions, ChannelInfo.colliding_roles(webhooks))
     |> assign(:route_toggle, !is_nil(notification) and notification.route_alerts_enabled?)
+    |> assign(:dirty, %{kills: false, route: false})
+    |> assign(:mention_errors, %{})
     |> assign(:excluded_systems, excluded_system_labels(notification))
     |> assign(:focus_corps, focus_corp_labels(notification))
     |> assign(:home_system_options, home_system_options(notification))
-    |> assign(:form, notification_form(notification))
+    |> assign(:form, kills_form(notification))
+    |> assign(:route_form, route_form(notification))
     |> assign(:webhook_forms, webhook_forms(webhooks))
     |> assign(:excluded_form, to_form(%{"excluded_system" => nil}, as: :excluded))
     |> assign(:focus_corp_form, to_form(%{"focus_corp" => nil}, as: :focus_corp))
@@ -612,28 +760,61 @@ defmodule WandererAppWeb.MapNotificationsComponent do
     Map.new(@roles, fn role -> {role, Enum.find(records, &(&1.role == role))} end)
   end
 
-  defp notification_form(notification) do
-    to_form(
-      %{
-        "webhook_url" => "",
-        "wh_only" => is_nil(notification) or notification.wh_only,
-        "enabled" => is_nil(notification) or notification.enabled?,
-        # Unlike wh_only/enabled, this one defaults OFF (Task 3: `default:
-        # false`) — `is_nil(notification) or ...` would default it ON, which
-        # is backwards for this field.
-        "route_alerts_enabled" => !is_nil(notification) and notification.route_alerts_enabled?,
-        "home_system_id" => home_system_id_value(notification),
-        "route_max_jumps" => route_max_jumps_value(notification)
-      },
-      as: :notification
-    )
+  # Rebuilds a form from submitted params WITHOUT losing fields the payload
+  # did not mention.
+  #
+  # #130 established that these change handlers must rebuild the form at all
+  # (a checkbox renders `checked` from its form value, so re-rendering against
+  # the unchanged form patches the user's tick back out). Rebuilding straight
+  # from `params` then introduces the opposite failure: a payload carrying
+  # only the field that changed blanks every other field in the form, and the
+  # next Save posts those blanks.
+  #
+  # A real browser serialises the whole form even for an input-level
+  # `phx-change`, so in production the merge is a no-op — including for
+  # unticking, where the hidden "false" companion keeps the key present. It
+  # matters for any partial payload, and it means the base values fall back to
+  # the persisted record rather than to empty.
+  #
+  # `webhook_url` is forced back to "" last, keeping #130's defence even
+  # though no form that carries a credential has a `phx-change` any more: the
+  # generic `.input` writes `value=` for password inputs too, so a submitted
+  # URL reaching `to_form/2` would be printed into the server-rendered HTML.
+  defp rebuild_form(params, base) do
+    base
+    |> Map.merge(params)
+    |> Map.put("webhook_url", "")
+    |> to_form(as: :notification)
+  end
+
+  defp kills_form(notification), do: to_form(kills_form_values(notification), as: :notification)
+
+  defp kills_form_values(notification) do
+    %{
+      "webhook_url" => "",
+      "enabled" => is_nil(notification) or notification.enabled?,
+      "wh_only" => is_nil(notification) or notification.wh_only
+    }
+  end
+
+  defp route_form(notification), do: to_form(route_form_values(notification), as: :notification)
+
+  defp route_form_values(notification) do
+    %{
+      # Unlike wh_only/enabled, this one defaults OFF (Task 3: `default:
+      # false`) — `is_nil(notification) or ...` would default it ON, which
+      # is backwards for this field.
+      "route_alerts_enabled" => !is_nil(notification) and notification.route_alerts_enabled?,
+      "home_system_id" => home_system_id_value(notification),
+      "route_max_jumps" => route_max_jumps_value(notification)
+    }
   end
 
   defp home_system_id_value(nil), do: ""
   defp home_system_id_value(%{home_system_id: nil}), do: ""
   defp home_system_id_value(%{home_system_id: id}), do: to_string(id)
 
-  defp route_max_jumps_value(nil), do: 5
+  defp route_max_jumps_value(nil), do: @default_route_max_jumps
   defp route_max_jumps_value(%{route_max_jumps: n}), do: n
 
   # Blank or non-numeric input clears the home system rather than raising —
@@ -647,8 +828,24 @@ defmodule WandererAppWeb.MapNotificationsComponent do
     end
   end
 
+  defp save_route(socket, rec, params) do
+    case MapDiscordNotification.update(rec, notification_attrs(params)) do
+      {:ok, updated} ->
+        {:noreply,
+         socket
+         |> assign_notification(updated)
+         |> assign(:home_system_error, nil)
+         |> put_message(:route, :info, "Saved.")}
+
+      {:error, error} ->
+        {:noreply, put_message(socket, :route, :error, humanize_error(error))}
+    end
+  end
+
   # What the form posts for the home system, resolved to the integer id the
-  # resource stores.
+  # resource stores. Returns the params back with `home_system_id` rewritten,
+  # so `notification_attrs/1` keeps being the single place that decides which
+  # attributes a save touches.
   #
   # LiveSelect submits two inputs: the hidden `home_system_id` (the picked
   # option's value) and the visible `home_system_id_text_input`. Normally only
@@ -658,20 +855,26 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   # when route alerts are enabled", which says nothing about the name they
   # typed.
   #
-  # The text is only consulted while route alerts are ENABLED. With the toggle
-  # off the whole block is hidden, so leftover text in it is invisible, and
-  # refusing to save unrelated settings over something the user cannot see
-  # would be baffling.
+  # With route alerts off the picker sits inside a `disabled` fieldset, so it
+  # submits NOTHING — neither input is in `params`. That absence is D1's
+  # "keep the current value", and it must not be turned into a nil here: it is
+  # exactly what stops Save-with-alerts-off from wiping a saved home system.
+  defp resolve_home_system(params) when not is_map_key(params, "home_system_id"),
+    do: {:ok, params}
+
   defp resolve_home_system(params) do
     case parse_home_system_id(params["home_system_id"]) do
       id when is_integer(id) ->
-        {:ok, id}
+        {:ok, Map.put(params, "home_system_id", id)}
 
       nil ->
-        resolve_home_system_name(
-          params["home_system_id_text_input"],
-          checked?(params["route_alerts_enabled"])
-        )
+        with {:ok, id} <-
+               resolve_home_system_name(
+                 params["home_system_id_text_input"],
+                 checked?(params["route_alerts_enabled"])
+               ) do
+          {:ok, Map.put(params, "home_system_id", id)}
+        end
     end
   end
 
@@ -716,16 +919,32 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   defp put_home_system_error(socket, message) do
     socket
     |> assign(:home_system_error, message)
-    |> assign(:flash_message, nil)
+    |> assign(:message, nil)
   end
 
-  # Falls back to the column default (5) on blank/non-numeric input rather
-  # than sending `nil` into an `allow_nil?: false` attribute, which Ash would
+  # Falls back to the column default on blank/non-numeric input rather than
+  # sending `nil` into an `allow_nil?: false` attribute, which Ash would
   # reject outright.
   defp parse_route_max_jumps(raw) do
     case Integer.parse(to_string(raw || "")) do
       {n, ""} -> n
-      _ -> 5
+      _ -> @default_route_max_jumps
+    end
+  end
+
+  # D7's numeric fallback: an all-digits query becomes a usable option even
+  # when it matches no system name (or matches nothing at all, e.g. an id for
+  # a system this instance's SDE snapshot doesn't carry). `Integer.parse`
+  # requiring a full match (`{id, ""}`) is the "all-digits" check — "31k" or
+  # "J1234" fall through untouched.
+  #
+  # The value is a STRING for the reason `search_systems/1` explains: LiveSelect
+  # re-derives its selection by matching `field.value`, which round-trips
+  # through the browser as a string.
+  defp maybe_prepend_numeric_system(options, text) do
+    case Integer.parse(text) do
+      {id, ""} -> [{"Solar system #{id}", to_string(id)} | options]
+      _ -> options
     end
   end
 
@@ -936,20 +1155,280 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   defp var_string(value) when is_number(value) or is_atom(value), do: to_string(value)
   defp var_string(value), do: inspect(value)
 
-  defp masked_url(nil), do: ""
-
-  defp masked_url(url) when is_binary(url) do
-    case String.split(url, "/", trim: true) do
-      parts when length(parts) >= 2 ->
-        [token, id | _] = Enum.reverse(parts)
-        ".../#{id}/#{String.slice(token, 0, 4)}••••"
-
-      _ ->
-        "••••"
+  # D6's webhook identity, replacing the old `masked_url/1` (which rendered the
+  # channel snowflake in full and the first four characters of the token).
+  # `ChannelInfo.describe/1` answers from cache, then the label persisted on the
+  # row, then a masked hint — never blocking and never doing I/O on this render
+  # path, which matters because the tab re-renders on every typeahead keystroke.
+  # Whichever tier answers, the string is safe to show: a resolved label is the
+  # channel's own "#name", and the fallback is a truncated non-reversible digest
+  # that is never derived from the token.
+  defp channel_hint(webhook) do
+    case ChannelInfo.describe(webhook) do
+      {:ok, %{label: label}} -> label
+      {:error, _reason} -> nil
     end
   end
 
-  defp masked_url(_), do: "••••"
+  # Roles whose destination resolves to the same Discord channel as `role`.
+  # `ChannelInfo.colliding_roles/1` groups on the resolved `channel_id` where it
+  # has one, so this catches two DISTINCT webhook URLs pointing at the same
+  # channel — not merely the same URL pasted twice.
+  defp collision_partners(collisions, role) do
+    collisions
+    |> Enum.find([], &(role in &1))
+    |> List.delete(role)
+  end
+
+  # The route wording is deliberately not the generic one. A route alert names
+  # every system between the home system and Jita, and the channel's own help
+  # text asks the map owner to treat it as trusted — so a route channel shared
+  # with the kill feed is a disclosure, not just untidy configuration.
+  defp collision_text(:route, partners),
+    do:
+      "Route alerts post to the same Discord channel as #{role_names(partners)}. " <>
+        "Anyone who can read that channel can see this map's home system and the " <>
+        "route to it."
+
+  defp collision_text(_role, partners),
+    do: "This channel is also used by #{role_names(partners)} on this map."
+
+  defp role_names(partners), do: partners |> Enum.map(&role_name/1) |> to_sentence()
+
+  defp role_name(:system), do: "the system channel"
+  defp role_name(:character), do: "the character channel"
+  defp role_name(:route), do: "route alerts"
+
+  defp to_sentence([one]), do: one
+
+  defp to_sentence(names) do
+    {rest, [last]} = Enum.split(names, -1)
+    "#{Enum.join(rest, ", ")} and #{last}"
+  end
+
+  # --- Status (P1 hierarchy) -----------------------------------------------
+
+  defp status_state(nil), do: :never
+  defp status_state(%{enabled?: false}), do: :disabled
+
+  defp status_state(%{last_error: error, consecutive_failures: n})
+       when not is_nil(error) and n > 0,
+       do: :degraded
+
+  defp status_state(%{last_delivery_at: nil}), do: :never
+  defp status_state(_webhook), do: :delivering
+
+  defp status_label(:delivering), do: "Delivering"
+  defp status_label(:degraded), do: "Degraded"
+  defp status_label(:disabled), do: "Disabled"
+  defp status_label(:never), do: "Never delivered"
+
+  defp status_class(:delivering), do: "text-emerald-400"
+  defp status_class(:degraded), do: "text-amber-400"
+  defp status_class(:disabled), do: "text-red-400"
+  defp status_class(:never), do: "opacity-70"
+
+  defp status_line(nil), do: nil
+
+  defp status_line(webhook),
+    do: "Posting to channel #{channel_hint(webhook)} · #{last_kill_text(webhook)}"
+
+  defp last_kill_text(%{last_delivery_at: nil}), do: "no kills yet"
+
+  defp last_kill_text(%{last_delivery_at: dt}),
+    do: "last kill #{Calendar.strftime(dt, "%Y-%m-%d %H:%M UTC")}"
+
+  # --- Route-alerts P0: the reachable inert warning (D4) -------------------
+
+  # Alerts ON, no usable channel — the guard that already existed, now
+  # reachable at any time rather than only while a client-toggled `hidden`
+  # class happened to be off.
+  #
+  # `toggle?` is the UNSAVED checkbox state, and it is ORed with the persisted
+  # flag on purpose: ticking the box is exactly the moment the map owner needs
+  # to be told there is no channel to send to, and making them press Save
+  # first to learn it is the delayed-feedback version of the same bug.
+  defp route_alert_on_no_channel?(notification, route_webhook, toggle?) do
+    (toggle? or match?(%{route_alerts_enabled?: true}, notification)) and
+      not route_destination_ready?(route_webhook)
+  end
+
+  # Alerts OFF, channel fully configured — the P0 this rework exists for: a
+  # reachable channel with nothing telling the map owner it is not being used.
+  defp route_inert?(%{route_alerts_enabled?: false}, route_webhook),
+    do: route_destination_ready?(route_webhook)
+
+  defp route_inert?(_notification, _route_webhook), do: false
+
+  # --- Disclosure badges (D5) — computed server-side so a client-only toggle
+  # cannot defeat what the badge reports. ------------------------------------
+
+  defp filters_badge(excluded_systems, focus_corps) do
+    [
+      excluded_count_label(length(excluded_systems)),
+      focus_corp_count_label(length(focus_corps))
+    ]
+    |> Enum.filter(& &1)
+    |> case do
+      [] -> nil
+      parts -> Enum.join(parts, " · ")
+    end
+  end
+
+  defp excluded_count_label(0), do: nil
+  defp excluded_count_label(1), do: "1 system excluded"
+  defp excluded_count_label(n), do: "#{n} systems excluded"
+
+  defp focus_corp_count_label(0), do: nil
+  defp focus_corp_count_label(1), do: "1 corporation"
+  defp focus_corp_count_label(n), do: "#{n} corporations"
+
+  # Never collapse a problem: auto-expand when there is anything to fix or
+  # already configured, collapse only when the section is genuinely empty and
+  # untouched.
+  # "Never collapse a problem" (D5). The message scope is part of that: a
+  # save result rendered inside a collapsed body is exactly the silent-flash
+  # failure this rework exists to remove, so anything addressed to this panel
+  # forces it open.
+  defp filters_expanded?(
+         excluded_systems,
+         focus_corps,
+         character_webhook,
+         sys_err,
+         corp_err,
+         message,
+         collisions
+       ) do
+    excluded_systems != [] or
+      focus_corps != [] or
+      not is_nil(character_webhook) or
+      not is_nil(sys_err) or
+      not is_nil(corp_err) or
+      collision_partners(collisions, :character) != [] or
+      match?(%{scope: :filters}, message)
+  end
+
+  defp route_badge(nil, _route_webhook), do: "Off"
+
+  defp route_badge(%{route_alerts_enabled?: true}, route_webhook) do
+    if route_destination_ready?(route_webhook), do: "On", else: "On — no channel ready"
+  end
+
+  defp route_badge(%{route_alerts_enabled?: false}, route_webhook) do
+    if route_destination_ready?(route_webhook), do: "Off — channel configured", else: "Off"
+  end
+
+  defp route_expanded?(nil, _route_webhook, _collisions), do: false
+
+  defp route_expanded?(%{route_alerts_enabled?: enabled?}, route_webhook, collisions) do
+    problem? =
+      (enabled? and not route_destination_ready?(route_webhook)) or
+        (not enabled? and route_destination_ready?(route_webhook)) or
+        collision_partners(collisions, :route) != []
+
+    # `and`, not `&&`: this feeds `expanded?`, a `:boolean` attr that is used
+    # as `not @expanded?` in the disclosure body's class list. `&&` would
+    # return the nil webhook itself when there is no route destination, and
+    # `not nil` is an ArgumentError at render time rather than a falsy value.
+    problem? or (not is_nil(route_webhook) and not is_nil(route_webhook.last_error))
+  end
+
+  # --- Function components ---------------------------------------------
+
+  # D5's disclosure mechanism: client-side only (`JS.toggle_class`), following
+  # the one existing precedent in the app
+  # (characters_live.html.heex:92) rather than inventing a parallel pattern or
+  # round-tripping open/closed state through the server. The SERVER decides
+  # the initial `hidden`/caret class via `@expanded?` — computed by the
+  # `*_expanded?/*` helpers above from persisted state, so a section holding a
+  # problem always starts open no matter what a previous client toggle did.
+  attr :id, :string, required: true
+  attr :title, :string, required: true
+  attr :badge, :string, default: nil
+  attr :expanded?, :boolean, default: false
+  slot :inner_block, required: true
+
+  defp disclosure(assigns) do
+    ~H"""
+    <div class="rounded border border-white/10">
+      <button
+        type="button"
+        class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left"
+        phx-click={
+          JS.toggle_class("hidden", to: "##{@id}-body")
+          |> JS.toggle_class("rotate-90", to: "##{@id}-caret")
+        }
+      >
+        <span class="flex items-center gap-2 text-sm font-semibold">
+          <span
+            id={"#{@id}-caret"}
+            class={["inline-block transition-transform", @expanded? && "rotate-90"]}
+          >
+            ▸
+          </span>
+          {@title}
+        </span>
+        <span :if={@badge} class="text-xs opacity-70">{@badge}</span>
+      </button>
+
+      <div
+        id={"#{@id}-body"}
+        class={["flex flex-col gap-3 border-t border-white/10 p-3", not @expanded? && "hidden"]}
+      >
+        {render_slot(@inner_block)}
+      </div>
+    </div>
+    """
+  end
+
+  # D2's per-panel flash: one `@message` assign shaped
+  # `%{scope:, kind:, text:}`, rendered once per panel via `scope`. Only the
+  # panel that matches `@message.scope` ever shows anything, so a save on one
+  # channel cannot be mistaken for a save on another.
+  attr :message, :any, default: nil
+  attr :scope, :atom, required: true
+
+  defp panel_message(assigns) do
+    ~H"""
+    <p :if={@message && @message.scope == @scope} class={message_class(@message.kind)}>
+      {@message.text}
+    </p>
+    """
+  end
+
+  defp message_class(:error), do: "text-sm text-red-400"
+  defp message_class(:info), do: "text-sm text-green-400"
+
+  # Unifies excluded-systems and focus-corporation removal onto one visual
+  # treatment (Minors: chips) — both used to render the same semantics two
+  # different ways (a bare `<ul><li>` versus a rounded chip) sitting one
+  # panel apart. `:rest` picks up `phx-click`/`phx-value-*`/`phx-target`
+  # unchanged (they're all `phx-`-prefixed, in the global attribute set by
+  # default), so each call site is just the label plus its own removal event.
+  attr :label, :string, required: true
+  attr :rest, :global
+
+  defp chip(assigns) do
+    ~H"""
+    <li class="flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-sm">
+      <span>{@label}</span>
+      <.button type="button" variant={:ghost} {@rest}>Remove</.button>
+    </li>
+    """
+  end
+
+  attr :role, :atom, required: true
+  attr :collisions, :list, required: true
+
+  defp collision_warning(assigns) do
+    assigns = assign(assigns, :partners, collision_partners(assigns.collisions, assigns.role))
+
+    ~H"""
+    <p :if={@partners != []} id={"collision-#{@role}"} class="text-sm text-amber-400">
+      {collision_text(@role, @partners)}
+    </p>
+    """
+  end
 
   attr :role, :atom, required: true
   attr :title, :string, required: true
@@ -959,6 +1438,13 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   attr :replacing?, :boolean, required: true
   attr :removable?, :boolean, required: true
   attr :show_mentions?, :boolean, default: false
+  # The system row's own delivery status is promoted to the card level (P1
+  # hierarchy) — the status line and failure line live just above this
+  # component in L1, so repeating them here would be the exact "identical to
+  # the help text above it" problem being fixed. Character/route rows have no
+  # card-level equivalent and keep their own status block.
+  attr :show_status?, :boolean, default: true
+  attr :mention_error, :string, default: nil
   attr :myself, :any, required: true
 
   defp webhook_row(assigns) do
@@ -986,32 +1472,54 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         />
 
         <div :if={!@replacing? && @webhook} class="flex items-center gap-2">
-          <span class="text-sm opacity-70">URL: {masked_url(@webhook.webhook_url)}</span>
-          <.button type="button" phx-click="replace-url" phx-value-role={@role} phx-target={@myself}>
-            Replace
+          <span class="text-sm opacity-70">Channel: {channel_hint(@webhook)}</span>
+          <.button
+            type="button"
+            variant={:ghost}
+            phx-click="replace-url"
+            phx-value-role={@role}
+            phx-target={@myself}
+          >
+            Edit
           </.button>
         </div>
 
+        <.button
+          :if={@replacing? && @webhook}
+          type="button"
+          variant={:ghost}
+          class="self-start"
+          phx-click="cancel-replace"
+          phx-value-role={@role}
+          phx-target={@myself}
+        >
+          Cancel
+        </.button>
+
         <.input :if={@webhook} field={wf[:enabled]} type="checkbox" label="Enabled" />
 
-        <div class={if @show_mentions?, do: "flex flex-col gap-1", else: "hidden"}>
+        <div class={["flex-col gap-1", if(@show_mentions?, do: "flex", else: "hidden")]}>
           <.input
             field={wf[:mention_targets]}
             type="text"
             label="Mentions (optional)"
             placeholder="role:123456789012345678, user:234567890123456789"
+            phx-change="validate-mentions"
+            phx-value-role={@role}
+            phx-target={@myself}
           />
+          <p :if={@mention_error} class="text-sm text-red-400">{@mention_error}</p>
           <p class="text-xs opacity-70">
             Comma-separated <code>user:&lt;id&gt;</code>
             or <code>role:&lt;id&gt;</code>
-            Discord snowflakes to ping when a route
-            opens. Handles like <code>@name</code>
-            do not work — Discord
-            requires the numeric id. Leave empty to post with no ping.
+            Discord snowflakes to ping when a route opens. Handles like <code>@name</code>
+            do not work; Discord requires the numeric id. Leave empty to post with no ping.
           </p>
         </div>
 
-        <.button type="submit" class="self-start">{if @webhook, do: "Save", else: "Add"}</.button>
+        <.button type="submit" variant={:primary} class="self-start">
+          {if @webhook, do: "Save", else: "Add"}
+        </.button>
       </.form>
 
       <div :if={@webhook} class="flex items-center gap-2">
@@ -1026,7 +1534,8 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         <.button
           :if={@removable?}
           type="button"
-          class="p-button-danger self-start"
+          variant={:danger}
+          class="self-start"
           phx-click="remove-webhook"
           phx-value-role={@role}
           phx-target={@myself}
@@ -1036,7 +1545,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         </.button>
       </div>
 
-      <div :if={@webhook} class="flex flex-col gap-1 text-sm">
+      <div :if={@webhook && @show_status?} class="flex flex-col gap-1 text-sm">
         <span :if={@webhook.last_delivery_at} class="opacity-70">
           Last delivered: {Calendar.strftime(@webhook.last_delivery_at, "%Y-%m-%d %H:%M UTC")}
         </span>
@@ -1058,6 +1567,40 @@ defmodule WandererAppWeb.MapNotificationsComponent do
     """
   end
 
+  attr :notification, :any, required: true
+  attr :webhooks, :any, required: true
+  attr :route_toggle, :boolean, required: true
+  attr :myself, :any, required: true
+
+  # D4's reachable warning, rendered at card level OUTSIDE either disclosure so
+  # a configured-but-inert route destination is visible without opening
+  # anything. Both halves of the "disable, don't hide" fix live here: the
+  # alerts-on-but-no-channel case is the pre-existing guard made reachable at
+  # all times, and the alerts-off-but-configured case is the P0 this rework
+  # was written for.
+  defp route_alert_banner(assigns) do
+    ~H"""
+    <p
+      :if={route_alert_on_no_channel?(@notification, @webhooks[:route], @route_toggle)}
+      class="text-sm text-amber-400"
+    >
+      Route alerts are on, but no Route alert channel is ready — nothing is being sent.
+    </p>
+
+    <div
+      :if={route_inert?(@notification, @webhooks[:route])}
+      class="flex items-center gap-2 text-sm text-amber-400"
+    >
+      <span>
+        Route alerts are switched off, but this channel is configured — nothing is being sent to it.
+      </span>
+      <.button type="button" phx-click="enable-route-alerts" phx-target={@myself}>
+        Enable route alerts
+      </.button>
+    </div>
+    """
+  end
+
   @impl true
   def render(assigns) do
     ~H"""
@@ -1067,248 +1610,379 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         own filters, which are per-user and only affect what you see in the map UI.
       </p>
 
-      <p :if={@error} class="text-sm text-red-400">{@error}</p>
-      <p :if={@flash_message} class="text-sm text-green-400">{@flash_message}</p>
+      <div :if={is_nil(@notification)} class="flex flex-col gap-3 rounded border border-white/10 p-3">
+        <h3 class="text-base font-semibold">Kill notifications</h3>
 
-      <.form
-        :let={f}
-        for={@form}
-        id="discord-notification-form"
-        phx-submit="save"
-        phx-change="notification-changed"
-        phx-target={@myself}
-        class="flex flex-col gap-3 rounded border border-white/10 p-3"
-      >
-        <.input
-          :if={is_nil(@notification)}
-          field={f[:webhook_url]}
-          type="password"
-          label="Discord webhook URL (system channel)"
-          placeholder="https://discord.com/api/webhooks/..."
-          autocomplete="off"
-        />
+        <.panel_message message={@message} scope={:kills} />
 
-        <.input field={f[:wh_only]} type="checkbox" label="Only wormhole kills" />
-        <.input field={f[:enabled]} type="checkbox" label="Enabled for this map" />
-
-        <.input
-          field={f[:route_alerts_enabled]}
-          type="checkbox"
-          label="Route alerts (highsec route to Jita)"
-          phx-change="toggle-route-alerts"
+        <.form
+          :let={f}
+          for={@form}
+          id="discord-notification-form"
+          phx-submit="save"
           phx-target={@myself}
-        />
-
-        <div class={if @route_toggle, do: "flex flex-col gap-2", else: "hidden"}>
-          <div class="flex flex-col gap-1">
-            <span class="text-sm">Home system</span>
-            <.live_select
-              field={f[:home_system_id]}
-              id={@home_system_select_id}
-              phx-target={@myself}
-              dropdown_extra_class="!h-24"
-              compact={true}
-              debounce={250}
-              update_min_len={@min_search_length}
-              mode={:single}
-              options={@home_system_options}
-              placeholder="Search a system by name, e.g. Jita"
-            />
-            <p :if={@home_system_error} class="text-sm text-red-400">{@home_system_error}</p>
-            <p :if={@home_system_search_error} class="text-sm text-amber-400">
-              {@home_system_search_error}
-            </p>
-          </div>
+          class="flex flex-col gap-3"
+        >
           <.input
-            field={f[:route_max_jumps]}
-            type="number"
-            min="1"
-            max="20"
-            label="Max jumps to Jita (inclusive)"
+            field={f[:webhook_url]}
+            type="password"
+            label="Discord webhook URL"
+            placeholder="https://discord.com/api/webhooks/..."
+            autocomplete="off"
           />
-          <p class="text-xs opacity-70">
-            Posts when a highsec-only route this length or shorter opens from
-            the home system to Jita. Wormhole hops on the way don't count
-            against "highsec" — only k-space systems on the path do. Pick the
-            home system by name from the search results.
-          </p>
-          <p
-            :if={@notification && not route_destination_ready?(@webhooks[:route])}
-            class="text-xs text-amber-400"
-          >
-            Route alerts need an enabled Route alert channel below — they are
-            not sent to any other channel.
-          </p>
+
+          <.button type="submit" variant={:primary} class="self-start">Connect</.button>
+        </.form>
+      </div>
+
+      <div :if={@notification} class="flex flex-col gap-3 rounded border border-white/10 p-3">
+        <div class="flex items-center justify-between gap-2">
+          <h3 class="text-base font-semibold">Kill notifications</h3>
+          <span class={["text-xs font-semibold", status_class(status_state(@webhooks[:system]))]}>
+            ● {status_label(status_state(@webhooks[:system]))}
+          </span>
         </div>
 
-        <.button type="submit" class="self-start">Save</.button>
-      </.form>
+        <p class="text-sm opacity-70">{status_line(@webhooks[:system])}</p>
+        <p :if={@webhooks[:system] && @webhooks[:system].last_error} class="text-sm text-amber-400">
+          Last error: {@webhooks[:system].last_error}
+          <span :if={@webhooks[:system].consecutive_failures > 0}>
+            ({@webhooks[:system].consecutive_failures} consecutive failures)
+          </span>
+        </p>
+        <.collision_warning role={:system} collisions={@collisions} />
 
-      <.webhook_row
-        :if={@notification}
-        role={:system}
-        title="System channel"
-        help="Receives kills that happen in systems on this map."
-        webhook={@webhooks[:system]}
-        form={@webhook_forms[:system]}
-        replacing?={@replacing_url?[:system]}
-        removable?={false}
-        myself={@myself}
-      />
+        <.webhook_row
+          role={:system}
+          title="System channel"
+          help="Receives kills that happen in systems on this map."
+          webhook={@webhooks[:system]}
+          form={@webhook_forms[:system]}
+          replacing?={@replacing_url?[:system]}
+          removable?={false}
+          show_status?={false}
+          myself={@myself}
+        />
 
-      <.webhook_row
-        :if={@notification}
-        role={:character}
-        title="Character channel (optional)"
-        help={
-          "Receives kills involving characters tracked on this map, wherever they happen. " <>
-            "Leave it unset and those kills go to the system channel instead."
-        }
-        webhook={@webhooks[:character]}
-        form={@webhook_forms[:character]}
-        replacing?={@replacing_url?[:character]}
-        removable?={true}
-        myself={@myself}
-      />
+        <.panel_message message={@message} scope={:kills} />
 
-      <.webhook_row
-        :if={@notification}
-        role={:route}
-        title="Route alert channel (optional)"
-        help={
-          "Receives an alert when a highsec-only route opens from the home system to Jita. " <>
-            "This message names every system on the route in order — treat this channel as " <>
-            "trusted, there is no redacted version of it. Route alerts are sent here and " <>
-            "nowhere else: leave it unset and no route alerts are sent at all."
-        }
-        webhook={@webhooks[:route]}
-        form={@webhook_forms[:route]}
-        replacing?={@replacing_url?[:route]}
-        removable?={true}
-        show_mentions?={true}
-        myself={@myself}
-      />
-
-      <div :if={@notification} class="flex flex-col gap-2 rounded border border-white/10 p-3">
-        <h4 class="text-sm font-semibold">Excluded systems</h4>
-
-        <ul class="flex flex-col gap-1">
-          <li :for={{system_id, label} <- @excluded_systems} class="flex items-center gap-2 text-sm">
-            <span>{label}</span>
-            <.button
-              type="button"
-              phx-click="remove-excluded"
-              phx-value-system_id={system_id}
-              phx-target={@myself}
-            >
-              Remove
-            </.button>
-          </li>
-        </ul>
-
-        <%!-- Height matching, without predicting either box: `compact` makes the
-              field wrapper exactly as tall as its input, `!py-0` drops the
-              button's vertical padding so its intrinsic height (one line of
-              text) is always shorter than the input's, and the grid row is
-              therefore sized by the field. `items-stretch` then gives the
-              button that exact height. Nothing here depends on the button and
-              the input agreeing on font size, padding or line-height, which
-              they do not. --%>
         <.form
-          :let={ef}
-          for={@excluded_form}
-          id="excluded-system-form"
-          phx-submit="add-excluded"
+          :let={f}
+          for={@form}
+          id="discord-notification-form"
+          phx-submit="save"
+          phx-change="kills-form-change"
           phx-target={@myself}
-          class="grid items-stretch gap-2"
-          style="grid-template-columns: minmax(0, 24rem) max-content"
+          class="flex flex-col gap-2"
         >
-          <.live_select
-            field={ef[:excluded_system]}
-            id={@excluded_select_id}
-            phx-target={@myself}
-            dropdown_extra_class="!h-24"
-            compact={true}
-            debounce={250}
-            update_min_len={@min_search_length}
-            mode={:single}
-            options={@system_options}
-            placeholder="Search a system by name"
-          />
-          <.button type="submit" class="!py-0 inline-flex items-center justify-center">Add</.button>
+          <%!-- The record-level master switch. It is deliberately still here
+                at L1 and not folded into the per-destination `enabled?` on the
+                webhook rows: this one stops kill notifications for the whole
+                map in one tick, and without it the only way to stop delivery
+                would be "Remove all Discord notifications", which also throws
+                away every filter and channel the user has configured. --%>
+          <.input field={f[:enabled]} type="checkbox" label="Send kill notifications" />
+          <.input field={f[:wh_only]} type="checkbox" label="Only wormhole kills" />
+
+          <.button type="submit" variant={:primary} class="self-start" disabled={not @dirty.kills}>
+            Save
+          </.button>
         </.form>
 
-        <p :if={@system_search_error} class="text-sm text-amber-400">{@system_search_error}</p>
-      </div>
+        <.route_alert_banner
+          notification={@notification}
+          webhooks={@webhooks}
+          route_toggle={@route_toggle}
+          myself={@myself}
+        />
 
-      <div :if={@notification} class="flex flex-col gap-2 rounded border border-white/10 p-3">
-        <h4 class="text-sm font-semibold">Corporation filter</h4>
-        <p class="text-xs opacity-70">
-          When set, only kills involving these corporations go to the character
-          channel, instead of your map-tracked characters. Everything else follows
-          the normal system rules. Leave empty to use map-tracked characters.
-          These kills ignore the excluded-system and wormhole-only filters.
-        </p>
+        <.disclosure
+          id="filters-disclosure"
+          title="Filters and routing"
+          badge={filters_badge(@excluded_systems, @focus_corps)}
+          expanded?={
+            filters_expanded?(
+              @excluded_systems,
+              @focus_corps,
+              @webhooks[:character],
+              @system_search_error,
+              @corp_search_error,
+              @message,
+              @collisions
+            )
+          }
+        >
+          <div class="flex flex-col gap-2">
+            <.panel_message message={@message} scope={:filters} />
 
-        <ul class="flex flex-wrap gap-2">
-          <li
-            :for={{corp_id, label} <- @focus_corps}
-            class="flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-sm"
+            <h4 class="text-sm font-semibold">Excluded systems</h4>
+
+            <ul class="flex flex-wrap gap-2">
+              <li :for={{system_id, label} <- @excluded_systems}>
+                <.chip
+                  label={label}
+                  phx-click="remove-excluded"
+                  phx-value-system_id={system_id}
+                  phx-target={@myself}
+                />
+              </li>
+            </ul>
+
+            <%!-- Height matching, without predicting either box: `compact` makes the
+                  field wrapper exactly as tall as its input, `!py-0` drops the
+                  button's vertical padding so its intrinsic height (one line of
+                  text) is always shorter than the input's, and the grid row is
+                  therefore sized by the field. `items-stretch` then gives the
+                  button that exact height. Nothing here depends on the button and
+                  the input agreeing on font size, padding or line-height, which
+                  they do not. --%>
+            <.form
+              :let={ef}
+              for={@excluded_form}
+              id="excluded-system-form"
+              phx-submit="add-excluded"
+              phx-target={@myself}
+              class="grid items-stretch gap-2"
+              style="grid-template-columns: 1fr auto"
+            >
+              <.live_select
+                field={ef[:excluded_system]}
+                id={@excluded_select_id}
+                phx-target={@myself}
+                dropdown_extra_class="!h-24"
+                compact={true}
+                debounce={250}
+                update_min_len={@min_search_length}
+                mode={:single}
+                options={@system_options}
+                placeholder="Search a system by name"
+              />
+              <.button type="submit" class="!py-0 inline-flex items-center justify-center">
+                Add
+              </.button>
+            </.form>
+
+            <p :if={@system_search_error} class="text-sm text-amber-400">{@system_search_error}</p>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <h4 class="text-sm font-semibold">Corporation filter</h4>
+            <p class="text-xs opacity-70">
+              When set, only kills involving these corporations go to the character
+              channel, instead of your map-tracked characters. Everything else follows
+              the normal system rules. Leave empty to use map-tracked characters.
+              These kills ignore the excluded-system and wormhole-only filters.
+            </p>
+
+            <ul class="flex flex-wrap gap-2">
+              <li :for={{corp_id, label} <- @focus_corps}>
+                <.chip
+                  label={label}
+                  phx-click="remove-focus-corp"
+                  phx-value-corp_id={corp_id}
+                  phx-target={@myself}
+                />
+              </li>
+            </ul>
+
+            <p :if={@current_user.characters in [nil, []]} class="text-sm text-amber-400">
+              Add a character to this account to search corporations.
+            </p>
+
+            <.form
+              :let={cf}
+              :if={@current_user.characters not in [nil, []]}
+              for={@focus_corp_form}
+              id="focus-corp-form"
+              phx-submit="add-focus-corp"
+              phx-target={@myself}
+              class="grid items-stretch gap-2"
+              style="grid-template-columns: 1fr auto"
+            >
+              <.live_select
+                field={cf[:focus_corp]}
+                id={@focus_corp_select_id}
+                phx-target={@myself}
+                dropdown_extra_class="!h-24"
+                compact={true}
+                debounce={250}
+                update_min_len={@corp_min_search_length}
+                mode={:single}
+                options={@corp_options}
+                placeholder="Search a corporation by name"
+              />
+              <.button type="submit" class="!py-0 inline-flex items-center justify-center">
+                Add
+              </.button>
+            </.form>
+
+            <p :if={@corp_search_error} class="text-sm text-amber-400">{@corp_search_error}</p>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <%!-- Nested toggle: collapsed to a single link when no character
+                  channel exists (the common case, per the shared brief — the
+                  minimum viable config is one pasted URL), auto-expanded the
+                  moment one does. CSS-only, same JS.toggle_class mechanism as
+                  the outer disclosures, so the row stays in the DOM either way
+                  and `#webhook-form-character` keeps existing for tests. --%>
+            <button
+              type="button"
+              id="character-channel-toggle"
+              class={[
+                "text-left text-sm underline opacity-80 hover:opacity-100",
+                @webhooks[:character] && "hidden"
+              ]}
+              phx-click={
+                JS.toggle_class("hidden", to: "#character-channel-toggle")
+                |> JS.toggle_class("hidden", to: "#character-channel-body")
+              }
+            >
+              + Add a separate channel
+            </button>
+
+            <div
+              id="character-channel-body"
+              class={["flex flex-col gap-2", is_nil(@webhooks[:character]) && "hidden"]}
+            >
+              <.webhook_row
+                role={:character}
+                title="Character channel"
+                help={
+                  "Receives kills involving characters tracked on this map, wherever they happen. " <>
+                    "Leave it unset and those kills go to the system channel instead."
+                }
+                webhook={@webhooks[:character]}
+                form={@webhook_forms[:character]}
+                replacing?={@replacing_url?[:character]}
+                removable?={true}
+                mention_error={@mention_errors[:character]}
+                myself={@myself}
+              />
+
+              <.collision_warning role={:character} collisions={@collisions} />
+            </div>
+          </div>
+        </.disclosure>
+
+        <.disclosure
+          id="route-disclosure"
+          title="Route alerts"
+          badge={route_badge(@notification, @webhooks[:route])}
+          expanded?={route_expanded?(@notification, @webhooks[:route], @collisions)}
+        >
+          <.panel_message message={@message} scope={:route} />
+
+          <.form
+            :let={rf}
+            for={@route_form}
+            id="route-alerts-form"
+            phx-submit="save-route"
+            phx-change="route-form-change"
+            phx-target={@myself}
+            class="flex flex-col gap-2"
           >
-            <span>{label}</span>
-            <.button
-              type="button"
-              phx-click="remove-focus-corp"
-              phx-value-corp_id={corp_id}
+            <%!-- The same `phx-change` as the enclosing form, declared on the
+                  checkbox itself as well. An input-level `phx-change` still
+                  serialises the whole form, so the handler receives exactly
+                  the same params either way — but it makes the toggle
+                  independently addressable, which is how both the tests and
+                  the #130 regression drive it. --%>
+            <.input
+              field={rf[:route_alerts_enabled]}
+              type="checkbox"
+              label="Route alerts (highsec route to Jita)"
+              phx-change="route-form-change"
               phx-target={@myself}
-            >
-              Remove
+            />
+
+            <%!-- Disabled rather than hidden (upstream checklist §5), and disabled
+                  through a <fieldset> rather than per-input for two reasons. It
+                  natively disables every descendant control including
+                  LiveSelect's own text and hidden inputs — `live_select/1`
+                  declares no `disabled` attr, and adding one belongs to
+                  core_components' owner, not this file. And it is a real
+                  disable: keyboard and AT see it, unlike a pointer-events or
+                  opacity trick.
+
+                  Nothing here submits while disabled, which is safe only
+                  because `notification_attrs/1` treats an absent key as "leave
+                  this field alone" — otherwise pressing Save with alerts off
+                  would clear a saved home system. --%>
+            <fieldset disabled={not @route_toggle} class="flex flex-col gap-2 border-0 p-0">
+              <div class="flex flex-col gap-1">
+                <span class="text-sm">Home system</span>
+                <.live_select
+                  field={rf[:home_system_id]}
+                  id={@home_system_select_id}
+                  phx-target={@myself}
+                  dropdown_extra_class="!h-24"
+                  compact={true}
+                  debounce={250}
+                  update_min_len={@min_search_length}
+                  mode={:single}
+                  options={@home_system_options}
+                  placeholder="Search a system by name, or enter its solar system ID"
+                />
+                <p :if={@home_system_error} class="text-sm text-red-400">{@home_system_error}</p>
+                <p :if={@home_system_search_error} class="text-sm text-amber-400">
+                  {@home_system_search_error}
+                </p>
+              </div>
+
+              <.input
+                field={rf[:route_max_jumps]}
+                type="number"
+                min={@min_route_max_jumps}
+                max={@max_route_max_jumps}
+                label="Max jumps to Jita (inclusive)"
+              />
+            </fieldset>
+
+            <p class="text-xs opacity-70">
+              Posts when a highsec-only route this length or shorter opens from the home
+              system to Jita. Wormhole hops on the way don't count against "highsec" —
+              only k-space systems on the path do.
+            </p>
+
+            <.button type="submit" variant={:primary} class="self-start" disabled={not @dirty.route}>
+              Save
             </.button>
-          </li>
-        </ul>
+          </.form>
 
-        <p :if={@current_user.characters in [nil, []]} class="text-sm text-amber-400">
-          Add a character to this account to search corporations.
-        </p>
-
-        <.form
-          :let={cf}
-          :if={@current_user.characters not in [nil, []]}
-          for={@focus_corp_form}
-          id="focus-corp-form"
-          phx-submit="add-focus-corp"
-          phx-target={@myself}
-          class="grid items-stretch gap-2"
-          style="grid-template-columns: minmax(0, 24rem) max-content"
-        >
-          <.live_select
-            field={cf[:focus_corp]}
-            id={@focus_corp_select_id}
-            phx-target={@myself}
-            dropdown_extra_class="!h-24"
-            compact={true}
-            debounce={250}
-            update_min_len={@corp_min_search_length}
-            mode={:single}
-            options={@corp_options}
-            placeholder="Search a corporation by name"
+          <.webhook_row
+            role={:route}
+            title="Route alert channel"
+            help={
+              "Receives an alert when a highsec-only route opens from the home system to Jita. " <>
+                "This message names every system on the route in order. Treat this channel as " <>
+                "trusted; there is no redacted version of it. Route alerts are sent here and " <>
+                "nowhere else — leave it unset and no route alerts are sent at all."
+            }
+            webhook={@webhooks[:route]}
+            form={@webhook_forms[:route]}
+            replacing?={@replacing_url?[:route]}
+            removable?={true}
+            show_mentions?={true}
+            mention_error={@mention_errors[:route]}
+            myself={@myself}
           />
-          <.button type="submit" class="!py-0 inline-flex items-center justify-center">Add</.button>
-        </.form>
 
-        <p :if={@corp_search_error} class="text-sm text-amber-400">{@corp_search_error}</p>
-      </div>
+          <.collision_warning role={:route} collisions={@collisions} />
+        </.disclosure>
 
-      <div :if={@notification} class="flex items-center gap-2">
-        <.button
-          type="button"
-          class="p-button-danger self-start"
-          phx-click="delete"
-          phx-target={@myself}
-          data-confirm="Remove Discord notifications for this map?"
-        >
-          Remove all Discord notifications
-        </.button>
+        <div class="flex items-center gap-2">
+          <.button
+            type="button"
+            variant={:danger}
+            class="self-start"
+            phx-click="delete"
+            phx-target={@myself}
+            data-confirm="Remove Discord notifications for this map?"
+          >
+            Remove all Discord notifications
+          </.button>
+        </div>
       </div>
     </div>
     """

--- a/test/wanderer_app_web/live/map_notifications_test.exs
+++ b/test/wanderer_app_web/live/map_notifications_test.exs
@@ -107,22 +107,25 @@ defmodule WandererAppWeb.MapNotificationsTest do
   test "saving a valid webhook url creates the record", %{conn: conn, map: map} do
     view = open_notifications(conn, map)
 
+    # L0 is one URL field and one button — no checkboxes at all. The absent
+    # params are the point: `notification_attrs/1` omits a key it was not
+    # given rather than parsing `nil` into `false`, so the resource defaults
+    # apply.
     view
     |> form("#discord-notification-form", %{
-      "notification" => %{
-        "webhook_url" => "https://discord.com/api/webhooks/123/tok",
-        "wh_only" => "true",
-        "enabled" => "true"
-      }
+      "notification" => %{"webhook_url" => "https://discord.com/api/webhooks/123/tok"}
     })
     |> render_submit()
 
     assert {:ok, rec} = MapDiscordNotification.by_map(map.id)
     assert rec.wh_only == true
-    # Regression guard: the Enabled checkbox must render during creation too.
-    # When it was hidden behind `:if={@notification}` the param was absent, so
-    # `params["enabled"] == "true"` was false and every new config was born
-    # disabled — invisibly, because the UI showed no checkbox to contradict it.
+
+    # Regression guard, now guarding a different mechanism. Previously the
+    # Enabled checkbox was hidden behind `:if={@notification}`, so its param
+    # was absent, `params["enabled"] == "true"` was false, and every new
+    # config was born disabled — invisibly, because no checkbox contradicted
+    # it. The checkbox is deliberately absent at L0 again, so what keeps this
+    # true is `put_param/5` treating "key not submitted" as "leave it alone".
     assert rec.enabled? == true
 
     # The create action seeds the required `:system` destination in the same
@@ -849,6 +852,50 @@ defmodule WandererAppWeb.MapNotificationsTest do
     refute log =~ "bread_crumbs:"
   end
 
+  describe "channel collisions" do
+    test "the route channel sharing a Discord channel with the kill feed is warned about", %{
+      conn: conn,
+      map: map
+    } do
+      rec = notification_with_webhooks(map, [:route])
+      {:ok, webhooks} = MapDiscordWebhook.by_notification(rec.id)
+
+      # Two DISTINCT webhook URLs resolved to the SAME channel — the case the
+      # old same-URL check could not see, and the one that actually leaks the
+      # home system into the kill feed's audience.
+      for wh <- webhooks do
+        {:ok, _} =
+          MapDiscordWebhook.cache_channel_info(wh, %{
+            channel_id: "987650001234500777",
+            channel_label: "#kills"
+          })
+      end
+
+      html = conn |> open_notifications(map) |> render()
+
+      assert html =~ "Route alerts post to the same Discord channel as the system channel."
+      assert html =~ "route to it"
+
+      # The generic counterpart on the kill-notification card, naming the other
+      # side rather than "another destination".
+      assert html =~ "This channel is also used by route alerts on this map."
+
+      # D6: the resolved label is what identifies a destination now. The
+      # snowflake itself is never rendered.
+      assert html =~ "#kills"
+      refute html =~ "987650001234500777"
+    end
+
+    test "distinct channels produce no warning", %{conn: conn, map: map} do
+      notification_with_webhooks(map, [:route])
+
+      html = conn |> open_notifications(map) |> render()
+
+      refute html =~ "also used by"
+      refute html =~ "Route alerts post to the same Discord channel"
+    end
+  end
+
   describe "route alerts" do
     test "enabling route alerts without a home system surfaces the Ash validation error", %{
       conn: conn,
@@ -857,18 +904,21 @@ defmodule WandererAppWeb.MapNotificationsTest do
       notification_with_webhooks(map, [:system])
       view = open_notifications(conn, map)
 
+      # Route settings now live on their own form with their own submit, so
+      # this no longer rides along with the kill-notification Save. Pushed at
+      # the component rather than through `form/3` because `home_system_id` is
+      # a LiveSelect hidden input, which LiveViewTest refuses to set (same
+      # reason as the excluded-systems and focus-corp tests above).
       html =
         view
-        |> form("#discord-notification-form", %{
+        |> with_target("#map-notifications")
+        |> render_submit("save-route", %{
           "notification" => %{
-            "enabled" => "true",
-            "wh_only" => "true",
             "route_alerts_enabled" => "true",
             "home_system_id" => "",
             "route_max_jumps" => "5"
           }
         })
-        |> render_submit()
 
       # Exact wording is Task 3's to define; this asserts on it because a
       # substring match loose enough to survive any wording would also survive
@@ -899,10 +949,8 @@ defmodule WandererAppWeb.MapNotificationsTest do
       # DOM — LiveSelect's hidden input, holding the id behind the name the
       # user picked — which is the whole point of the picker.
       view
-      |> form("#discord-notification-form", %{
+      |> form("#route-alerts-form", %{
         "notification" => %{
-          "enabled" => "true",
-          "wh_only" => "true",
           "route_alerts_enabled" => "true",
           "route_max_jumps" => "3"
         }
@@ -915,23 +963,77 @@ defmodule WandererAppWeb.MapNotificationsTest do
       assert rec.route_max_jumps == 3
     end
 
-    test "the route fields are hidden while the toggle is off, not removed from the form", %{
+    test "the route Save writes only route fields, and the kills Save only kill fields", %{
+      conn: conn,
+      map: map
+    } do
+      rec = notification_with_webhooks(map, [:system])
+
+      {:ok, _} =
+        MapDiscordNotification.update(rec, %{
+          wh_only: true,
+          route_alerts_enabled?: true,
+          home_system_id: 30_000_142,
+          route_max_jumps: 3
+        })
+
+      view = open_notifications(conn, map)
+
+      # P0 (four saves, one flash, no scope): pressing one panel's Save must
+      # not touch another panel's fields. Before the split, ticking a box in
+      # one section and pressing the wrong Save reported "Saved." and silently
+      # reverted the tick, because every Save submitted the whole tab.
+      view
+      |> form("#discord-notification-form", %{
+        "notification" => %{"enabled" => "true", "wh_only" => "false"}
+      })
+      |> render_submit()
+
+      assert {:ok, after_kills} = MapDiscordNotification.by_map(map.id)
+      assert after_kills.wh_only == false
+      # Untouched by the kills Save, not reset to their defaults.
+      assert after_kills.route_alerts_enabled? == true
+      assert after_kills.home_system_id == 30_000_142
+      assert after_kills.route_max_jumps == 3
+
+      view
+      |> with_target("#map-notifications")
+      |> render_submit("save-route", %{
+        "notification" => %{
+          "route_alerts_enabled" => "true",
+          "home_system_id" => "30000144",
+          "route_max_jumps" => "7"
+        }
+      })
+
+      assert {:ok, after_route} = MapDiscordNotification.by_map(map.id)
+      assert after_route.home_system_id == 30_000_144
+      assert after_route.route_max_jumps == 7
+      # And the route Save did not resurrect the wh_only default.
+      assert after_route.wh_only == false
+      assert after_route.enabled? == true
+    end
+
+    test "the route fields are disabled while the toggle is off, not hidden or removed", %{
       conn: conn,
       map: map
     } do
       notification_with_webhooks(map, [:system])
       view = open_notifications(conn, map)
 
-      # Off by default (route_alerts_enabled? defaults to false per Task 3) —
-      # the wrapper carries the "hidden" class, and the inputs are still
-      # present in the DOM so their values still post on save. Scoped to
-      # `#discord-notification-form` because the settings dialog itself also
-      # renders with a (JS-toggled, not LiveView-toggled) "hidden" class in
-      # the static test render — an unscoped `div.hidden` selector matches
-      # that outer wrapper too and would pass/fail for the wrong reason.
+      # Off by default (route_alerts_enabled? defaults to false per Task 3).
+      # These fields used to be wrapped in a `hidden` div, which is what made
+      # the "configured but switched off" warning unreachable: the one state
+      # that needed a warning rendered it inside the container that was
+      # hidden. They are now DISABLED instead (upstream checklist §5), via a
+      # <fieldset> so the disable reaches LiveSelect's own inputs too.
+      #
+      # Asserting on the fieldset rather than the input because that is where
+      # the attribute lives; `input[disabled]` would not match a descendant
+      # disabled by an ancestor fieldset.
       assert has_element?(
                view,
-               "#discord-notification-form div.hidden input[name='notification[home_system_id]']"
+               "#route-alerts-form fieldset[disabled] input[name='notification[home_system_id]']"
              )
 
       view
@@ -940,8 +1042,40 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
       refute has_element?(
                view,
-               "#discord-notification-form div.hidden input[name='notification[home_system_id]']"
+               "#route-alerts-form fieldset[disabled] input[name='notification[home_system_id]']"
              )
+
+      # Still in the DOM either way — never `:if`-ed out.
+      assert has_element?(view, "#route-alerts-form input[name='notification[home_system_id]']")
+    end
+
+    test "a disabled route field does not wipe the saved value on the next save", %{
+      conn: conn,
+      map: map
+    } do
+      rec = notification_with_webhooks(map, [:system])
+
+      {:ok, _} =
+        MapDiscordNotification.update(rec, %{
+          route_alerts_enabled?: true,
+          home_system_id: 30_000_142,
+          route_max_jumps: 3
+        })
+
+      view = open_notifications(conn, map)
+
+      # Turning the toggle off disables the fields below it, and a disabled
+      # input submits NOTHING — not even the hidden "false" companion. If
+      # `notification_attrs/1` read the key unconditionally it would parse the
+      # absent value as nil and clear a home system the user never touched.
+      view
+      |> with_target("#map-notifications")
+      |> render_submit("save-route", %{"notification" => %{"route_alerts_enabled" => "false"}})
+
+      assert {:ok, saved} = MapDiscordNotification.by_map(map.id)
+      assert saved.route_alerts_enabled? == false
+      assert saved.home_system_id == 30_000_142
+      assert saved.route_max_jumps == 3
     end
 
     # The two save tests above hand `render_submit` an explicit params map, so
@@ -1027,7 +1161,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
       # No params at all — the checkbox and the picked home system both come
       # from the rendered DOM, which is the whole point: this is what the
       # browser actually posts.
-      view |> form("#discord-notification-form") |> render_submit()
+      view |> form("#route-alerts-form") |> render_submit()
 
       assert {:ok, rec} = MapDiscordNotification.by_map(map.id)
       assert rec.route_alerts_enabled? == true
@@ -1065,7 +1199,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
       |> render_change("option_click", %{"idx" => "0"})
 
       view
-      |> form("#discord-notification-form", %{
+      |> form("#route-alerts-form", %{
         "notification" => %{"route_alerts_enabled" => "true"}
       })
       |> render_submit()
@@ -1102,7 +1236,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
       # says nothing about the name that was actually typed.
       html =
         view
-        |> form("#discord-notification-form", %{
+        |> form("#route-alerts-form", %{
           "notification" => %{
             "route_alerts_enabled" => "true",
             "home_system_id_text_input" => "Jitaaa"
@@ -1129,7 +1263,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
       |> render_change(%{"notification" => %{"route_alerts_enabled" => "true"}})
 
       view
-      |> form("#discord-notification-form", %{
+      |> form("#route-alerts-form", %{
         "notification" => %{
           "route_alerts_enabled" => "true",
           "home_system_id_text_input" => "jita"
@@ -1164,7 +1298,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
       html =
         view
-        |> form("#discord-notification-form", %{
+        |> form("#route-alerts-form", %{
           "notification" => %{
             "route_alerts_enabled" => "true",
             "home_system_id_text_input" => "Jit"
@@ -1199,7 +1333,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
       pick_home_system(view, "Jita")
 
       # What the browser does on selection: post the form as the DOM now has it.
-      view |> form("#discord-notification-form") |> render_change()
+      view |> form("#route-alerts-form") |> render_change()
 
       # An unrelated widget re-renders the component.
       view
@@ -1212,31 +1346,45 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
       assert has_element?(view, "input[name='notification[home_system_id]'][value='30000142']")
 
-      view |> form("#discord-notification-form") |> render_submit()
+      view |> form("#route-alerts-form") |> render_submit()
 
       assert {:ok, rec} = MapDiscordNotification.by_map(map.id)
       assert rec.home_system_id == 30_000_142
     end
 
-    test "toggling route alerts never renders a submitted webhook url", %{conn: conn, map: map} do
-      # No notification yet, so the create path renders the webhook URL field
-      # alongside the route toggle. The change event carries whatever is typed
-      # into it, and the generic `.input` writes `value=` for password inputs
-      # too — so a form rebuilt straight from those params would print a live
-      # credential into the HTML.
+    test "no form carrying a webhook url has a change handler that could echo it", %{
+      conn: conn,
+      map: map
+    } do
+      # #130's fix was to blank `webhook_url` before rebuilding the form on
+      # change, because the route toggle and the create-path URL field shared
+      # one form and the generic `.input` writes `value=` for password inputs
+      # too. The IA split removes the shared form entirely: the credential now
+      # lives only on the L0 create form and the per-row webhook forms, none of
+      # which carry a `phx-change`. This asserts the structural property rather
+      # than the old symptom, so it fails if a change handler is ever added
+      # back to a form holding a URL.
       view = open_notifications(conn, map)
+      html = render(view)
 
-      url = "https://discord.com/api/webhooks/1534657087244603394/supersecrettoken"
+      # The L0 create form is the one that holds the URL field...
+      assert has_element?(
+               view,
+               "#discord-notification-form input[name='notification[webhook_url]']"
+             )
 
-      html =
-        view
-        |> element("input[name='notification[route_alerts_enabled]'][type='checkbox']")
-        |> render_change(%{
-          "notification" => %{"route_alerts_enabled" => "true", "webhook_url" => url}
-        })
+      # ...and its form tag must carry no phx-change.
+      [create_form] = Regex.run(~r/<form[^>]*id="discord-notification-form"[^>]*>/, html)
+      refute create_form =~ "phx-change"
 
-      refute html =~ "supersecrettoken"
-      refute html =~ url
+      notification_with_webhooks(map, [:system, :character, :route])
+
+      html = render(open_notifications(conn, map))
+
+      for role <- ~w(system character route) do
+        [form_tag] = Regex.run(~r/<form[^>]*id="webhook-form-#{role}"[^>]*>/, html)
+        refute form_tag =~ "phx-change"
+      end
     end
 
     test "the route webhook url can be added", %{conn: conn, map: map} do
@@ -1300,7 +1448,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
     # form lets an owner enable route alerts, set a home system and max jumps,
     # and save successfully while every alert is silently dropped for want of a
     # destination. The hint is the only feedback in that state.
-    @hint "Route alerts need an enabled Route alert channel below"
+    @hint "Route alerts are on, but no Route alert channel is ready"
 
     test "enabling route alerts with no route channel warns that nothing will be sent", %{
       conn: conn,


### PR DESCRIPTION
Prompt D of the Notifications-tab critique. Owns
`lib/wanderer_app_web/live/maps/components/map_notifications_component.ex`
exclusively. Sits on top of #132 (button variants), #133 (`ChannelInfo`), #134
(home-system picker), #130 and #131.

## The two P0s

**Route alerts were silently inert.** `discord_dispatcher.ex:295` gates delivery
on `notification.route_alerts_enabled?`. With the toggle off but the route
channel fully configured, nothing delivered — and the status line read
"No kills delivered yet", the same copy a healthy-but-quiet channel shows. The
inverse guard existed, but it was rendered inside a div that was `hidden`
whenever the toggle was off, so the one state that needed a warning was the one
state where warnings were unreachable.

Fixed in three places rather than one, so the bug class is structurally
unavailable: route alerts is now a single self-contained section (the ~900px
separation that made the bug possible no longer exists); the warning renders at
card level *outside every collapsed container*, carrying an inline "Enable route
alerts" control; and the collapsed disclosure header reads `Off — channel
configured`, so the state is legible without expanding anything.

**Four save buttons, one flash, no scope.** The top form wrote
`wh_only`/`enabled`/`route_alerts_enabled`/`home_system_id`/`route_max_jumps`
while each webhook row wrote a disjoint set, all reporting through one shared
flash. Ticking "Enabled" on the System channel and pressing the *top* Save said
"Saved." and reverted the checkbox. There are now two scoped settings forms
(`#discord-notification-form` for kills, `#route-alerts-form` for route) plus
the three row forms, each with a panel-local message, dirty-state tracking, and
Save disabled until something actually changed.

## The change everything else rests on

Review checklist §5 says disable, never hide. A disabled input submits *nothing*
— `core_components.ex:397` disables the hidden `"false"` companion too. So an
absent param now means **"keep the current value"**, never "clear it":

```elixir
defp put_param(attrs, params, key, attr, parse) do
  if Map.has_key?(params, key), do: Map.put(attrs, attr, parse.(params[key])), else: attrs
end
```

Without this, pressing Save with route alerts off would wipe a saved home
system every time. It also fixes a second, independent bug: L0 has no
`enabled`/`wh_only` checkboxes, and `checked?(nil)` is `false`, so every new
config would have been born disabled — invisibly, because no checkbox
contradicted it. Present-but-blank still clears; that is the user emptying a
field, which is different from the field not being on the page.

## IA

Reorganised around the two features the tab actually has — kill notifications
and route alerts — not three peer destinations.

- **L0** (nothing configured): one URL field, one button. Nothing else.
- **L1**: status line first, wormhole-only toggle, Send test, two collapsed
  disclosures.
- **L2** (Filters and routing): excluded systems, corporation filter, and the
  character channel behind "+ Add a separate channel".
- **L3** (Route alerts): toggle, channel, home system, max jumps, mentions —
  all in one place.

Disclosures use `JS.toggle_class`, following the only precedent in the app
(`characters_live.html.heex:92`); no accordion primitive exists and no
open/closed state round-trips through the server. Content stays in the DOM when
collapsed, which is what keeps the existing DOM contract intact. The **server**
picks the initial state, so a client toggle cannot defeat a badge: a section
holding a failing webhook, a channel collision, or a configured-but-inert
feature always starts expanded.

## Webhook identity (consuming #133)

`masked_url/1` rendered the channel snowflake in full *and* the first four
characters of the token. It is replaced by `ChannelInfo.describe/1`, which is
explicitly non-blocking and does no I/O on the render path — this template
re-renders on every typeahead keystroke.

Collisions come from `ChannelInfo.colliding_roles/1`, which groups on the
*resolved* `channel_id` and so catches two **distinct** webhook URLs pointing at
the same Discord channel. The route wording is deliberately not the generic one:
a route alert names every system between the home system and Jita, and that
channel's own help text asks the owner to treat it as trusted, so a shared route
channel is a disclosure rather than untidy configuration. A collision counts as
a "problem" for the disclosure rules, so it cannot sit inside a collapsed
section.

## Also

Replace is no longer a trap door (`replacing_url?` had nothing clearing it but a
successful save — it has a Cancel now) · delivery status promoted to a real
state with colour (`delivering` / `degraded` / `never delivered` / `disabled`)
· button variants from #132, with `:danger` reserved for "Remove all Discord
notifications" · excluded systems unified onto the corporation filter's chip
treatment · home system picked by name via `MapSolarSystem.find_by_name` with a
numeric-ID fallback · mentions validated on change, not only on submit · field
grids to `1fr auto`, preserving the height-matching technique and its comment ·
named constants for the two unnamed `5`s and the inline `min`/`max` · route help
text trimmed of its four em dashes.

## Deliberate non-change, flag in review

The three webhook **row** forms have no `phx-change`. Their first field is a
webhook URL, a credential this file goes to unusual lengths never to log or
echo, and a change handler would ship it to the server on every keystroke. They
get scope, panel-local flash and explicit labels instead — which is what
actually fixes "four identical Saves, one flash, no scope". A test asserts this
structurally, so it fails loudly if someone later adds dirty-state tracking to a
row form.

## Verification

- `MIX_ENV=test mix test test/wanderer_app_web/live/map_notifications_test.exs`
  — **54 tests, 0 failures**
- `mix format --check-formatted` — clean (whole project, and clean on the base
  commit too, per §13)
- `mix credo` on the component — 165 mods/funs, no issues
- `mix compile --force --warnings-as-errors` — clean

Five tests are new or rewritten, including one for each P0 (a
configured-but-disabled route channel must produce a visible warning; each Save
must persist exactly its own field set) and one proving the collision case the
pre-#133 check structurally could not see.

Expected log noise, not a failure: the suite prints
`[ChannelInfo] webhook identity exited for <fingerprint>` per rendered
destination. That is #133's background refresh finding no network under test —
rescued, logs only a fingerprint, and does not affect what renders.

## Not done

**Screenshots (§9).** They need a running server and a seeded map behind EVE
OAuth; I have not captured them. Happy to if you can point me at a way to get a
logged-in session locally.
