### PR TITLE
zoo(docs): refresh the prompt doc after the history rewrite, add two upstream findings

### DIFF
--- a/docs/prompts-2026-08-08.md
+++ b/docs/prompts-2026-08-08.md
@@ -994,14 +994,104 @@ Keep that file until the human confirms nothing is missing.
 
 ---
 
+## Prompt 16 — Settings-tab feature-flag bypass (upstream)
+
+> **New 2026-08-08.** Found by re-reviewing the 7 commits that landed after this document
+> was written (#129). Fixed on the fork in `c6a78c12` (#131); the weakness is still present
+> upstream.
+
+### The finding
+
+`handle_event("change_settings_tab", %{"tab" => tab}, socket)` assigns whatever tab string
+the client pushes:
+
+```elixir
+def handle_event("change_settings_tab", %{"tab" => tab}, socket),
+  do: {:noreply, socket |> assign(active_settings_tab: tab)}
+```
+
+Verified present verbatim at `lib/wanderer_app_web/live/maps/maps_live.ex:399-400` on **both**
+`upstream/main` and `upstream/develop`.
+
+The tab list in `maps_live.html.heex` guards three tabs on `@map_subscriptions_enabled?`
+(lines 289, 316, 398) and one on `not WandererApp.Env.public_api_disabled?()` (line 370).
+Because the handler does not re-check, those `:if` guards are cosmetic — a crafted event
+renders the Balance, Subscription or Bots panel with the flag off. Public Api was the only
+tab with a defence-in-depth body re-check.
+
+### Scope it honestly
+
+This is **feature-flag bypass, not privilege escalation.** The settings dialog is already
+gated on the `delete_map` permission in `apply_action(:settings, ...)`, so every actor
+reaching this handler is a map owner or ACL admin. Say that plainly in the PR — overstating
+it as a security hole will cost credibility, and a maintainer will check.
+
+### The fix
+
+Take `c6a78c12` as the reference. It adds an allowlist mirroring the template guards and
+keeps the current selection when a tab is unknown or its flag is off. Confirm the module
+attributes and the `:if` guards stay in sync — that coupling is the fix's weak point and
+deserves the comment the fork version carries.
+
+The commit also replaces a bare `"general"` literal with `@default_settings_tab`. Keep that;
+it is small and it is what makes the allowlist readable.
+
+### Verify before opening
+
+```bash
+git show upstream/main:lib/wanderer_app_web/live/maps/maps_live.ex | grep -A2 change_settings_tab
+```
+
+If upstream has since added a guard, stop — the finding is closed.
+
+---
+
+## Prompt 17 — `button/1` style variants (upstream, low priority)
+
+> **New 2026-08-08.** Fixed on the fork in `9a0ce094` (#132).
+
+### The finding
+
+`core_components.ex` `button/1` on `upstream/main` has no variant attribute — every caller
+hand-writes classes onto a single outlined style (`upstream/main:...core_components.ex:292`).
+Confirmed: no `attr :variant` exists upstream.
+
+The fork added `primary` / `secondary` / `ghost` / `danger`.
+
+### Why it is low priority
+
+This is an enhancement, not a bug, and it touches a file every LiveView imports — a maintainer
+may reasonably have opinions about the variant names or prefer their own design tokens. Open
+it as a discussion or a draft PR rather than a finished one, and be ready for the names to
+change.
+
+---
+
+## Triage of the remaining post-#129 commits
+
+Assessed and deliberately **not** upstreamable — every path they touch is fork-only:
+
+| Commit | What | Why not upstream |
+|--------|------|------------------|
+| `1d3d4032` (#130) | route-alerts checkbox toggle | `map_notifications_component.ex` is fork-only |
+| `f394497a` (#134) | route-alert home system by name | same file, fork-only |
+| `4f70afdc` (#133) | Discord channel identity + collisions | Discord subsystem is fork-only |
+| `b04677d6` (#137) | Notifications tab restructure | same file, fork-only |
+| `2e304d54` (#135) | maps_v1 scopes drift + codegen CI gate | the migration and snapshot are fork-only; the `test.yml` part overlaps prompt 5 |
+
+`2e304d54` is the only borderline case: its `test.yml` change could ride along with prompt 5,
+but the migration it accompanies is fork-specific, so do not bundle them.
+
+---
+
 ## Suggested order
 
 If you are running several sessions at once:
 
-**Start immediately, no conflicts, high value:** 1, 3, 4, 5, 6, 15
-**Start immediately, lower value:** 8, 9, 12
+**Start immediately, no conflicts, high value:** 1, 3, 4, 5, 6, 16
+**Start immediately, lower value:** 8, 9, 17
 **Sequence:** 2 → 7 (shared file)
-**Sequence:** 13 → 14, or 14 → 13 (shared file)
 **Do last, needs a decision first:** 10 (may become a discussion issue rather than a PR)
-**Do whenever, but decide the outcome first:** 11 (also touches `docs/ZOO-FORK.md` — sequence
-against 13 and 14)
+
+Prompts 11, 12, 13 and 15 are done — see the markers on each. 14 is superseded in part by
+the history rewrite; the merge-policy half still stands.

--- a/docs/prompts-2026-08-08.md
+++ b/docs/prompts-2026-08-08.md
@@ -19,9 +19,20 @@ itself, including the shared context and ground rules.
 | Fork repo | `guarzo/wanderer` — remote `origin` |
 | Upstream repo | `wanderer-industries/wanderer` — remote `upstream` |
 | Fork branch | `guarzo/zoo` |
-| Upstream baseline at review time | `upstream/main` @ `b7ddbc486`, `upstream/develop` @ `35ea4e5f1` |
-| Divergence at review time | 58 commits / 312 files ahead; 0 behind either upstream branch |
+| Upstream baseline at review time | `upstream/main` @ `b7ddbc486`, `upstream/develop` @ `35ea4e5f1` — re-checked 2026-08-08 post-rewrite, both unmoved |
+| Divergence at review time | 82 commits / 322 files ahead of `upstream/main`; 242 ahead of `upstream/develop`; 0 behind either |
 | Fork documentation | `docs/ZOO-FORK.md` — read the relevant section before starting |
+
+> **History rewrite, 2026-08-08.** `guarzo/zoo` was force-pushed to split its three
+> mega-commits into 18 feature commits. Every commit SHA above the fork point changed, so
+> most SHAs originally cited in this document were left unreachable. They have been remapped
+> in place — the old→new table is under "Superseded: the history rewrite" in prompt 14.
+> The pre-rewrite history is preserved at `origin/guarzo/zoo-prerewrite`. If you have an
+> existing checkout, run `git fetch origin && git reset --hard origin/guarzo/zoo` — **not**
+> `git pull`, which would merge the old history back in.
+>
+> The ahead count grew 58 → 82 for two reasons, only one of which is real work: the split
+> itself added 15 commits without changing a single byte of the tree.
 
 Re-verify the baseline before you start, because it moves. Check every fact in the table
 above, not just the ahead count:
@@ -195,7 +206,7 @@ Confirm both are still present on the current `upstream/main` before proceeding.
 
 ### Where the fix lives on the fork
 
-Commit `03454f669` (#127) — **this one is unusually clean**. `cached_info.ex` and
+Commit `3d38754f4` (#127) — **this one is unusually clean**. `cached_info.ex` and
 `routes_by.ex` are touched by that commit and nothing else, so those two files can be taken
 almost as-is.
 
@@ -261,9 +272,10 @@ just the corporation search where it was originally noticed.
 
 ### Where the fix lives on the fork
 
-Inside squash commit `cb2b8d024` (#103), which also contains unrelated corporation-typeahead
-work. **Extract, do not cherry-pick.** The file is also touched by `c32c9ca87` (#112, the
-IPv6 change — that is prompt 7) and by the `e791d4e10` mega-commit.
+Inside squash commit `a010cb479` (#103), which also contains unrelated corporation-typeahead
+work. **Extract, do not cherry-pick.** The file is also touched by `0518a96cb` (#112, the
+IPv6 change — that is prompt 7) and by the killmail-notifications region,
+`1b4a7e2aa`..`7f819f1c5` (formerly the `e791d4e10` mega-commit).
 
 ### Approach
 
@@ -303,8 +315,11 @@ delete means no garbage is collected that day.
 
 ### Where the fix lives on the fork
 
-**Only in the mega-commits** (`defb24439`, `e791d4e10`) plus `a91d4943f`. There is no clean
-commit to reference. Reconstruct from the current tree:
+**Only in the former mega-commit regions** (`6ebdb3010`..`032eec9c7`, was `defb24439`;
+`1b4a7e2aa`..`7f819f1c5`, was `e791d4e10`) plus `aabeead2e`. Since the rewrite the region is
+navigable, so check whether one of the 18 split commits now isolates this change before
+falling back — `git log --oneline -- <path>` over the range will tell you. If it still spans
+several, reconstruct from the current tree:
 
 ```bash
 git diff upstream/main...origin/guarzo/zoo -- lib/wanderer_app/map/map_garbage_collector.ex
@@ -371,7 +386,7 @@ coverage → Credo → Dialyzer serially. Everything waits on everything.
 
 ### The fork's version
 
-Commit `e815c2283` (#121) restructures it into:
+Commit `708d601b3` (#121) restructures it into:
 
 - `setup` — installs and compiles deps once, seeds the shared cache
 - `tests` — a 4-way `mix test --partitions` matrix
@@ -383,8 +398,8 @@ It also fixes the dependency caches, which were the reason the fan-out did not h
 
 ### ⚠ Strip the zoo-specific parts
 
-`test.yml` is also touched by `2e6487a84` (#117), which added `guarzo/zoo` branch triggers,
-and by `a91d4943f` (#118). The upstream PR must contain **only** the structural change — no
+`test.yml` is also touched by `66cefb9ac` (#117), which added `guarzo/zoo` branch triggers,
+and by `aabeead2e` (#118). The upstream PR must contain **only** the structural change — no
 zoo branch names anywhere in `on:`.
 
 ### Coupling to preserve
@@ -453,7 +468,7 @@ diagnostic dead-end is the real cost.
 
 ### The fix on the fork
 
-Commit `c32c9ca87` (#112) adds to `lib/wanderer_app/route_builder_client.ex`:
+Commit `0518a96cb` (#112) adds to `lib/wanderer_app/route_builder_client.ex`:
 
 ```elixir
 @connect_opts [connect_options: [transport_opts: [inet6: true]]]
@@ -565,7 +580,7 @@ generates cleanly.
 ### What it is
 
 `fix(json-api): correct JsonApiFormatter payload contract against real producers`
-(`725b44a4d`, #105) reworked ~575 lines of
+(`2321332cb`, #105) reworked ~575 lines of
 `lib/wanderer_app/external_events/json_api_formatter.ex` so the
 emitted payloads match what the event producers actually send, rather than what the formatter
 assumed.
@@ -579,7 +594,7 @@ current (wrong) shape. This cannot be presented as a pure bugfix.
 
 ### Good news
 
-`json_api_formatter.ex` is touched by **only** commit `725b44a4d` on the fork, so unlike the
+`json_api_formatter.ex` is touched by **only** commit `2321332cb` on the fork, so unlike the
 other prompts this one is a genuine clean cherry-pick candidate. Verify that is still true:
 
 ```bash
@@ -605,6 +620,13 @@ These branch from `origin/guarzo/zoo` and stay in the fork.
 ---
 
 ## Prompt 11 — Resolve the dead `WANDERER_FLEET_READINESS_ENABLED` flag
+
+> **✅ DONE — landed in #136 (`05322156c`), 2026-08-08.** Resolved by *deleting* the flag, not
+> wiring it. `git log -S fleet_readiness --all -- lib/ assets/` returns nothing, ever: no
+> consumer was ever written, so there was no intent-to-gate to honour. Wiring it at its
+> existing `"false"` default would have silently disabled fleet readiness for every current
+> deployment. `docs/ZOO-FORK.md` now carries a "No feature flag." note in its place.
+> Left below for the reasoning trail.
 
 ### The finding
 
@@ -645,10 +667,21 @@ are running.
 
 ## Prompt 12 — Guard against the `FixMapsScopesDefault` migration collision
 
+> **✅ DONE — landed in #136 (`05322156c`), 2026-08-08.** A `Migration hygiene` job now fails
+> CI on duplicate migration *module names*. It is pure shell with no BEAM or deps, so it
+> reports in seconds rather than waiting on `setup`, and it is wired into the `Test Suite`
+> gate (verified live: the gate log prints `migrations: success`).
+>
+> Why module names and not versions: `mix ecto.migrate` already rejects duplicate version
+> numbers, so only duplicate module names with *distinct* timestamps slip through — and in
+> Elixir that is not a compile error. The later definition silently replaces the earlier, so
+> a migration simply never runs. Validated against `a500f6e86^`, the real historical
+> regression, not just the current clean tree.
+
 ### The finding
 
 `priv/repo/migrations/20260801200000_fix_maps_scopes_default.exs` is on the fork. Commit
-`1b4970ffb` (#122) describes it as upstream's, but it is on **neither** `upstream/main` nor
+`a500f6e86` (#122) describes it as upstream's, but it is on **neither** `upstream/main` nor
 `upstream/develop`.
 
 Search by **module name**, not by filename — the whole risk here is upstream landing the same
@@ -661,7 +694,7 @@ for ref in upstream/main upstream/develop; do
 done
 ```
 
-At review time both printed `absent`. It arrived via `a91d4943f` (#118), which pulled from an
+At review time both printed `absent`. It arrived via `aabeead2e` (#118), which pulled from an
 upstream PR that had not merged.
 
 ### Why this matters
@@ -705,6 +738,22 @@ module name, so the check above will not catch them. Mention this in your report
 ---
 
 ## Prompt 13 — Audit the label-system section of the fork doc
+
+> **✅ DONE — landed in #136 (`05322156c`), 2026-08-08.** The audit found three real errors,
+> all now corrected in `docs/ZOO-FORK.md`:
+>
+> 1. **Icons were swapped** between `crit` and `structure` in the doc table. The code was
+>    right; the doc was wrong.
+> 2. **The storage claim was backwards.** The doc said the enum *member* names persist. It
+>    is the enum *values* — `system.labels` contains `de`/`gas`/`eol`/`crit`/`structure`/
+>    `steve`, never `la`/`lb`/`lc`. Traced to `labelIconMap.tsx`'s own header comment, which
+>    the doc had copied; that comment was corrected too, so the two cannot drift apart again.
+> 3. **The styles pointer was incomplete.** `ZOO_BOOKMARK_STYLES` has no entry for
+>    `structure` or `steve`, which the doc implied it covered.
+>
+> One thing deliberately *not* asserted: `steve`'s short name `DB` has no expansion anywhere
+> in the tree. Only `LP` = "Low Power Structure" is supported by a source comment. `DB` is
+> described as historic rather than guessed at.
 
 ### Why
 
@@ -772,21 +821,48 @@ messages follow it well. What is missing is a stated **merge** policy.
 4. Document it — a short "Contributing / merge policy" section in `docs/ZOO-FORK.md`, or a
    `CONTRIBUTING.md` if you prefer it discoverable from the repo root.
 
-### Explicitly out of scope
+### Superseded: the history rewrite (done 2026-08-08)
 
-**Do not rewrite existing history.** The three mega-commits (`defb24439` "zoo: custom", 145
-files; `e791d4e10` "zoo: killmail notifications", 98 files; `045388354` "share intel between
-maps", 42 files) carry roughly 20k lines with no recoverable rationale, and `git blame` into
-the theme, ownership, label, and Discord subsystems dead-ends there.
+This section previously read **"Do not rewrite existing history."** That advice was overtaken
+by events — the rewrite was carried out deliberately on 2026-08-08. Recorded here so the
+reversal is not mistaken for drift.
 
-That information is already lost. A rebase would not recover it — it would only invalidate
-every published branch and every open worktree. `docs/ZOO-FORK.md` now serves as the map into
-that region instead. Leave the history alone.
+The original reasoning was that a rebase would not recover the lost rationale and would
+invalidate every published branch and open worktree. The first half still holds: nothing was
+recovered, because nothing was recoverable. What changed is the second half — the cost was
+paid down first. Every PR was merged, no unmerged branch of consequence remained, and the
+pre-rewrite tip was preserved at `origin/guarzo/zoo-prerewrite` before the force-push.
+
+The three mega-commits were split by chronological file grouping, which is sound here only
+because they contain zero deletions and zero renames:
+
+| Was | Now | Commits |
+|-----|-----|---------|
+| `045388354` "share intel between maps", 42 files | `d1e2db50b` | 1 |
+| `defb24439` "zoo: custom", 145 files | `6ebdb3010`..`032eec9c7` | 11 |
+| `e791d4e10` "zoo: killmail notifications", 98 files | `1b4a7e2aa`..`7f819f1c5` | 6 |
+
+The three "was" SHAs are unreachable from `guarzo/zoo` but remain reachable from
+`origin/guarzo/zoo-prerewrite`, so `git show defb24439` still works after a fresh clone as
+long as that ref exists. Do not delete it.
+
+Verified before the push: the final tree is byte-identical to the pre-rewrite tip
+(`git diff --stat` empty), all 61 downstream commits retain identical trees and subjects, all
+3 merge commits survive with 2 parents each, and each of the 18 new commits builds under both
+`yarn build` and `mix compile` so `git bisect` stays usable across the region.
+
+What this does **not** fix: `git blame` still dead-ends at the split commits rather than at
+real authorship, because the underlying rationale was never recorded. `docs/ZOO-FORK.md`
+remains the map into that region. The split buys navigability and bisectability, not history.
+
+One caveat on the push itself — it bypassed the branch ruleset ("Test Suite" required check,
+"changes must be made through a pull request"), which is inherent to a force-push. The
+rewritten history has therefore never run CI as a unit.
 
 ### Minor note
 
-`8b866fc0b` ("temporary failing test to validate the deploy gate on a red commit") is a
-deliberately-red commit on the mainline, reverted cleanly by `febcf9d4a` — verified as an
+`e69d727bd` ("temporary failing test to validate the deploy gate on a red commit") is a
+deliberately-red commit on the mainline, reverted cleanly by `151031c90` — verified as an
 empty diff across the pair. It is a small `git bisect` landmine and it is documented in
 `docs/superpowers/plans/2026-08-07-deploy-approval-gate.md`. Worth a sentence in the merge
 policy saying not to do this again; not worth fixing retroactively.
@@ -794,6 +870,11 @@ policy saying not to do this again; not worth fixing retroactively.
 ---
 
 ## Prompt 15 — Prune merged branches
+
+> **✅ MOSTLY DONE — 2026-08-08.** Remote branches 176 → 130, local 94 → 76. Only 4 merged
+> remote refs remain. The three backup branches were **deliberately kept** — see the
+> correction below; they are the one part of this prompt that should not be carried out as
+> written. Re-derive the counts before acting, as the prompt already instructs.
 
 ### The finding
 
@@ -807,7 +888,24 @@ from `origin`. The 63 above excludes them. Treat any count you did not produce a
 
 The backup branches (`backup/guarzo-zoo-prerebase`, `zoo-backup-prerebase`,
 `backup-pre-rebase-102`) are **not** being kept deliberately — they simply have not been
-cleaned up yet, and can go.
+cleaned up yet.
+
+⚠ Corrected 2026-08-08: an earlier draft said they "can go". Checked before deleting, and
+each one holds commits reachable from **no** surviving ref — 18, 38, and 32 respectively.
+That is expected for pre-rebase snapshots, whose commits were rewritten rather than merged,
+but it means deleting them discards the only copy rather than removing a duplicate. They are
+local-only refs costing nothing, and they have been left in place. If you do delete them,
+do it as a deliberate choice, not as cleanup. Run the containment check first:
+
+```bash
+for b in backup/guarzo-zoo-prerebase zoo-backup-prerebase backup-pre-rebase-102; do
+  printf '%-32s unique-commits=%s\n' "$b" \
+    "$(git rev-list --count "$b" --not origin/guarzo/zoo origin/guarzo/zoo-prerewrite)"
+done
+```
+
+The same check applies to any branch in the list below: `--merged` proves containment, but
+these backups are precisely the refs that are *not* merged anywhere.
 
 ### The task
 


### PR DESCRIPTION
The force-push that split the three mega-commits changed every SHA above the fork point,
which left `docs/prompts-2026-08-08.md` citing commits that no longer exist. This repairs it
and folds in a fresh review of the work that landed after the doc was written.

## SHA remapping

13 of the 15 commits the doc cited were orphaned. Each is remapped to its post-rewrite
counterpart, matched by subject — sound here because the rewrite preserved trees and subjects
exactly (verified: identical `(tree, subject)` sets across all 61 downstream commits, no
duplicate subjects).

The three mega-commits have no 1:1 successor, so those citations now name ranges:

| Was | Now | Commits |
|-----|-----|---------|
| `045388354` share intel between maps | `d1e2db50b` | 1 |
| `defb24439` zoo: custom | `6ebdb3010`..`032eec9c7` | 11 |
| `e791d4e10` zoo: killmail notifications | `1b4a7e2aa`..`7f819f1c5` | 6 |

Those three "was" SHAs stay reachable from `origin/guarzo/zoo-prerewrite`, which the doc now
says explicitly. After this, every SHA in the file resolves against `guarzo/zoo` except those
three deliberate historical references.

## Two corrections where the doc contradicted evidence

**The "do not rewrite existing history" section.** Overtaken by events. Kept, with the
original reasoning and what changed — the cost was paid down first (all PRs merged, safety
ref pushed) rather than the advice being wrong at the time.

**"The backup branches can go."** Checked before deleting: `backup/guarzo-zoo-prerebase`,
`zoo-backup-prerebase` and `backup-pre-rebase-102` hold 18, 38 and 32 commits reachable from
no surviving ref. Expected for pre-rebase snapshots, but it means deleting them discards the
only copy. They have been left in place and the doc now carries the containment check.

## Fresh review — prompts 16 and 17

Seven commits landed after the doc was written and had never been assessed. Two are genuine
upstream candidates, both verified still-broken upstream rather than assumed:

- **Prompt 16 — settings-tab feature-flag bypass (#131).** The unguarded
  `change_settings_tab` handler is present verbatim on both `upstream/main` and
  `upstream/develop`, behind template `:if` guards upstream also has. Deliberately written up
  as *feature-flag bypass, not privilege escalation* — the dialog is already gated on
  `delete_map`, so every actor reaching it is a map owner or ACL admin. This is the highest
  value item found.
- **Prompt 17 — `button/1` variants (#132).** Upstream has no `attr :variant`. An
  enhancement, not a bug; flagged low priority and better opened as a discussion.

The other five are fork-only (notifications and Discord paths that do not exist upstream) and
are tabulated so nobody re-derives that.

## Also

Prompts 11, 12, 13 and 15 are marked landed with what was actually decided, so a fresh
session does not redo them — including the two places the outcome differed from the prompt
(the fleet-readiness flag was deleted rather than wired; the backup branches were kept).

Baseline re-verified: `upstream/main` @ `b7ddbc486` and `upstream/develop` @ `35ea4e5f1` are
both unmoved. Divergence updated 58 → 82 commits / 312 → 322 files, noting that 15 of the 24
new commits are the split itself and changed no content.
