### PR TITLE
zoo(ci): drop the deploy approval gate, correct the secret's scope

### DIFF
--- a/.github/workflows/zoo-deploy.yml
+++ b/.github/workflows/zoo-deploy.yml
@@ -1,9 +1,10 @@
 name: 🚀 Zoo Deploy
 
 # Deploys are gated on a green test suite, so the trigger is the test workflow
-# finishing — not the push itself. An environment gate does not wait for another
-# workflow's checks, so `on: push` would offer approval while the suite is still
-# running, and a red commit could be approved and shipped.
+# finishing — not the push itself. `on: push` would fire while the suite was
+# still running and ship a red commit. The suite is now the ONLY gate: the
+# `production-deploy` environment carries no approval rule, so a green push to
+# guarzo/zoo reaches production unattended.
 on:
   workflow_run:
     workflows: ["🧪 Test Suite"]
@@ -28,37 +29,43 @@ jobs:
     # workflow_run fires on EVERY completion of the test suite — GitHub offers
     # no conclusion filter on the trigger itself, so a red suite still creates a
     # Zoo Deploy run. This condition is what makes it inert: the single job is
-    # skipped, so no environment is referenced, no approval is requested, and no
-    # credential is released. Expect skipped runs in the Actions tab after every
-    # failed suite; that is the mechanism working, not a misfire.
+    # skipped, so no environment is referenced and no credential is released.
+    # Expect skipped runs in the Actions tab after every failed suite; that is
+    # the mechanism working, not a misfire.
     #
-    # The `event == 'push'` clause guards a narrower hole: workflow_run's
-    # `branches:` filter (above) matches the triggering run's head_branch, and
-    # this is a public fork whose default branch is itself named `guarzo/zoo`.
-    # Without this clause, a fork PR whose source branch is also named
-    # `guarzo/zoo` would match the filter and, if its tests pass, raise a
-    # production-deploy approval request for a commit the requester controls.
+    # The `event == 'push'` clause guards a narrower hole, and now guards it
+    # ALONE: workflow_run's `branches:` filter (above) matches the triggering
+    # run's head_branch, and this is a public fork whose default branch is itself
+    # named `guarzo/zoo`. Without this clause a fork PR whose source branch is
+    # also named `guarzo/zoo` would match the filter and, if its tests passed,
+    # deploy a commit the requester controls. That used to surface as an approval
+    # request a human could reject; with the approval rule gone it would deploy
+    # straight to production. Do not weaken this clause.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
 
-    # The gate AND the work live in one job on purpose. A protected environment
-    # gates every job that references it, so splitting them would prompt twice;
-    # and FLY_DEPLOY_TOKEN is an environment secret, readable only by a job inside
-    # the environment. Secrets cannot be passed between jobs.
+    # KEEP THIS LINE. It no longer gates anything — the environment's approval
+    # rule was removed deliberately — but FLY_DEPLOY_TOKEN is an ENVIRONMENT
+    # secret, not a repository secret, and is readable only by a job that
+    # references its environment. Deleting this line does not fail loudly:
+    # `secrets.FLY_DEPLOY_TOKEN` resolves to the empty string and the deploy
+    # fails at `flyctl deploy` with an auth error. Keeping the token scoped to
+    # this environment is also what stops other workflows from reading the
+    # production credential (see the FLY_API_TOKEN note on the deploy step).
     environment: production-deploy
 
     permissions:
       contents: write
 
-    # NEVER set cancel-in-progress: true here. Cancellation applies to running
-    # jobs, not just to runs awaiting approval: a merge landing mid-deploy would
+    # NEVER set cancel-in-progress: true here. A merge landing mid-deploy would
     # kill this job while Fly's builder keeps going, changing production with no
     # tag — and the tag is the only record of what is live. That is the exact
     # failure this workflow exists to prevent. `false` also serializes deploys
-    # onto the single machine.
+    # onto the single machine, which is what makes the staleness guard below
+    # still necessary now that runs no longer wait for a human.
     concurrency:
       group: zoo-deploy-run
       cancel-in-progress: false
@@ -89,9 +96,11 @@ jobs:
           # Annotated tagging needs full history.
           fetch-depth: 0
 
-      # Runs AFTER approval, which is the entire point: a run may sit pending
-      # for hours while guarzo/zoo moves on. Because runs are never cancelled,
-      # this is what stops an old approval from shipping a superseded commit.
+      # Still load-bearing without the approval gate. Runs no longer sit pending
+      # for hours, but `cancel-in-progress: false` queues them: while one deploy
+      # runs, later pushes stack up behind it and each still checks out its own
+      # older SHA. This is what stops a queued run from shipping a commit that
+      # guarzo/zoo has already moved past.
       - name: Guard against a superseded commit
         id: guard
         env:
@@ -107,7 +116,7 @@ jobs:
           TIP="$(git rev-parse origin/guarzo/zoo)"
           HERE="$(git rev-parse HEAD)"
           if [ "$TIP" != "$HERE" ]; then
-            echo "::notice title=Superseded::guarzo/zoo has moved to ${TIP}; this run was approved for ${HERE}. Nothing was deployed."
+            echo "::notice title=Superseded::guarzo/zoo has moved to ${TIP}; this run was queued for ${HERE}. Nothing was deployed."
             # Also write to the job summary, not just the notice: a notice
             # requires opening the run to see, so without this the summary
             # pane stays blank and a superseded run reads identically to a
@@ -115,7 +124,7 @@ jobs:
             {
               echo "### Not deployed — superseded"
               echo ""
-              echo "guarzo/zoo has moved to \`${TIP}\`; this run was approved for \`${HERE}\`. Nothing was deployed."
+              echo "guarzo/zoo has moved to \`${TIP}\`; this run was queued for \`${HERE}\`. Nothing was deployed."
             } >> "$GITHUB_STEP_SUMMARY"
             echo "proceed=false" >> "$GITHUB_OUTPUT"
           else
@@ -134,11 +143,13 @@ jobs:
         if: steps.guard.outputs.proceed == 'true'
         id: deploy
         env:
-          # Repository secret name is FLY_DEPLOY_TOKEN, deliberately NOT
-          # FLY_API_TOKEN: advanced-test.yml reads a secret of that name with no
-          # environment gate, for the separate wanderer-test app. Distinct names
-          # mean this production credential can never be picked up there. The
-          # env var flyctl itself reads is still FLY_API_TOKEN.
+          # FLY_DEPLOY_TOKEN is an ENVIRONMENT secret on `production-deploy`
+          # (not a repository secret), deliberately NOT named FLY_API_TOKEN:
+          # advanced-test.yml reads a secret of that name with no environment
+          # reference at all, for the separate wanderer-test app. The distinct
+          # name plus the environment scoping mean this production credential
+          # can never be picked up there. The env var flyctl itself reads is
+          # still FLY_API_TOKEN.
           FLY_API_TOKEN: ${{ secrets.FLY_DEPLOY_TOKEN }}
         run: |
           set -euo pipefail

--- a/docs/ZOO-FORK.md
+++ b/docs/ZOO-FORK.md
@@ -394,12 +394,24 @@ The fork deploys to Fly.io; upstream's VM release pipeline was dropped (`ce58765
 > `/welcome`. Its pipeline is deliberately minimal — no `CheckApiDisabled`, no auth, no rate
 > limiting — because Fly kills a machine that fails its health check and there is one machine.
 
-### Gated deploy
+### Automatic deploy
 
-`.github/workflows/zoo-deploy.yml` implements an approval-gated deploy for `guarzo/zoo`.
-Design and plan: `docs/superpowers/specs/2026-08-07-deploy-approval-gate-design.md` and
-`docs/superpowers/plans/2026-08-07-deploy-approval-gate.md`. The Fly credential is read from
-`FLY_DEPLOY_TOKEN` (not `FLY_API_TOKEN`), and the release number is read from `.Version`.
+`.github/workflows/zoo-deploy.yml` deploys `guarzo/zoo` to Fly automatically: a push whose
+test suite goes green deploys with no human in the loop. The `production-deploy` environment
+still exists and the workflow still references it, but it carries **no approval rule** — the
+rule was removed once CI was trusted enough to be the only gate.
+
+> Do not remove `environment: production-deploy` from the workflow to "clean up" the now-empty
+> environment. `FLY_DEPLOY_TOKEN` is an **environment** secret, not a repository secret, so
+> dropping that line makes it resolve to the empty string and every deploy fails at
+> `flyctl deploy` with an auth error. The scoping is also what keeps the production credential
+> unreadable from `advanced-test.yml`.
+
+The Fly credential is read from `FLY_DEPLOY_TOKEN` (not `FLY_API_TOKEN`), and the release
+number is read from `.Version`. Design and plan documents for the original approval-gated
+version — `docs/superpowers/specs/2026-08-07-deploy-approval-gate-design.md` and
+`docs/superpowers/plans/2026-08-07-deploy-approval-gate.md` — are retained as history; they
+describe the approval flow, which no longer applies.
 
 ---
 


### PR DESCRIPTION
Removes the approval step from the zoo deploy. CI is now trusted as the only gate, so a push to `guarzo/zoo` whose test suite goes green deploys unattended.

## What actually changed

The gate was the `required_reviewers` protection rule on the `production-deploy` environment, not anything in the workflow file. It was removed via the API:

```
PUT /repos/guarzo/wanderer/environments/production-deploy
→ protection_rules: []
```

**This is already in effect** — it is repo configuration, not something this PR can carry. Merging this PR only lands the comment and documentation updates that describe the new reality. Reverting the PR would not restore the gate; re-adding the reviewer rule would.

The rule had `prevent_self_review: false` with a single reviewer, so it was self-approved in practice — latency rather than review.

## Why `environment: production-deploy` stays in the workflow

The obvious cleanup — deleting that line now that the environment gates nothing — breaks deploys, and does so quietly.

`FLY_DEPLOY_TOKEN` is an **environment** secret, not a repository secret (the repo secrets are only `DOCKER_HUB_*` and `SERVER_*`). It is readable only by a job that references its environment. Drop the line and `secrets.FLY_DEPLOY_TOKEN` expands to the empty string, `flyctl` receives an empty `FLY_API_TOKEN`, and the deploy fails at `flyctl deploy` with an auth error.

The comment on the deploy step previously called it a "repository secret," which is exactly what would make that cleanup look safe. Corrected here, with a warning added to `ZOO-FORK.md`.

The scoping also keeps the production credential unreadable from `advanced-test.yml`, which reads an unscoped `FLY_API_TOKEN` for the separate `wanderer-test` app.

## Two invariants that change meaning without the human

- **`event == 'push'` is now the only guard against the fork-PR hole.** `workflow_run`'s `branches:` filter matches the triggering run's `head_branch`, and this public fork's default branch is itself named `guarzo/zoo`. A fork PR from a same-named branch used to raise an approval a human could reject; it would now deploy straight to production. Do not weaken that clause.
- **The staleness guard still earns its place.** Runs no longer sit pending for hours, but `cancel-in-progress: false` queues them — pushes stack behind a running deploy and each still checks out its own older SHA.

## Scope of the diff

Comments and docs, with two exceptions: the superseded-run notice and job summary said "this run was approved for `<sha>`", now "queued for".

The workflow YAML was re-parsed to confirm every functional value is unchanged — `environment`, `concurrency`, the `if:` expression, all 7 steps, and the token reference are identical.

`docs/superpowers/{specs,plans}/2026-08-07-deploy-approval-gate*.md` are left in place and relabeled as history rather than current behavior.

## Verification

- `production-deploy` re-read after the change: `protection_rules: []`, `deployment_branch_policy: null`, `FLY_DEPLOY_TOKEN` still present with its original timestamp.
- Workflow YAML parsed and functional values diffed.
- No links anywhere to the renamed "Gated deploy" heading.

**Not verified:** no deploy has run since the change, so "the token still resolves" is inferred from the secret being intact and the environment still referenced, not proven end-to-end. The first push to `guarzo/zoo` after this is the real test — worth watching that run rather than assuming it. `mix test` was not run; no Elixir code is touched.
