### PR TITLE
feat(notifications): rebuild the route-alert embed around Discord's own vocabulary

### DIFF
--- a/lib/wanderer_app/external_events/discord/embed_formatter.ex
+++ b/lib/wanderer_app/external_events/discord/embed_formatter.ex
@@ -11,6 +11,8 @@ defmodule WandererApp.ExternalEvents.Discord.EmbedFormatter do
   the payload, decides the colour and the author line.
   """
 
+  require Logger
+
   alias WandererApp.ExternalEvents.Discord.Mentions
   alias WandererApp.ExternalEvents.Discord.SystemName
 
@@ -28,10 +30,13 @@ defmodule WandererApp.ExternalEvents.Discord.EmbedFormatter do
   # title bound is reachable from ordinary user input, not just malice.
   @max_title_length 256
   @max_description_length 4096
-  # Discord's per-field value bound. The route path is the one field built from
-  # an unbounded number of unbounded names (up to route_max_jumps + 1 systems,
-  # each of which may carry a length-unconstrained custom_name), so it is the
-  # one that can reach this from ordinary user input.
+  # Discord's per-field value bound. Still the tightest bound in the route
+  # embed's exit field, whose system names carry no length constraint on
+  # `MapSystem`. The route PATH now renders as the description rather than a
+  # field, so it is bounded by @max_description_length instead — that is the
+  # looser of the two, and the path is the one string built from an unbounded
+  # number of unbounded names (up to route_max_jumps + 1 systems, each of which
+  # may carry a length-unconstrained custom_name).
   @max_field_length 1024
   # The per-message ceiling counts the text of every embed in the message
   # together, so it can be breached by a batch that satisfies each field bound
@@ -40,7 +45,31 @@ defmodule WandererApp.ExternalEvents.Discord.EmbedFormatter do
 
   @color_loss 0xE74C3C
   @color_kill 0x2ECC71
-  @color_route 0x2ECC71
+
+  # Route alerts are logistics, not combat, and they share a channel with kill
+  # embeds — so they deliberately sit outside the kill palette's hues. Red,
+  # green, yellow and orange are all spoken for by @color_loss, @color_kill and
+  # the @value_colors tiers below; blue is unclaimed, and it is also The Forge's
+  # own colour, which is where the alert always points.
+  #
+  # The two states are one hue at two lightness steps rather than two hues: the
+  # family should read as "route" at a glance, with `:improved` legibly the
+  # quieter of the two. An `:improved` alert also carries no ping (see
+  # `route_ping/2`), so the dimmer stripe matches how loud the message is.
+  @color_route_opened 0x2E9BD6
+  @color_route_improved 0x2A6E90
+
+  # What `Evaluator`'s pinned @solver_settings actually guarantee, in the
+  # reader's language rather than the config's. This is the whole value of the
+  # alert — that the route needs no scouting — and it was previously invisible,
+  # so a reader had to know the internals to trust the message.
+  #
+  # Deliberately makes NO ship-class claim: `include_cruise: true` means a
+  # cruiser-sized hole qualifies, so "freighter-safe" would be false. The three
+  # exclusions are stated plainly and the reader judges their own hull.
+  # `route_guarantee_settings/0` and its test pin this string to the settings it
+  # describes, because drift here turns a safety guarantee into a lie.
+  @route_guarantee "highsec only · no EOL · no crit · no frigate holes"
 
   # ISK tiers for kills involving nobody we track, largest first.
   #
@@ -124,33 +153,160 @@ defmodule WandererApp.ExternalEvents.Discord.EmbedFormatter do
 
   defp route_embed(alert) do
     %{
-      "title" => route_title(alert),
-      "color" => @color_route,
-      "fields" => [
-        %{
-          "name" => "Path",
-          "value" => truncate(route_path_text(alert), @max_field_length),
-          "inline" => false
-        },
-        %{
-          "name" => "Exit system",
-          "value" => truncate(route_system_name(alert, alert.exit_system), @max_field_length),
-          "inline" => true
-        }
-      ]
+      "author" => %{"name" => route_kind_label(alert.kind)},
+      "title" => truncate(route_title(alert), @max_title_length),
+      "url" => map_url(alert.map_id),
+      "color" => route_color(alert.kind),
+      "description" => truncate(route_path_text(alert), @max_description_length),
+      "footer" => %{"text" => @route_guarantee},
+      # Renders client-side as the reader's local time. A qualifying route is
+      # perishable — the chain it runs through can roll or die within the hour —
+      # so "how old is this alert" is part of the decision, not metadata.
+      "timestamp" => DateTime.utc_now() |> DateTime.to_iso8601()
     }
+    |> put_route_fields(alert)
     |> drop_nils()
   end
 
-  defp route_title(%{kind: :opened, jumps: jumps}),
-    do: "Highsec route to Jita — #{jumps} jumps"
-
-  defp route_title(%{kind: :improved, jumps: jumps}),
-    do: "Highsec route to Jita improved — #{jumps} jumps"
-
-  defp route_path_text(alert) do
-    Enum.map_join(alert.path, " → ", &route_system_name(alert, &1))
+  # The exit field earns its place only when the exit is NOT the destination.
+  # `find_exit_system/2` returns the first non-wormhole system in path order, so
+  # on a chain that pops straight into Jita it returns Jita — and "Exit system:
+  # Jita" then restates the last token of the path line directly above it. When
+  # the exit is somewhere else it is the most decision-relevant fact in the
+  # message (where the chain touches k-space), so it gets stated with the gate
+  # distance that makes it actionable.
+  defp put_route_fields(embed, alert) do
+    case route_exit_field(alert) do
+      nil -> embed
+      field -> Map.put(embed, "fields", [field])
+    end
   end
+
+  defp route_exit_field(%{exit_system: nil}), do: nil
+
+  defp route_exit_field(alert) do
+    destination = List.last(alert.path)
+
+    if alert.exit_system == destination do
+      nil
+    else
+      %{
+        "name" => "Exit",
+        "value" =>
+          truncate(
+            "#{route_system_name(alert, alert.exit_system)} · #{gates_from_exit(alert)} from #{route_system_name(alert, destination)}",
+            @max_field_length
+          ),
+        "inline" => true
+      }
+    end
+  end
+
+  # Gates remaining between the exit and the destination. Read off the solved
+  # path by position rather than recomputed: the path IS the route, so the hops
+  # after the exit's index are exactly the k-space legs left to fly. Falls back
+  # to the full jump count if the exit is somehow not on the path, which
+  # `find_exit_system/2` cannot produce but which keeps this function total —
+  # a raise here costs the whole alert, not just the field.
+  defp gates_from_exit(alert) do
+    remaining =
+      case Enum.find_index(alert.path, &(&1 == alert.exit_system)) do
+        nil -> alert.jumps
+        index -> length(alert.path) - 1 - index
+      end
+
+    pluralize(remaining, "gate")
+  end
+
+  defp route_kind_label(:opened), do: "Route opened"
+  defp route_kind_label(:improved), do: "Route shortened"
+
+  defp route_color(:opened), do: @color_route_opened
+  defp route_color(:improved), do: @color_route_improved
+
+  # Origin and destination live in the TITLE, not only in the description,
+  # because a mobile push preview shows the title and nothing else. The origin
+  # resolves map-local first (see `route_system_name/2`), so a map that names its
+  # home "Home" reads as "Home → Jita" with no special-casing here — that naming
+  # decision belongs to the map, not to this formatter.
+  #
+  # The delta clause comes first and everything else falls through to the plain
+  # total: that covers `:opened` (which has no previous count by construction)
+  # and an `:improved` alert whose previous count is somehow absent, without
+  # writing the same title string twice. Two copies of one format string is how
+  # the separator drifts in one place and not the other.
+  #
+  # The delta itself is why `previous_jumps` is threaded down from the watcher's
+  # transition table at all: 3 → 2 is a shrug and 7 → 2 is news, and the bare
+  # "2 jumps" of the old format could not tell them apart.
+  defp route_title(%{kind: :improved, previous_jumps: previous} = alert)
+       when is_integer(previous) do
+    "#{route_origin_name(alert)} → #{route_destination_name(alert)} · #{previous} → #{pluralize(alert.jumps, "jump")}"
+  end
+
+  defp route_title(alert) do
+    "#{route_origin_name(alert)} → #{route_destination_name(alert)} · #{pluralize(alert.jumps, "jump")}"
+  end
+
+  defp route_origin_name(alert), do: route_system_name(alert, List.first(alert.path))
+  defp route_destination_name(alert), do: route_system_name(alert, List.last(alert.path))
+
+  defp pluralize(1, unit), do: "1 #{unit}"
+  defp pluralize(count, unit), do: "#{count} #{unit}s"
+
+  # The destination is bolded because it is the one hop the reader is scanning
+  # for; every other hop is context for getting there.
+  defp route_path_text(alert) do
+    destination = List.last(alert.path)
+
+    Enum.map_join(alert.path, " → ", fn system_id ->
+      name = route_system_name(alert, system_id)
+      if system_id == destination, do: "**#{name}**", else: name
+    end)
+  end
+
+  # Makes the embed title a link back to the map that raised the alert, so the
+  # message is not a dead end.
+  #
+  # Returns nil rather than a best-effort URL on every failure path. A malformed
+  # `url` is a 400 from Discord, not a broken link in the client — and a 400 is
+  # a delivery failure, which counts toward `@max_consecutive_failures` and can
+  # auto-disable the destination. `Env.base_url/0` defaults to the literal
+  # placeholder "<BASE_URL>" when unconfigured, so the scheme check is load-
+  # bearing, not defensive padding.
+  defp map_url(map_id) when is_binary(map_id) do
+    with %URI{scheme: scheme, host: host} <- URI.parse(WandererApp.Env.base_url()),
+         true <- scheme in ["http", "https"],
+         true <- is_binary(host) and host != "",
+         {:ok, %{slug: slug}} when is_binary(slug) <- WandererApp.Api.Map.by_id(map_id) do
+      "#{String.trim_trailing(WandererApp.Env.base_url(), "/")}/#{slug}"
+    else
+      _ -> nil
+    end
+  rescue
+    error ->
+      Logger.debug(fn ->
+        "[EmbedFormatter] map url lookup failed for #{map_id}: #{inspect(error)}"
+      end)
+
+      nil
+  end
+
+  defp map_url(_map_id), do: nil
+
+  @doc """
+  The `Evaluator` settings that `@route_guarantee` claims to describe, as
+  `{key, required_value}` pairs. Exposed so a test can assert the string and the
+  solver cannot drift apart — the footer is a safety guarantee, and a stale one
+  is worse than none.
+  """
+  @spec route_guarantee_settings() :: keyword()
+  def route_guarantee_settings,
+    do: [include_eol: false, include_mass_crit: false, include_frig: false]
+
+  @doc false
+  @spec route_guarantee() :: String.t()
+  def route_guarantee, do: @route_guarantee
 
   # Literal :route, per SystemName's map-local-names privacy boundary — never
   # threaded through as a variable. See the Router moduledoc's "Role

--- a/lib/wanderer_app/external_events/discord/route_watcher.ex
+++ b/lib/wanderer_app/external_events/discord/route_watcher.ex
@@ -340,8 +340,8 @@ defmodule WandererApp.ExternalEvents.Discord.RouteWatcher do
 
   defp transition(%{route_state: prev} = state, notification, {:qualifying, %{jumps: jumps} = q}) do
     case prev do
-      p when p in [:unknown, :none] -> alert(state, notification, :opened, q, jumps)
-      {:qualifying, old} when jumps < old -> alert(state, notification, :improved, q, jumps)
+      p when p in [:unknown, :none] -> alert(state, notification, :opened, q, jumps, nil)
+      {:qualifying, old} when jumps < old -> alert(state, notification, :improved, q, jumps, old)
       {:qualifying, _old} -> persist(%{state | route_state: {:qualifying, jumps}})
     end
   end
@@ -350,7 +350,12 @@ defmodule WandererApp.ExternalEvents.Discord.RouteWatcher do
   # at-most-once posture (`handle_delivery_result/4`): a delivery failure loses
   # one alert rather than repeating it. `{:error, :not_running}` means nothing
   # was enqueued, so the write is reverted exactly as the dispatcher does.
-  defp alert(state, notification, kind, qualifying, jumps) do
+  # `previous_jumps` is the jump count this route is improving on, and is nil
+  # for `:opened` (there is no prior qualifying route to compare against). It
+  # exists only so the embed can say "7 → 2 jumps" instead of "2 jumps": the
+  # delta is what makes an `:improved` alert worth reading, and the transition
+  # table above is the only place that still knows it.
+  defp alert(state, notification, kind, qualifying, jumps, previous_jumps) do
     # `state` still carries the PREVIOUS route_state here — captured as
     # `prev_state` before the optimistic write, so a reverted delivery
     # restores exactly what was there before this transition, not the new
@@ -360,10 +365,19 @@ defmodule WandererApp.ExternalEvents.Discord.RouteWatcher do
 
     case Router.route_destination(notification) do
       {:ok, webhook} ->
-        deliver_alert(new_state, prev_state, notification, webhook, kind, qualifying, jumps)
+        deliver_alert(
+          new_state,
+          prev_state,
+          notification,
+          webhook,
+          kind,
+          qualifying,
+          jumps,
+          previous_jumps
+        )
 
       # Also "nothing was enqueued", so it reverts exactly like
-      # `deliver_alert/7`'s {:error, :not_running}. Keeping the optimistic
+      # `deliver_alert/8`'s {:error, :not_running}. Keeping the optimistic
       # write here would mean the same route at the same jump count takes the
       # silent `{:qualifying, _old}` branch forever once the destination is
       # usable again, and is never announced.
@@ -372,10 +386,20 @@ defmodule WandererApp.ExternalEvents.Discord.RouteWatcher do
     end
   end
 
-  defp deliver_alert(state, prev_state, notification, webhook, kind, qualifying, jumps) do
+  defp deliver_alert(
+         state,
+         prev_state,
+         notification,
+         webhook,
+         kind,
+         qualifying,
+         jumps,
+         previous_jumps
+       ) do
     alert = %{
       kind: kind,
       jumps: jumps,
+      previous_jumps: previous_jumps,
       path: qualifying.path,
       exit_system: qualifying.exit_system,
       map_id: state.map_id,

--- a/test/unit/external_events/discord/embed_formatter_test.exs
+++ b/test/unit/external_events/discord/embed_formatter_test.exs
@@ -812,38 +812,84 @@ defmodule WandererApp.ExternalEvents.Discord.EmbedFormatterRouteAlertTest do
       alert = %{
         kind: :opened,
         jumps: 4,
+        previous_jumps: nil,
         path: [@home, @wh_hop, @exit_system, @jita],
         exit_system: @exit_system,
         map_id: map.id,
         home_system_id: @home
       }
 
-      %{alert: alert}
+      %{alert: alert, map: map}
     end
 
-    test "an opened alert is a single green embed titled with the jump count", %{alert: alert} do
+    test "an opened alert is a single blue embed titled origin → destination · jumps", %{
+      alert: alert
+    } do
       assert [%{"embeds" => [embed]}] = EmbedFormatter.format_route_alert(alert, [])
 
-      assert embed["title"] == "Highsec route to Jita — 4 jumps"
-      assert embed["color"] == 0x2ECC71
+      assert embed["author"] == %{"name" => "Route opened"}
+      assert embed["title"] == "J115405 → Jita · 4 jumps"
+      assert embed["color"] == 0x2E9BD6
     end
 
-    test "the path renders home through Jita using map-local names for wormhole hops", %{
+    # Route alerts share a channel with kill embeds. Reusing the kill green made
+    # the stripe — the fastest signal in the message — say "kill" on a logistics
+    # alert, so the two must not converge again.
+    test "a route alert is never coloured like a kill or a loss", %{alert: alert} do
+      [%{"embeds" => [opened]}] = EmbedFormatter.format_route_alert(alert, [])
+
+      [%{"embeds" => [improved]}] =
+        EmbedFormatter.format_route_alert(
+          %{alert | kind: :improved, previous_jumps: 7, jumps: 3},
+          []
+        )
+
+      kill_palette = [0xE74C3C, 0x2ECC71, 0xFF0000, 0xFF6600, 0xFFFF00, 0x00FF00, 0x808080]
+
+      refute opened["color"] in kill_palette
+      refute improved["color"] in kill_palette
+      refute opened["color"] == improved["color"]
+    end
+
+    test "the path renders home through Jita as the description, destination bolded", %{
       alert: alert
     } do
       [%{"embeds" => [embed]}] = EmbedFormatter.format_route_alert(alert, [])
 
-      path_field = Enum.find(embed["fields"], &(&1["name"] == "Path"))
-      assert path_field["value"] == "J115405 → J132412 → Amarr → Jita"
+      assert embed["description"] == "J115405 → J132412 → Amarr → **Jita**"
+    end
+
+    test "the embed carries the solver guarantee and a timestamp", %{alert: alert} do
+      [%{"embeds" => [embed]}] = EmbedFormatter.format_route_alert(alert, [])
+
+      assert embed["footer"] == %{"text" => EmbedFormatter.route_guarantee()}
+      assert {:ok, _dt, _offset} = DateTime.from_iso8601(embed["timestamp"])
+    end
+
+    # The footer states a safety guarantee. If the solver's pinned settings ever
+    # relax, the footer becomes a lie that reads exactly as authoritative as it
+    # did when true — so the string is pinned to the settings it describes.
+    test "the guarantee footer matches the solver settings it claims" do
+      settings = WandererApp.Map.RouteAlert.Evaluator.solver_settings()
+
+      Enum.each(EmbedFormatter.route_guarantee_settings(), fn {key, required} ->
+        assert Map.fetch!(settings, key) == required,
+               "@route_guarantee claims #{key} == #{required}, but the solver has #{inspect(Map.get(settings, key))}"
+      end)
+
+      # No ship-class claim: `include_cruise: true` means a cruiser-sized hole
+      # qualifies, so a freighter is not guaranteed to fit.
+      assert settings.include_cruise == true
+      refute EmbedFormatter.route_guarantee() =~ ~r/freighter/i
     end
 
     # route_max_jumps tops out at 20, so a path is at most 21 systems — but
     # MapSystem's custom_name/temporary_name carry no length constraint, so an
-    # ordinary long name breaches Discord's 1024-char field bound and the POST
-    # is rejected 400 (which counts toward @max_consecutive_failures and can
+    # ordinary long name breaches Discord's description bound and the POST is
+    # rejected 400 (which counts toward @max_consecutive_failures and can
     # auto-disable the destination).
-    test "a path too long for Discord's field bound is truncated", %{alert: alert} do
-      long_name = String.duplicate("A", 60)
+    test "a path too long for Discord's description bound is truncated", %{alert: alert} do
+      long_name = String.duplicate("A", 250)
 
       ids = Enum.map(1..21, &(32_000_000 + &1))
 
@@ -860,25 +906,81 @@ defmodule WandererApp.ExternalEvents.Discord.EmbedFormatterRouteAlertTest do
       [%{"embeds" => [embed]}] =
         EmbedFormatter.format_route_alert(%{alert | path: ids, jumps: 20}, [])
 
-      path_field = Enum.find(embed["fields"], &(&1["name"] == "Path"))
-
-      assert String.length(path_field["value"]) == 1024
-      assert String.ends_with?(path_field["value"], "…")
+      assert String.length(embed["description"]) == 4096
+      assert String.ends_with?(embed["description"], "…")
     end
 
-    test "the exit system gets its own field", %{alert: alert} do
+    test "the exit field names the exit and its distance from the destination", %{alert: alert} do
       [%{"embeds" => [embed]}] = EmbedFormatter.format_route_alert(alert, [])
 
-      exit_field = Enum.find(embed["fields"], &(&1["name"] == "Exit system"))
-      assert exit_field["value"] == "Amarr"
+      exit_field = Enum.find(embed["fields"], &(&1["name"] == "Exit"))
+      assert exit_field["value"] == "Amarr · 1 gate from Jita"
     end
 
-    test "an improved alert titles with 'improved' and carries no content", %{alert: alert} do
-      improved = %{alert | kind: :improved, jumps: 3}
+    # The old embed always rendered this field, so a chain popping straight into
+    # Jita produced "Exit system: Jita" directly under a path ending in Jita.
+    test "the exit field is omitted when the exit is the destination", %{alert: alert} do
+      direct = %{alert | path: [@home, @wh_hop, @jita], jumps: 2, exit_system: @jita}
+
+      [%{"embeds" => [embed]}] = EmbedFormatter.format_route_alert(direct, [])
+
+      refute Map.has_key?(embed, "fields")
+      assert embed["description"] == "J115405 → J132412 → **Jita**"
+    end
+
+    test "a one-jump route says 'jump', not 'jumps'", %{alert: alert} do
+      single = %{alert | path: [@home, @jita], jumps: 1, exit_system: @jita}
+
+      [%{"embeds" => [embed]}] = EmbedFormatter.format_route_alert(single, [])
+
+      assert embed["title"] == "J115405 → Jita · 1 jump"
+    end
+
+    test "the title links back to the map that raised the alert", %{alert: alert, map: map} do
+      [%{"embeds" => [embed]}] = EmbedFormatter.format_route_alert(alert, [])
+
+      assert embed["url"] =~ map.slug
+      assert %URI{scheme: scheme} = URI.parse(embed["url"])
+      assert scheme in ["http", "https"]
+    end
+
+    # Env.base_url/0 falls back to the literal placeholder "<BASE_URL>" when
+    # unconfigured. Emitting "<BASE_URL>/slug" as an embed url is a 400 from
+    # Discord, which is a delivery failure — so an unusable base url must drop
+    # the link rather than produce one.
+    test "no url is emitted when the base url is not a usable http(s) url", %{alert: alert} do
+      original = Application.get_env(:wanderer_app, :web_app_url)
+      Application.put_env(:wanderer_app, :web_app_url, "<BASE_URL>")
+      on_exit(fn -> Application.put_env(:wanderer_app, :web_app_url, original) end)
+
+      [%{"embeds" => [embed]}] = EmbedFormatter.format_route_alert(alert, [])
+
+      refute Map.has_key?(embed, "url")
+    end
+
+    test "an improved alert shows the delta it improved on and carries no content", %{
+      alert: alert
+    } do
+      improved = %{alert | kind: :improved, jumps: 3, previous_jumps: 7}
 
       assert [%{"embeds" => [embed]} = message] = EmbedFormatter.format_route_alert(improved, [])
-      assert embed["title"] == "Highsec route to Jita improved — 3 jumps"
+      assert embed["author"] == %{"name" => "Route shortened"}
+      assert embed["title"] == "J115405 → Jita · 7 → 3 jumps"
+      assert embed["color"] == 0x2A6E90
       refute Map.has_key?(message, "content")
+    end
+
+    # The delta is additive, not required: an improved alert whose previous
+    # count is somehow absent still renders a correct title rather than raising
+    # inside the formatter, where the failure would cost the whole alert.
+    test "an improved alert without a previous count falls back to the plain total", %{
+      alert: alert
+    } do
+      improved = %{alert | kind: :improved, jumps: 3, previous_jumps: nil}
+
+      [%{"embeds" => [embed]}] = EmbedFormatter.format_route_alert(improved, [])
+
+      assert embed["title"] == "J115405 → Jita · 3 jumps"
     end
 
     test "an opened alert with configured targets carries a content ping and allowed_mentions", %{
@@ -951,8 +1053,7 @@ defmodule WandererApp.ExternalEvents.Discord.EmbedFormatterRouteAlertTest do
 
       [%{"embeds" => [embed]}] = [message]
 
-      assert embed["fields"] |> Enum.find(&(&1["name"] == "Path")) |> Map.get("value") =~
-               "@everyone"
+      assert embed["description"] =~ "@everyone"
     end
 
     # `Env.discord_mentions_enabled?/0` reads a nested `:discord_mentions_enabled`

--- a/test/unit/external_events/discord/route_watcher_test.exs
+++ b/test/unit/external_events/discord/route_watcher_test.exs
@@ -211,6 +211,17 @@ defmodule WandererApp.ExternalEvents.Discord.RouteWatcherTest do
                wait_until(fn ->
                  length(HttpStub.requests_for(@route_url)) == 2
                end)
+
+      # The delta is the whole point of an :improved alert — "2 jumps" alone
+      # cannot distinguish a shrug from news. The transition table is the only
+      # place that still knows the previous count, so this asserts it survives
+      # all the way into the delivered payload rather than being dropped at the
+      # `alert/6` boundary.
+      [_opened, {_url, improved_body}] = HttpStub.requests_for(@route_url)
+
+      assert %{"embeds" => [%{"title" => title, "author" => author}]} = improved_body
+      assert title =~ "4 → 2 jumps"
+      assert author == %{"name" => "Route shortened"}
     end
 
     test "qualifying(2) -> qualifying(4) is silent but still stores 4", %{map: map, pid: pid} do
@@ -271,7 +282,7 @@ defmodule WandererApp.ExternalEvents.Discord.RouteWatcherTest do
     end
 
     # A dropped destination is "nothing was enqueued", exactly like
-    # `deliver_alert/7`'s {:error, :not_running}. If the optimistic
+    # `deliver_alert/8`'s {:error, :not_running}. If the optimistic
     # {:qualifying, N} write survives the drop, the SAME route at the SAME jump
     # count takes the silent `{:qualifying, _old}` branch forever after the
     # destination becomes usable again — it is never announced.
@@ -521,7 +532,7 @@ defmodule WandererApp.ExternalEvents.Discord.RouteWatcherTest do
     assert %{route_state: :unknown} = :sys.get_state(pid)
 
     # No telemetry fires for a failed delivery — only the `:ok` branch of
-    # `deliver_alert/7` emits it — so this proves the alert was never actually
+    # `deliver_alert/8` emits it — so this proves the alert was never actually
     # posted, not merely that route_state reverted.
     refute_receive {:route_alert_telemetry, _, %{outcome: :opened}}
     refute_receive {:route_alert_telemetry, _, %{outcome: :improved}}
@@ -568,7 +579,7 @@ end
 defmodule WandererApp.ExternalEvents.Discord.RouteWatcherTest.FailingWorkerSupervisor do
   @moduledoc """
   Stands in for `WorkerSupervisor` to script a delivery-enqueue failure whose
-  reason is something other than `:not_running` — exercising `deliver_alert/7`'s
+  reason is something other than `:not_running` — exercising `deliver_alert/8`'s
   general `{:error, reason}` catch-all, which the real `WorkerSupervisor` has no
   practical, deterministic way to trigger from a test (its only non-`:ok` return
   values are `:not_running` or a `DynamicSupervisor.start_child/2` failure that


### PR DESCRIPTION
The route alert to Jita was a title, a `Path` field and an `Exit system` field. Its stripe was `@color_route = 0x2ECC71` — byte-identical to `@color_kill`. Route alerts share a channel with kill embeds, so the fastest signal in the message said "kill" on a logistics notification.

## What changed

**Colour.** Splits into `@color_route_opened` / `@color_route_improved`. Blue, because red, green, yellow and orange are all spoken for by the kill palette, and because blue is The Forge's own colour — which is where the alert always points. Two lightness steps of one hue rather than two hues, so the family reads as "route" at a glance; since `:improved` carries no ping (`route_ping(:improved, _)` returns nil), the dimmer stripe matches how loud the message is.

**Layout.** The embed used three of Discord's slots and left five empty. `author` now carries the state, freeing the title for content: `origin → destination · N jumps`, linked back to the map. That matters because a mobile push preview shows the title and nothing else. The origin resolves map-local first, so a map naming its home "Home" reads as `Home → Jita` with no special-casing in the formatter — that naming decision belongs to the map. The path moves into the description with the destination bolded, and a `timestamp` renders client-side as local time, because a qualifying route is perishable.

**The delta.** An `:improved` alert said "3 jumps". 3 → 2 is a shrug and 7 → 2 is news. `previous_jumps` is threaded from `RouteWatcher`'s transition table — the only place that still knows it — through `alert/6` into `deliver_alert/8`. Additive: an improved alert without it renders the plain total rather than raising inside the formatter, where the failure would cost the whole alert.

**Conditional exit field.** `find_exit_system/2` returns the first non-wormhole system in path order, so a chain popping straight into Jita returned Jita and the embed rendered `Exit system: Jita` directly beneath a path ending in Jita. It now appears only when the exit is elsewhere, with the gate distance that makes it actionable.

**The guarantee footer.** `Evaluator`'s pinned `@solver_settings` are the whole value of the alert — the route needs no scouting — and were invisible. The footer states them in the reader's language.

## Reviewer focus

**The footer deliberately makes no ship-class claim.** `include_cruise: true` means a cruiser-sized hole qualifies, so "freighter-safe" would be false; the evaluator's own comment says "hauler". `route_guarantee_settings/0` and its test pin the string to the settings it describes, because drift here turns a safety guarantee into a lie that reads exactly as authoritative as it did when true.

**`route_title/1` clause order.** The delta clause must stay first, or `:improved` alerts silently lose their delta.

**`map_url/1` returns nil rather than a best-effort URL.** A malformed `url` is a 400 from Discord — a delivery failure, counting toward `@max_consecutive_failures`, able to auto-disable the destination. `Env.base_url/0` defaults to the literal `"<BASE_URL>"` when unconfigured, so the scheme check is load-bearing.

## Verification

- `mix test test/unit/external_events/ test/unit/map/route_alert/ test/wanderer_app/external_events/` → **464 tests, 0 failures**
- `mix credo` on both changed lib modules → **125 mods/funs, no issues**
- `mix compile --force --warnings-as-errors` → clean
- `mix format` → clean

Run against an isolated test DB partition; the shared `wanderer_test` has pre-existing migration drift unrelated to this change.
