### PR TITLE
fix(zoo): show scan age for unscanned signatures, stop hiding it past 12h

### DIFF
--- a/assets/js/hooks/Mapper/components/map/components/SolarSystemNode/SolarSystemNodeZoo.tsx
+++ b/assets/js/hooks/Mapper/components/map/components/SolarSystemNode/SolarSystemNodeZoo.tsx
@@ -23,6 +23,7 @@ import {
   LABEL_ICON_MAP,
 } from '@/hooks/Mapper/components/map/constants';
 import { WormholeClassComp } from '@/hooks/Mapper/components/map/components/WormholeClassComp';
+import { formatSignatureAge } from '@/hooks/Mapper/components/map/helpers/signatureAge';
 import { KillsCounter } from '../KillsCounter/KillsCounter';
 import { LocalCounter } from '../LocalCounter/LocalCounter';
 import { TooltipSize } from '@/hooks/Mapper/components/ui-kit/WdTooltipWrapper/utils';
@@ -138,7 +139,7 @@ export const SolarSystemNodeZoo = memo((props: NodeProps<MapSolarSystemType>) =>
             </div>
           )}
 
-          {updatedSignatures.length > 0 && signatureAgeHours >= 0 && (
+          {signatureAgeHours >= 0 && (
             <div className={clsx(classes.Bookmark)} style={{ backgroundColor: bookmarkColor }}>
               <span
                 className={clsx(classes.text)}
@@ -146,7 +147,7 @@ export const SolarSystemNodeZoo = memo((props: NodeProps<MapSolarSystemType>) =>
                   color: '#FFFFFF',
                 }}
               >
-                {signatureAgeHours}h
+                {formatSignatureAge(signatureAgeHours)}
               </span>
             </div>
           )}

--- a/assets/js/hooks/Mapper/components/map/helpers/signatureAge.test.ts
+++ b/assets/js/hooks/Mapper/components/map/helpers/signatureAge.test.ts
@@ -1,0 +1,117 @@
+import { SignatureGroup, SignatureKind, SystemSignature } from '@/hooks/Mapper/types/signatures';
+import { computeSignatureAge, formatSignatureAge, getSignatureAgeColor, SIGNATURE_AGE_COLORS } from './signatureAge';
+
+const HOUR = 1000 * 60 * 60;
+const NOW = Date.parse('2026-08-09T12:00:00Z');
+
+const sig = (overrides: Partial<SystemSignature> = {}): SystemSignature => ({
+  eve_id: 'ABC-123',
+  kind: SignatureKind.CosmicSignature,
+  name: '',
+  group: SignatureGroup.CosmicSignature,
+  type: '',
+  ...overrides,
+});
+
+const hoursAgo = (h: number) => new Date(NOW - h * HOUR).toISOString();
+
+describe('computeSignatureAge', () => {
+  it('reports no age when the system has no signatures at all', () => {
+    expect(computeSignatureAge([], NOW).signatureAgeHours).toBe(-1);
+    expect(computeSignatureAge(null, NOW).signatureAgeHours).toBe(-1);
+  });
+
+  // The reported bug: signatures pasted straight from the probe scanner have no
+  // resolved group, and were filtered out entirely, so a freshly scanned system
+  // showed no age until at least one signature resolved to a wormhole.
+  it('counts unscanned signatures whose group is still Cosmic Signature', () => {
+    const sigs = [sig({ group: SignatureGroup.CosmicSignature, updated_at: hoursAgo(2) })];
+
+    expect(computeSignatureAge(sigs, NOW).signatureAgeHours).toBe(2);
+  });
+
+  it('counts non-wormhole site signatures', () => {
+    const sigs = [sig({ group: SignatureGroup.CombatSite, name: 'Perimeter Ambush Point', updated_at: hoursAgo(5) })];
+
+    expect(computeSignatureAge(sigs, NOW).signatureAgeHours).toBe(5);
+  });
+
+  it('counts wormhole signatures already linked to a mapped system', () => {
+    const sigs = [
+      sig({
+        group: SignatureGroup.Wormhole,
+        updated_at: hoursAgo(3),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        linked_system: { solar_system_id: 31000001 } as any,
+      }),
+    ];
+
+    expect(computeSignatureAge(sigs, NOW).signatureAgeHours).toBe(3);
+  });
+
+  it('uses the newest timestamp across all signatures', () => {
+    const sigs = [
+      sig({ eve_id: 'AAA-111', updated_at: hoursAgo(9) }),
+      sig({ eve_id: 'BBB-222', updated_at: hoursAgo(1) }),
+      sig({ eve_id: 'CCC-333', updated_at: hoursAgo(6) }),
+    ];
+
+    const { signatureAgeHours, newestUpdatedAt } = computeSignatureAge(sigs, NOW);
+
+    expect(signatureAgeHours).toBe(1);
+    expect(newestUpdatedAt).toBe(NOW - HOUR);
+  });
+
+  it('falls back to inserted_at when a signature has never been updated', () => {
+    const sigs = [sig({ inserted_at: hoursAgo(7) })];
+
+    expect(computeSignatureAge(sigs, NOW).signatureAgeHours).toBe(7);
+  });
+
+  it('reports no age when signatures exist but carry no usable timestamp', () => {
+    expect(computeSignatureAge([sig()], NOW).signatureAgeHours).toBe(-1);
+  });
+
+  it('never reports a negative age for a clock skewed into the future', () => {
+    const sigs = [sig({ updated_at: new Date(NOW + 2 * HOUR).toISOString() })];
+
+    expect(computeSignatureAge(sigs, NOW).signatureAgeHours).toBe(0);
+  });
+
+  // The 12h cliff used to reuse -1 to mean "too old to display", which made a
+  // stale system indistinguishable from one that was never scanned.
+  it('keeps reporting an age well past twelve hours', () => {
+    const { signatureAgeHours, bookmarkColor } = computeSignatureAge([sig({ updated_at: hoursAgo(72) })], NOW);
+
+    expect(signatureAgeHours).toBe(72);
+    expect(bookmarkColor).toBe(SIGNATURE_AGE_COLORS.ancient);
+  });
+});
+
+describe('getSignatureAgeColor', () => {
+  it.each([
+    [0, SIGNATURE_AGE_COLORS.fresh],
+    [3, SIGNATURE_AGE_COLORS.fresh],
+    [4, SIGNATURE_AGE_COLORS.aging],
+    [8, SIGNATURE_AGE_COLORS.aging],
+    [9, SIGNATURE_AGE_COLORS.stale],
+    [12, SIGNATURE_AGE_COLORS.stale],
+    [13, SIGNATURE_AGE_COLORS.ancient],
+    [500, SIGNATURE_AGE_COLORS.ancient],
+  ])('maps %ih to the expected colour', (hours, expected) => {
+    expect(getSignatureAgeColor(hours)).toBe(expected);
+  });
+});
+
+describe('formatSignatureAge', () => {
+  it('shows hours below a day', () => {
+    expect(formatSignatureAge(0)).toBe('0h');
+    expect(formatSignatureAge(23)).toBe('23h');
+  });
+
+  it('switches to whole days at twenty-four hours so the bookmark stays narrow', () => {
+    expect(formatSignatureAge(24)).toBe('1d');
+    expect(formatSignatureAge(47)).toBe('1d');
+    expect(formatSignatureAge(72)).toBe('3d');
+  });
+});

--- a/assets/js/hooks/Mapper/components/map/helpers/signatureAge.test.ts
+++ b/assets/js/hooks/Mapper/components/map/helpers/signatureAge.test.ts
@@ -68,6 +68,33 @@ describe('computeSignatureAge', () => {
     expect(computeSignatureAge(sigs, NOW).signatureAgeHours).toBe(7);
   });
 
+  // An unparseable updated_at yields NaN, and `NaN > max` is false, so the
+  // signature used to collapse to 0 and take its perfectly good inserted_at
+  // down with it.
+  it('falls back to inserted_at when updated_at will not parse', () => {
+    const sigs = [sig({ updated_at: 'not-a-date', inserted_at: hoursAgo(7) })];
+
+    const { signatureAgeHours, newestUpdatedAt } = computeSignatureAge(sigs, NOW);
+
+    expect(signatureAgeHours).toBe(7);
+    expect(newestUpdatedAt).toBe(NOW - 7 * HOUR);
+  });
+
+  it('reports no age when neither timestamp will parse', () => {
+    const sigs = [sig({ updated_at: 'not-a-date', inserted_at: 'also-not-a-date' })];
+
+    expect(computeSignatureAge(sigs, NOW).signatureAgeHours).toBe(-1);
+  });
+
+  it('ignores a signature with unparseable timestamps without losing its neighbours', () => {
+    const sigs = [
+      sig({ eve_id: 'AAA-111', updated_at: 'not-a-date' }),
+      sig({ eve_id: 'BBB-222', updated_at: hoursAgo(2) }),
+    ];
+
+    expect(computeSignatureAge(sigs, NOW).signatureAgeHours).toBe(2);
+  });
+
   it('reports no age when signatures exist but carry no usable timestamp', () => {
     expect(computeSignatureAge([sig()], NOW).signatureAgeHours).toBe(-1);
   });

--- a/assets/js/hooks/Mapper/components/map/helpers/signatureAge.ts
+++ b/assets/js/hooks/Mapper/components/map/helpers/signatureAge.ts
@@ -50,14 +50,23 @@ export function formatSignatureAge(signatureAgeHours: number): string {
   return `${Math.floor(signatureAgeHours / DAY_HOURS)}d`;
 }
 
+/**
+ * Parses a signature timestamp, treating anything unparseable as absent.
+ *
+ * `new Date('garbage').getTime()` is NaN, and NaN loses every `>` comparison,
+ * so an unparseable value would otherwise be indistinguishable from "no
+ * timestamp" *and* would suppress the fallback below it.
+ */
+function parseTimestamp(value?: string | null): number {
+  if (!value) {
+    return 0;
+  }
+  const ts = new Date(value).getTime();
+  return Number.isFinite(ts) ? ts : 0;
+}
+
 function getSignatureTimestamp(s: SystemSignature): number {
-  if (s.updated_at) {
-    return new Date(s.updated_at).getTime();
-  }
-  if (s.inserted_at) {
-    return new Date(s.inserted_at).getTime();
-  }
-  return 0;
+  return parseTimestamp(s.updated_at) || parseTimestamp(s.inserted_at);
 }
 
 /**

--- a/assets/js/hooks/Mapper/components/map/helpers/signatureAge.ts
+++ b/assets/js/hooks/Mapper/components/map/helpers/signatureAge.ts
@@ -1,0 +1,99 @@
+import type { SystemSignature } from '@/hooks/Mapper/types/signatures';
+
+/**
+ * Bookmark colours for the "time since this system was scanned" indicator.
+ *
+ * `ancient` has no upper bound on purpose. An age that stops rendering past
+ * some threshold makes a long-neglected system look identical to one nobody
+ * has ever scanned, which is exactly the distinction the indicator exists to
+ * draw. Absence of the bookmark means "never scanned", and nothing else.
+ */
+export const SIGNATURE_AGE_COLORS = {
+  fresh: '#388E3C',
+  aging: '#E65100',
+  stale: '#B71C1C',
+  ancient: '#4A148C',
+} as const;
+
+/** Age, in hours, at which the label switches from hours to whole days. */
+const DAY_HOURS = 24;
+
+export type SignatureAge = {
+  /** Epoch millis of the most recent signature timestamp, or 0 if there is none. */
+  newestUpdatedAt: number;
+  /** Whole hours since that timestamp, or -1 when the system has never been scanned. */
+  signatureAgeHours: number;
+  bookmarkColor: string;
+};
+
+export function getSignatureAgeColor(signatureAgeHours: number): string {
+  if (signatureAgeHours < 4) {
+    return SIGNATURE_AGE_COLORS.fresh;
+  }
+  if (signatureAgeHours <= 8) {
+    return SIGNATURE_AGE_COLORS.aging;
+  }
+  if (signatureAgeHours <= 12) {
+    return SIGNATURE_AGE_COLORS.stale;
+  }
+  return SIGNATURE_AGE_COLORS.ancient;
+}
+
+/**
+ * Renders an age for the bookmark, keeping it to a couple of characters so the
+ * marker width stays stable as a system goes stale.
+ */
+export function formatSignatureAge(signatureAgeHours: number): string {
+  if (signatureAgeHours < DAY_HOURS) {
+    return `${signatureAgeHours}h`;
+  }
+  return `${Math.floor(signatureAgeHours / DAY_HOURS)}d`;
+}
+
+function getSignatureTimestamp(s: SystemSignature): number {
+  if (s.updated_at) {
+    return new Date(s.updated_at).getTime();
+  }
+  if (s.inserted_at) {
+    return new Date(s.inserted_at).getTime();
+  }
+  return 0;
+}
+
+/**
+ * Computes how long ago this system was last scanned.
+ *
+ * Every signature counts, whatever its group and whether or not it is linked to
+ * a mapped system: pasting the probe scanner window re-stamps every signature
+ * it contains (untouched rows are still sent as updates, see `getActualSigs`),
+ * so the newest timestamp in the system is the time of the last paste. An
+ * earlier version reused the `group === 'Wormhole' && !linked_system` predicate
+ * from `useUnsplashedSignatures`, which answers a different question — "which
+ * wormholes are still unmapped" — and so hid the indicator entirely for a
+ * system whose signatures were all still unscanned.
+ */
+export function computeSignatureAge(systemSigs: SystemSignature[] | null | undefined, now: number): SignatureAge {
+  const newestUpdatedAt = (systemSigs ?? []).reduce((max, s) => {
+    const ts = getSignatureTimestamp(s);
+    return ts > max ? ts : max;
+  }, 0);
+
+  // No signature carries a usable timestamp, so there is nothing to age. A
+  // negative age is the signal to suppress the bookmark; every real age, however
+  // large, renders.
+  if (newestUpdatedAt === 0) {
+    return {
+      newestUpdatedAt: 0,
+      signatureAgeHours: -1,
+      bookmarkColor: SIGNATURE_AGE_COLORS.fresh,
+    };
+  }
+
+  const signatureAgeHours = Math.max(0, Math.round((now - newestUpdatedAt) / (1000 * 60 * 60)));
+
+  return {
+    newestUpdatedAt,
+    signatureAgeHours,
+    bookmarkColor: getSignatureAgeColor(signatureAgeHours),
+  };
+}

--- a/assets/js/hooks/Mapper/components/map/hooks/useZooLogic.ts
+++ b/assets/js/hooks/Mapper/components/map/hooks/useZooLogic.ts
@@ -6,6 +6,7 @@ import type { SystemSignature } from '@/hooks/Mapper/types/signatures';
 import { useMapRootState } from '@/hooks/Mapper/mapRootProvider';
 import { useMapEventListener } from '@/hooks/Mapper/events';
 import { useMapState } from '../MapProvider';
+import { computeSignatureAge } from '../helpers/signatureAge';
 import { useUnsplashedSignatures } from './useUnsplashedSignatures';
 
 const zkillboardBaseURL = 'https://zkillboard.com';
@@ -215,22 +216,9 @@ export function useNodeSignatures(systemId: string): SystemSignature[] {
 }
 
 /**
- * Helper to map signature age (in hours) to a bookmark color.
- */
-function getBookmarkColor(signatureAgeHours: number): { color: string; age: number } {
-  if (signatureAgeHours < 4) {
-    return { color: '#388E3C', age: signatureAgeHours };
-  } else if (signatureAgeHours >= 4 && signatureAgeHours <= 8) {
-    return { color: '#E65100', age: signatureAgeHours };
-  } else if (signatureAgeHours > 8 && signatureAgeHours <= 12) {
-    return { color: '#B71C1C', age: signatureAgeHours };
-  } else {
-    return { color: '#388E3C', age: -1 };
-  }
-}
-
-/**
- * Computes the age of the most recently updated wormhole signature.
+ * Computes how long ago this system was last scanned.
+ *
+ * See `computeSignatureAge` for which signatures count and why.
  */
 export function useSignatureAge(systemSigs?: SystemSignature[] | null) {
   const [now, setNow] = useState(Date.now());
@@ -242,54 +230,5 @@ export function useSignatureAge(systemSigs?: SystemSignature[] | null) {
     return () => clearInterval(interval);
   }, []);
 
-  return useMemo(() => {
-    if (!systemSigs || systemSigs.length === 0) {
-      return {
-        newestUpdatedAt: 0,
-        signatureAgeHours: 0,
-        bookmarkColor: '#388E3C',
-      };
-    }
-
-    const filteredSignatures = systemSigs.filter(s => s.group === 'Wormhole' && !s.linked_system);
-
-    const getSignatureTimestamp = (s: SystemSignature): number => {
-      if (s.updated_at) {
-        return new Date(s.updated_at).getTime();
-      } else if (s.inserted_at) {
-        return new Date(s.inserted_at).getTime();
-      }
-      return 0;
-    };
-
-    const newestTimestamp = filteredSignatures.reduce((max, s) => {
-      const ts = getSignatureTimestamp(s);
-      return ts > max ? ts : max;
-    }, 0);
-
-    // No unlinked wormhole signature: report a negative age so the consumer's
-    // `signatureAgeHours >= 0` guard suppresses the bookmark. Returning 0 made
-    // a system whose signatures are all linked or non-wormhole render "0h", as
-    // if it had a brand-new unlinked wormhole.
-    if (newestTimestamp === 0) {
-      return {
-        newestUpdatedAt: 0,
-        signatureAgeHours: -1,
-        bookmarkColor: '#388E3C',
-        now,
-      };
-    }
-
-    const ageMs = now - newestTimestamp;
-    const signatureAgeHours = Math.max(0, Math.round(ageMs / (1000 * 60 * 60)));
-
-    const { color: bookmarkColor, age: computedAge } = getBookmarkColor(signatureAgeHours);
-
-    return {
-      newestUpdatedAt: newestTimestamp,
-      signatureAgeHours: computedAge,
-      bookmarkColor,
-      now,
-    };
-  }, [systemSigs, now]);
+  return useMemo(() => ({ ...computeSignatureAge(systemSigs, now), now }), [systemSigs, now]);
 }


### PR DESCRIPTION
## The bug

The zoo node's scan-age bookmark only appeared once at least one signature in the system had resolved to a specific type. Paste a fresh probe-scanner window full of unscanned sigs and the indicator stayed hidden — exactly when you most want to know the system was just scanned.

## Root cause

`useSignatureAge` filtered with:

```ts
systemSigs.filter(s => s.group === 'Wormhole' && !s.linked_system)
```

That is verbatim the predicate from `useUnsplashedSignatures.ts:17`, where it is correct — an unmapped wormhole *is* group=Wormhole and not yet linked. The age hook inherited the whole predicate while asking a different question. Signatures pasted before a type resolves carry `group: 'Cosmic Signature'`, so they were filtered out, the newest timestamp came back `0`, and the hook returned `-1` — which the node's `signatureAgeHours >= 0` guard reads as "suppress".

## The fix

**Every signature counts**, whatever its group and whether or not it is linked. Pasting re-stamps every signature in the window (untouched rows are still sent as updates by `getActualSigs`, and the server stamps each one in `apply_update_signature`), so the newest timestamp in a system is the time of the last paste — precisely what the indicator claims to show.

**The 12h cliff is gone.** `getBookmarkColor` was reusing the same `-1` sentinel to mean "too old to display", so a system scanned 13 hours ago rendered identically to one nobody had ever scanned — collapsing the two states the indicator most needs to distinguish. Ages now render without an upper bound in a fourth colour band (`#4A148C`), and switch from hours to whole days at 24h so the bookmark keeps its width. `-1` now means only "no signature carries a timestamp".

The age math moved to `helpers/signatureAge.ts` as pure functions, testable without a React renderer (the project has no `@testing-library/react`). `useSignatureAge` keeps the hourly `now` tick and delegates the rest.

## What reviewers will see on the map

This is wider than just unscanned sigs, by design:

- A system with only non-wormhole sites (combat, ore, relic) now shows an age where it previously showed none.
- A system whose wormholes are all linked now shows an age too.
- Past 12h the bookmark turns purple instead of disappearing.
- An absent bookmark now means one thing only: never scanned.

**Worth an eyeball on a live map** — particularly whether the purple reads clearly against the node backgrounds in the zoo theme. It was picked for contrast against the existing green/orange/red but has not been seen rendered.

## Verification

- 27 tests pass (19 new, 8 pre-existing). The new suite pins the reported case directly: a lone `Cosmic Signature` sig yields an age, as do a linked wormhole and a combat site.
- `tsc --noEmit`: 115 errors on this branch, 115 on base, the same three in `useZooLogic.ts` (all in untouched functions). None new.
- eslint + prettier clean on all four files.
- `vite build` succeeds.

Tests here were run with `--testEnvironment=node`, because `yarn test` is broken on base — `jest-environment-jsdom` is not installed despite `jest.config.js` requiring it. Fixed separately so this PR stays scoped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map bookmarks now display the age of the latest signature.
  * Signature ages are formatted in hours or days for easier interpretation.
  * Bookmark colors reflect signature age thresholds.

* **Bug Fixes**
  * Signature-age indicators now appear consistently, including when no signatures are available.

* **Tests**
  * Added coverage for age calculations, timestamp handling, formatting, color thresholds, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->