### PR TITLE
feat(notifications): rebuild the settings tab around what is true now

### DIFF
--- a/lib/wanderer_app/api/map_discord_notification.ex
+++ b/lib/wanderer_app/api/map_discord_notification.ex
@@ -67,25 +67,42 @@ defmodule WandererApp.Api.MapDiscordNotification do
       change after_transaction(&__MODULE__.after_destroy/3)
     end
 
-    # Creates the policy row and its :system destination in one transaction.
-    # The "a system webhook always exists" invariant cannot be declared — the
-    # child's unique identity gives at most one webhook per role, not at least
-    # one — so it is enforced here: either both rows exist or neither does.
+    # Creates the policy row, optionally with its :system destination in the
+    # same transaction.
+    #
+    # `webhook_url` used to be required, which encoded a "a system webhook
+    # always exists" invariant. That invariant was never true after the fact —
+    # nothing stops the row being destroyed later — and it had a real cost in
+    # the settings UI: route alerts are a separate feature that borrows the
+    # same plumbing, and requiring a kill webhook up front meant an operator
+    # who only wanted route alerts had to configure a kill channel first.
+    #
+    # Routing already tolerates the absence. `Router.route/3` resolves the
+    # `:system` destination through `usable/1`, which drops on `nil`, so a
+    # policy row with no kill destination simply posts no kills.
     create :create do
       primary? true
-      argument :webhook_url, :string, allow_nil?: false
+      argument :webhook_url, :string, allow_nil?: true
 
       # `manage_relationship`'s `transform:` option isn't available on the
       # installed Ash version (3.9.0) — its opts schema has no such key. This
       # explicit form builds the input map itself instead: one :system child,
-      # written in the same transaction as the parent.
+      # written in the same transaction as the parent. Skipped entirely when no
+      # URL was supplied, rather than passing `[]` — an empty list with
+      # `type: :create` is a no-op either way, but the branch says why.
       change fn changeset, _context ->
-        Ash.Changeset.manage_relationship(
-          changeset,
-          :webhooks,
-          [%{webhook_url: Ash.Changeset.get_argument(changeset, :webhook_url), role: :system}],
-          type: :create
-        )
+        case Ash.Changeset.get_argument(changeset, :webhook_url) do
+          url when is_binary(url) and url != "" ->
+            Ash.Changeset.manage_relationship(
+              changeset,
+              :webhooks,
+              [%{webhook_url: url, role: :system}],
+              type: :create
+            )
+
+          _absent ->
+            changeset
+        end
       end
 
       change after_transaction(&__MODULE__.invalidate_cache/3)
@@ -245,7 +262,13 @@ defmodule WandererApp.Api.MapDiscordNotification do
     home_system_id = Ash.Changeset.get_attribute(changeset, :home_system_id)
 
     if enabled? && is_nil(home_system_id) do
-      {:error, field: :home_system_id, message: "is required when route alerts are enabled"}
+      # The field is NAMED in the message, not left to the `field:` key. The
+      # settings tab renders Ash validation errors as a sentence in its own
+      # message region (`humanize_error/1`), so a field-scoped message alone
+      # surfaced as the orphan "is required when route alerts are enabled" —
+      # with no indication of which of the three route fields it meant.
+      {:error,
+       field: :home_system_id, message: "Home system is required when route alerts are enabled"}
     else
       :ok
     end

--- a/lib/wanderer_app_web/components/core_components.ex
+++ b/lib/wanderer_app_web/components/core_components.ex
@@ -76,13 +76,24 @@ defmodule WandererAppWeb.CoreComponents do
         aria-modal="true"
         tabindex="0"
       >
-        <div class="flex items-center justify-center w-full h-full p-4 sm:p-6 lg:py-8 p-dialog-mask p-dialog-center p-component-overlay p-component-overlay-enter p-dialog-resizable">
+        <%!-- The mask, not the dialog, is the scroll container. The dialog keeps
+              `overflow: visible` so absolutely-positioned children (LiveSelect
+              dropdowns, e.g. `maps_live.html.heex` add-map and every picker on
+              the Notifications tab) are never clipped — the reason
+              `!overflow-visible` exists here at all. Scrolling out here reaches
+              a too-tall dialog without introducing a new clipping context.
+
+              `m-auto` rather than `items-center`: a centred flex item taller
+              than a scrollable container overflows past its *start* edge, and
+              that region is unreachable by scrolling. Auto margins centre only
+              the slack, so a tall dialog pins to the top and stays reachable. --%>
+        <div class="flex w-full h-full overflow-y-auto p-4 sm:p-6 lg:py-8 p-dialog-mask p-dialog-center p-component-overlay p-component-overlay-enter p-dialog-resizable">
           <.focus_wrap
             id={"#{@id}-container"}
             phx-window-keydown={JS.exec("data-cancel", to: "##{@id}")}
             phx-key="escape"
             class={[
-              "relative hidden transition p-dialog p-component p-dialog-default p-ripple-disabled p-dialog-enter-done !overflow-visible max-w-full",
+              "relative hidden transition p-dialog p-component p-dialog-default p-ripple-disabled p-dialog-enter-done !overflow-visible max-w-full m-auto shrink-0",
               @class
             ]}
           >
@@ -602,7 +613,10 @@ defmodule WandererAppWeb.CoreComponents do
 
   def error(assigns) do
     ~H"""
-    <p class="label-text-alt text-rose-600 phx-no-feedback:hidden">
+    <%!-- rose-400, not rose-600: this app renders on a near-black panel, where
+          rose-600 measures about 3.8:1 and fails WCAG AA for body text. Error
+          text is the one place a contrast miss is least affordable. --%>
+    <p class="label-text-alt text-rose-400 phx-no-feedback:hidden">
       <.icon name="hero-exclamation-circle-mini" class="mt-0.5 h-5 w-5 flex-none" />
       {render_slot(@inner_block)}
     </p>
@@ -821,7 +835,29 @@ defmodule WandererAppWeb.CoreComponents do
         @label_class
       ]}
     >
-      <div :if={not @compact} for="form_description" class="label">
+      <%!-- `:label` used to be accepted, stripped from the forwarded opts and
+            then never rendered, which left every combobox in the app with no
+            accessible name — a screen reader announced five identical
+            "combobox, blank" controls on the Notifications tab alone.
+
+            `for` targets LiveSelect's text input, whose id is derived from the
+            form and the `<field>_text_input` name it registers internally, NOT
+            from the `id` we pass (that one lands on the LiveComponent wrapper).
+            Deriving it the same way LiveSelect does keeps the two in step.
+
+            In `compact` mode the label is screen-reader-only. `compact` exists
+            to make this wrapper exactly as tall as its input so a neighbouring
+            button lines up with the field; a visible label row would undo that
+            for the "field + Add" grids that use it. Nothing loses a visible
+            label it had before — this element did not render at all until now. --%>
+      <label
+        :if={@label}
+        for={Phoenix.HTML.Form.input_id(@field.form, :"#{@field.field}_text_input")}
+        class={if @compact, do: "sr-only", else: "label"}
+      >
+        <span class={if @compact, do: nil, else: "label-text"}>{@label}</span>
+      </label>
+      <div :if={not @compact and is_nil(@label)} class="label">
         <span class="label-text"></span>
       </div>
       <LiveSelect.live_select
@@ -843,7 +879,7 @@ defmodule WandererAppWeb.CoreComponents do
       >
         {render_slot(@inner_block)}
       </LiveSelect.live_select>
-      <div :if={not @compact or @errors != []} for="form_description" class="label">
+      <div :if={not @compact or @errors != []} class="label">
         <.error :for={msg <- @errors}>{msg}</.error>
       </div>
     </div>

--- a/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
+++ b/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
@@ -13,21 +13,56 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   hint with a replace flow, like a password field.
 
   The tab is organised around TWO features rather than three peer destinations,
-  because that is what the schema actually models: kill notifications (system
-  channel, required; optional character-channel split; filters) and route
-  alerts (a separate feature borrowing the same webhook plumbing — its own
-  toggle, channel, home system, max jumps and mentions). Four progressive
-  disclosure levels:
+  because that is what the schema actually models: kill notifications (kill
+  channel, optional character-kill-channel split, filters) and route alerts (a
+  separate feature borrowing the same webhook plumbing — its own toggle,
+  channel, home system, max jumps and mentions).
 
-    L0 (no record)  — one URL field, one Connect button.
-    L1 (configured) — status, the wormhole-only toggle, and two collapsed
-                       disclosures (below) plus the danger action.
-    L2 (disclosure) — "Filters and routing": excluded systems, corporation
-                       filter, and the optional character channel.
-    L3 (disclosure) — "Route alerts": toggle, channel, home system, max jumps,
-                       mentions — all in one self-contained section, so its
-                       toggle and its channel can never again end up hundreds
-                       of pixels apart.
+  Neither feature gates the other. There is no "no record yet" screen asking
+  for a kill webhook first: the policy row is created lazily by whichever
+  control the operator touches first (`upsert/2`, `ensure_notification/1`), and
+  `MapDiscordNotification`'s `create` takes an optional `webhook_url` for
+  exactly that reason. An operator who wants route alerts and nothing else
+  configures route alerts and nothing else.
+
+  The organising rule is *show what is true now; everything that changes it
+  goes behind an edit*. At rest the tab is a short list of statements — which
+  destinations exist, where they post, whether they are delivering — and the
+  controls that would change any of that are one click away. This is a hard
+  constraint, not a preference: the settings dialog has no height of its own,
+  so an expanded-by-default tab is a tab whose lower half cannot be reached on
+  a laptop.
+
+  Layout:
+
+    Kill notifications — the two map-level switches (which apply on change),
+                         then the kill channel and the character kill channel
+                         as truth lines with an Edit/Add affordance, then a
+                         "Kill filters" disclosure. The switches sit above both
+                         rows because they govern both.
+    Route alerts       — the toggle, home system and max jumps as one form
+                         (they are validated against each other, so they commit
+                         together) with the one Save that commits them, then
+                         the route channel, then a "Mentions" disclosure.
+    Message region     — the foot of the tab. Every control reports here.
+
+  Every control acts on the thing it sits next to; the tab has no global
+  buttons. The route trio is the only group with a Save at all, and it has one
+  because those three fields cannot commit on change: `route_max_jumps` is
+  typed (a per-keystroke save submits "" mid-edit against an `allow_nil? false`
+  attribute) and the toggle is validated against the home system, so committing
+  it alone reports a missing field the operator has not reached yet. There is
+  deliberately no wholesale "remove everything": each destination has its own
+  Remove, and a policy row with no destinations delivers nothing.
+
+  Warnings and results never render inside a disclosure: something inside a
+  collapsed body has not been shown to anyone.
+
+  Disclosure state (`@open_sections`) and per-row edit state
+  (`@replacing_url?`) both live on the server. Client-only `JS.toggle_class`
+  was tried first and is wrong here: this component re-renders on saves,
+  PubSub ticks and background channel-identity refreshes, each of which
+  re-sends the literal collapsed markup and slams an open section shut.
   """
 
   use WandererAppWeb, :live_component
@@ -151,6 +186,11 @@ defmodule WandererAppWeb.MapNotificationsComponent do
      |> assign_new(:corp_options, fn -> [] end)
      |> assign_new(:corp_search_error, fn -> nil end)
      |> assign_new(:message, fn -> nil end)
+     # Which disclosures are open. `assign_new`, so the set survives every
+     # `update/2` the parent triggers — a save, a PubSub tick or a background
+     # channel-identity refresh must not close a section the operator is
+     # working inside.
+     |> assign_new(:open_sections, fn -> MapSet.new() end)
      # Labels are decoration accumulated from whatever Discord has answered so
      # far, and they deliberately survive `assign_notification/2`: a chip that
      # reads "Scouts" must not flip back to a raw snowflake because the
@@ -165,139 +205,103 @@ defmodule WandererAppWeb.MapNotificationsComponent do
      |> assign_notification(notification)}
   end
 
-  # --- Kill-notification settings (`#discord-notification-form`) ---------
+  # --- Kill switches (`#kill-toggles-form`) -------------------------------
 
-  # Handles BOTH the L0 create submit (webhook_url present, notification nil)
-  # and the L1 settings submit (wh_only only). `notification_attrs/1` reading
-  # `params` rather than a hardcoded field list is what makes this safe for
-  # both: L0's form never renders wh_only, so it is simply absent from
-  # `params` and the resource default (`wh_only: true`) applies untouched. See
-  # `notification_attrs/1`.
+  # The two kill switches apply on change, with no Save of their own. They are
+  # independent booleans with nothing to validate them against, they render as
+  # switches (`.input type="checkbox"` is a PrimeReact switch in this app), and
+  # the chip lists beside them — excluded systems, focus corporations, mention
+  # targets — have always saved immediately. A Save button for two switches was
+  # the third of the five Saves the tab used to carry.
+  #
+  # The route toggle is deliberately NOT in here: it is validated against
+  # `home_system_id`, so it commits together with the home system and the jump
+  # limit through the Save inside the route section. See `save-settings`.
   @impl true
-  def handle_event("save", %{"notification" => params}, socket) do
-    attrs = notification_attrs(params)
-
-    result =
-      case socket.assigns.notification do
-        nil ->
-          create_with_system_webhook(socket.assigns.map_id, attrs, params["webhook_url"])
-
-        rec ->
-          # Deliberately NOT `webhook_url`: that moved to the child resource and
-          # is no longer an accepted input here — passing it raises NoSuchInput
-          # at runtime. URLs are saved through "save-webhook".
-          MapDiscordNotification.update(rec, attrs)
-      end
-
-    case result do
+  def handle_event("toggle-setting", %{"notification" => params}, socket) do
+    case upsert(socket, notification_attrs(params)) do
       {:ok, rec} ->
-        {:noreply, socket |> assign_notification(rec) |> put_message(:kills, :info, "Saved.")}
+        {:noreply, assign_notification(socket, rec)}
 
       {:error, error} ->
-        {:noreply, put_message(socket, :kills, :error, humanize_error(error))}
-    end
-  end
-
-  # Purely client-display dirty tracking for the L1 settings form: the only
-  # signal Save needs is "does this differ from the persisted record", so it
-  # is computed here rather than persisted. Fires on every keystroke/tick in
-  # `#discord-notification-form`, which at L1 holds only `wh_only`.
-  #
-  # The form is rebuilt from `params`, not left alone — #130. A checkbox
-  # renders `checked` from its form value, so re-rendering against the
-  # unchanged form emits the box UNCHECKED and LiveView patches the user's
-  # tick straight back out. Nothing here is persisted; `wh_only` is still
-  # only ever written by "save".
-  #
-  # Unlike #130 this needs no `webhook_url` blanking: the L1 form does not
-  # render that field at all. The credential lives on the mutually exclusive
-  # L0 create form (`is_nil(@notification)`), which deliberately carries no
-  # `phx-change`, so no submitted params containing a webhook URL ever reach
-  # a `to_form/2` call.
-  def handle_event("kills-form-change", %{"notification" => params}, socket) do
-    rec = socket.assigns.notification
-
-    dirty? =
-      changed?(params, "enabled", rec.enabled?, &checked?/1) or
-        changed?(params, "wh_only", rec.wh_only, &checked?/1)
-
-    {:noreply,
-     socket
-     |> assign(:form, rebuild_form(params, kills_form_values(rec)))
-     |> assign(:dirty, Map.put(socket.assigns.dirty, :kills, dirty?))}
-  end
-
-  # --- Route alerts (`#route-alerts-form`) --------------------------------
-
-  def handle_event("save-route", %{"notification" => params}, socket) do
-    case socket.assigns.notification do
-      nil ->
+        # Re-assigning the unchanged record is what puts the switch back where
+        # it was: a checkbox renders `checked` from its form value, so
+        # rebuilding the form from the record reverts the optimistic flip the
+        # browser already painted.
         {:noreply,
-         put_message(socket, :route, :error, "Save the map's kill notification settings first.")}
-
-      rec ->
-        case resolve_home_system(params) do
-          {:ok, params} -> save_route(socket, rec, params)
-          {:error, message} -> {:noreply, put_home_system_error(socket, message)}
-        end
+         socket
+         |> assign_notification(socket.assigns.notification)
+         |> put_message(:error, humanize_error(error))}
     end
   end
 
-  # Three jobs on every change of the route form: keep `route_toggle` (which
+  # --- Route alerts and their Save (`#notification-settings-form`) ---------
+
+  def handle_event("save-settings", %{"notification" => params}, socket) do
+    case resolve_home_system(params) do
+      {:ok, params} ->
+        case upsert(socket, notification_attrs(params)) do
+          {:ok, rec} ->
+            {:noreply,
+             socket
+             |> assign_notification(rec)
+             |> assign(:home_system_error, nil)
+             |> put_message(:info, "Saved.")}
+
+          {:error, error} ->
+            {:noreply, put_message(socket, :error, humanize_error(error))}
+        end
+
+      {:error, message} ->
+        {:noreply, put_home_system_error(socket, message)}
+    end
+  end
+
+  # Three jobs on every change of the settings form: keep `route_toggle` (which
   # fields below are enabled — D4, disable rather than hide) in step with the
   # unsaved checkbox state, rebuild the form so the tick survives the
   # round-trip (#130 — a checkbox renders `checked` from its form value, so
   # re-rendering against the unchanged form patches the user's tick back out
-  # and Save then posts `false`), and keep the route Save button's dirty gate
-  # honest. All three are purely client-display; the persisted values only
-  # ever change through "save-route".
+  # and Save then posts `false`), and keep the Save button's dirty gate honest.
+  # All three are purely client-display; the persisted values only ever change
+  # through "save-settings".
   #
   # Rebuilt from `params` rather than by patching one key, so anything already
   # typed into `home_system_id` / `route_max_jumps` is preserved instead of
   # being reset to the last-saved record on every tick. This form carries no
   # `webhook_url`, so #130's credential-blanking step has nothing to do here.
-  def handle_event("route-form-change", %{"notification" => params}, socket) do
+  def handle_event("settings-change", %{"notification" => params}, socket) do
     rec = socket.assigns.notification
 
     dirty? =
-      changed?(params, "route_alerts_enabled", rec.route_alerts_enabled?, &checked?/1) or
-        changed?(params, "home_system_id", rec.home_system_id, &parse_home_system_id/1) or
-        changed?(params, "route_max_jumps", rec.route_max_jumps, &parse_route_max_jumps/1)
+      changed?(params, "route_alerts_enabled", current_route_alerts?(rec), &checked?/1) or
+        changed?(params, "home_system_id", current_home_system_id(rec), &parse_home_system_id/1) or
+        changed?(
+          params,
+          "route_max_jumps",
+          current_route_max_jumps(rec),
+          &parse_route_max_jumps/1
+        )
 
     {:noreply,
      socket
      |> assign(:route_toggle, checked?(params["route_alerts_enabled"]))
-     |> assign(:route_form, rebuild_form(params, route_form_values(rec)))
-     |> assign(:dirty, Map.put(socket.assigns.dirty, :route, dirty?))}
-  end
-
-  # The inline remedy on the "switched off, but this channel is configured"
-  # warning (D4.2): saves immediately rather than only flipping the unsaved
-  # checkbox, because the warning exists precisely because a config can sit in
-  # this state indefinitely without anyone pressing Save. If `home_system_id`
-  # is nil the Ash "required when enabled" validation fires and lands in the
-  # route panel — that is correct, not a bug: enabling from here does not
-  # bypass the same validation the settings form is subject to.
-  def handle_event("enable-route-alerts", _params, socket) do
-    case socket.assigns.notification do
-      nil ->
-        {:noreply, socket}
-
-      rec ->
-        case MapDiscordNotification.update(rec, %{route_alerts_enabled?: true}) do
-          {:ok, updated} ->
-            {:noreply,
-             socket
-             |> assign_notification(updated)
-             |> put_message(:route, :info, "Route alerts enabled.")}
-
-          {:error, error} ->
-            {:noreply, put_message(socket, :route, :error, humanize_error(error))}
-        end
-    end
+     |> assign(:settings_form, rebuild_form(params, route_form_values(rec)))
+     |> assign(:dirty, dirty?)}
   end
 
   # --- Webhook destinations (system / character / route rows) ------------
+
+  def handle_event("toggle-section", %{"section" => section}, socket) do
+    open = socket.assigns.open_sections
+
+    open =
+      if MapSet.member?(open, section),
+        do: MapSet.delete(open, section),
+        else: MapSet.put(open, section)
+
+    {:noreply, assign(socket, :open_sections, open)}
+  end
 
   def handle_event("replace-url", %{"role" => role}, socket) do
     {:noreply, put_replacing(socket, parse_role(role), true)}
@@ -311,51 +315,56 @@ defmodule WandererAppWeb.MapNotificationsComponent do
     {:noreply, put_replacing(socket, parse_role(role), false)}
   end
 
+  # Creates the policy row on demand. Any destination can be the first one
+  # configured on a map — including `:route`, which is the whole point of the
+  # resource's `webhook_url` argument having become optional. Before that, the
+  # only way to reach this screen's route half was to configure a kill channel
+  # you might not want.
   def handle_event("save-webhook", %{"role" => role, "webhook" => params}, socket) do
     role = parse_role(role)
-    scope = webhook_scope(role)
 
-    with %{} = rec <- socket.assigns.notification,
+    with {:ok, rec} <- ensure_notification(socket),
          {:ok, _} <- save_webhook(rec, socket.assigns.webhooks[role], role, params) do
       {:noreply,
        socket
        |> assign_notification(reload_notification(socket.assigns.map_id))
-       |> put_message(scope, :info, "Saved.")}
+       |> put_message(:info, "Saved.")}
     else
       {:error, error} ->
-        {:noreply, put_message(socket, scope, :error, humanize_error(error))}
-
-      _ ->
-        {:noreply,
-         put_message(socket, scope, :error, "Save the map's notification settings first.")}
+        {:noreply, put_message(socket, :error, humanize_error(error))}
     end
   end
 
   def handle_event("remove-webhook", %{"role" => role}, socket) do
-    # `:character` and `:route` are removable; `:system` is required —
-    # removing notifications entirely means deleting the parent record.
+    # All three destinations are removable. `:system` used to be exempt on the
+    # grounds that "removing notifications entirely means deleting the parent
+    # record" — true while a pane-level destroy existed and while `create`
+    # required a kill webhook, and false now that neither does. Leaving it
+    # exempt would have made the kill channel the one destination on the tab
+    # that could be added but never taken away.
+    #
     # Removing `:character` falls back to `:system`; removing `:route` does
     # NOT — route alerts stop entirely, because the Router deliberately has no
-    # fallback for chain topology.
+    # fallback for chain topology. Removing `:system` stops kill delivery for
+    # systems on the map, and `Router.usable/1` drops the destination rather
+    # than routing elsewhere.
     role = parse_role(role)
-    scope = webhook_scope(role)
 
     case {role, socket.assigns.webhooks[role]} do
-      {role, %{} = webhook} when role in [:character, :route] ->
+      {role, %{} = webhook} when role in [:system, :character, :route] ->
         case MapDiscordWebhook.destroy(webhook) do
           :ok ->
             {:noreply,
              socket
              |> assign_notification(reload_notification(socket.assigns.map_id))
-             |> put_message(scope, :info, "#{role_label(role)} destination removed.")}
+             |> put_message(:info, "#{role_label(role)} destination removed.")}
 
           {:error, error} ->
-            {:noreply, put_message(socket, scope, :error, humanize_error(error))}
+            {:noreply, put_message(socket, :error, humanize_error(error))}
         end
 
       _ ->
-        {:noreply,
-         put_message(socket, scope, :error, "The system destination cannot be removed.")}
+        {:noreply, put_message(socket, :error, "That destination is not configured.")}
     end
   end
 
@@ -494,7 +503,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
          {id, ""} <- Integer.parse(to_string(raw)) do
       update_excluded(socket, rec, Enum.uniq([id | rec.excluded_systems]))
     else
-      _ -> {:noreply, put_message(socket, :kills, :error, "Pick a system from the list.")}
+      _ -> {:noreply, put_message(socket, :error, "Pick a system from the list.")}
     end
   end
 
@@ -506,7 +515,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
          {id, ""} <- Integer.parse(to_string(raw)) do
       update_excluded(socket, rec, Enum.reject(rec.excluded_systems, &(&1 == id)))
     else
-      _ -> {:noreply, put_message(socket, :kills, :error, "Could not remove that system.")}
+      _ -> {:noreply, put_message(socket, :error, "Could not remove that system.")}
     end
   end
 
@@ -519,7 +528,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
          {id, ""} <- Integer.parse(to_string(raw)) do
       update_focus_corps(socket, rec, Enum.uniq(rec.focus_corp_ids ++ [id]))
     else
-      _ -> {:noreply, put_message(socket, :kills, :error, "Pick a corporation from the list.")}
+      _ -> {:noreply, put_message(socket, :error, "Pick a corporation from the list.")}
     end
   end
 
@@ -528,24 +537,21 @@ defmodule WandererAppWeb.MapNotificationsComponent do
          {id, ""} <- Integer.parse(to_string(raw)) do
       update_focus_corps(socket, rec, Enum.reject(rec.focus_corp_ids, &(&1 == id)))
     else
-      _ -> {:noreply, put_message(socket, :kills, :error, "Could not remove that corporation.")}
+      _ -> {:noreply, put_message(socket, :error, "Could not remove that corporation.")}
     end
   end
 
   def handle_event("send-test", %{"webhook_id" => webhook_id}, socket) do
-    scope = webhook_scope(role_for_webhook_id(socket.assigns.webhooks, webhook_id))
-
     case send_test(socket, webhook_id) do
       # `:ok` means the message was ENQUEUED — the last hop is an async cast, so
       # this must not claim Discord accepted it.
       :ok ->
-        {:noreply, put_message(socket, scope, :info, "Test message queued.")}
+        {:noreply, put_message(socket, :info, "Test message queued.")}
 
       {:error, :notifications_disabled} ->
         {:noreply,
          put_message(
            socket,
-           scope,
            :error,
            "Discord notifications are disabled on this server. Ask an administrator to enable them."
          )}
@@ -554,7 +560,6 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         {:noreply,
          put_message(
            socket,
-           scope,
            :error,
            "This destination is disabled. Enable it and save before sending a test message."
          )}
@@ -564,7 +569,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
       # but a user can do nothing about either except save a URL, and this
       # wording is brief-mandated verbatim.
       {:error, reason} when reason in [:webhook_not_found, :webhook_url_missing] ->
-        {:noreply, put_message(socket, scope, :error, "Save a webhook URL first.")}
+        {:noreply, put_message(socket, :error, "Save a webhook URL first.")}
 
       {:error, other} ->
         # `inspect(other)` here put the raw failure term — which can carry the
@@ -574,34 +579,24 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         {:noreply,
          put_message(
            socket,
-           scope,
            :error,
            "Could not send a test message. Check the webhook URL and try again."
          )}
     end
   end
 
-  def handle_event("delete", _params, socket) do
-    case socket.assigns.notification do
-      nil ->
-        {:noreply, socket}
+  # There is deliberately no "remove everything" event. Each destination has its
+  # own Remove, and a policy row with no destinations delivers nothing — so the
+  # only thing a wholesale destroy did that the per-row removes do not was
+  # discard invisible filter and mention state, at the cost of parking the
+  # tab's most destructive control in a permanent action bar.
 
-      rec ->
-        # The resource's custom destroy invalidates the config cache and stops
-        # the delivery workers; the webhook children cascade with the parent.
-        case WandererApp.Api.MapDiscordNotification.destroy(rec) do
-          :ok ->
-            {:noreply,
-             socket |> assign_notification(nil) |> put_message(:kills, :info, "Removed.")}
-
-          {:error, error} ->
-            {:noreply, put_message(socket, :kills, :error, humanize_error(error))}
-        end
-    end
-  end
-
-  defp put_message(socket, scope, kind, text) do
-    assign(socket, :message, %{scope: scope, kind: kind, text: text})
+  # One message region for the whole pane, at its foot. It used to be two
+  # (`scope: :kills | :route`), which only made sense while the tab had a Save
+  # per section and the two sections were far enough apart that a result had to
+  # land next to the control that produced it.
+  defp put_message(socket, kind, text) do
+    assign(socket, :message, %{kind: kind, text: text})
   end
 
   # `webhook_id` arrives from the client as `phx-value-webhook_id`, and
@@ -627,24 +622,6 @@ defmodule WandererAppWeb.MapNotificationsComponent do
       _webhook -> WandererApp.ExternalEvents.DiscordDispatcher.send_test_message(webhook_id)
     end
   end
-
-  # Which role a webhook id belongs to, so a message produced by "send-test"
-  # (which only receives the id) lands in the panel that contains that
-  # destination. `nil` (id not found / not yet known) falls back to the kills
-  # panel — every send-test button is reachable from a row that lives inside
-  # either the kills card or one of its disclosures, and the kills panel is
-  # the only one always on screen.
-  defp role_for_webhook_id(webhooks, webhook_id) do
-    Enum.find_value(webhooks, fn {role, wh} -> match?(%{id: ^webhook_id}, wh) && role end)
-  end
-
-  # Maps a destination to the message panel that contains it (D2): a
-  # channel's own save/test/remove result must land where the user is looking,
-  # not at the top of a two-thousand-pixel page.
-  defp webhook_scope(:system), do: :kills
-  defp webhook_scope(:character), do: :kills
-  defp webhook_scope(:route), do: :route
-  defp webhook_scope(nil), do: :kills
 
   # `mention_targets` is deliberately absent from every branch here. It left
   # this form in D3 and is now chip state saved by its own events — passing it
@@ -678,20 +655,36 @@ defmodule WandererAppWeb.MapNotificationsComponent do
     MapDiscordWebhook.update(webhook, %{enabled?: checked?(params["enabled"])})
   end
 
-  # Creating the config and its required `:system` destination is one user
-  # action. Task 2's `create` takes `webhook_url` as a required argument and
-  # creates the `:system` child through `manage_relationship` in the SAME
-  # transaction, so there is no window in which a parent exists without a
-  # destination. Do not split this into two calls with a compensating cleanup:
-  # the two-step version fails outright (`create` rejects a missing
-  # `webhook_url`) and its explicit child create would collide with Task 1's
-  # (notification_id, role) identity.
-  defp create_with_system_webhook(map_id, attrs, url) do
-    attrs
-    |> Map.put(:map_id, map_id)
-    |> Map.put(:webhook_url, url)
-    |> MapDiscordNotification.create()
+  # Every write on this tab funnels through here: the policy row is created
+  # lazily by whichever control the operator touched first, with no webhook
+  # attached. `create`'s `webhook_url` argument is optional for exactly this
+  # (map_discord_notification.ex) — the destinations are then added through
+  # "save-webhook" like any later one.
+  defp upsert(socket, attrs) do
+    case socket.assigns.notification do
+      nil -> attrs |> Map.put(:map_id, socket.assigns.map_id) |> MapDiscordNotification.create()
+      rec -> MapDiscordNotification.update(rec, attrs)
+    end
   end
+
+  defp ensure_notification(socket) do
+    case socket.assigns.notification do
+      nil -> MapDiscordNotification.create(%{map_id: socket.assigns.map_id})
+      rec -> {:ok, rec}
+    end
+  end
+
+  # Record-or-default readers, so the dirty gate and the form values work the
+  # same before and after the policy row exists. Each mirrors the resource's
+  # own default for the attribute.
+  defp current_route_alerts?(nil), do: false
+  defp current_route_alerts?(%{route_alerts_enabled?: value}), do: value
+
+  defp current_home_system_id(nil), do: nil
+  defp current_home_system_id(%{home_system_id: value}), do: value
+
+  defp current_route_max_jumps(nil), do: @default_route_max_jumps
+  defp current_route_max_jumps(%{route_max_jumps: value}), do: value
 
   defp put_replacing(socket, role, value) do
     assign(socket, :replacing_url?, Map.put(socket.assigns.replacing_url?, role, value))
@@ -727,7 +720,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         {:noreply, assign_notification(socket, updated)}
 
       {:error, error} ->
-        {:noreply, put_message(socket, :kills, :error, humanize_error(error))}
+        {:noreply, put_message(socket, :error, humanize_error(error))}
     end
   end
 
@@ -737,7 +730,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         {:noreply, assign_notification(socket, updated)}
 
       {:error, error} ->
-        {:noreply, put_message(socket, :kills, :error, humanize_error(error))}
+        {:noreply, put_message(socket, :error, humanize_error(error))}
     end
   end
 
@@ -785,13 +778,13 @@ defmodule WandererAppWeb.MapNotificationsComponent do
     |> assign(:notification, notification)
     |> assign(:webhooks, webhooks)
     |> assign(:collisions, ChannelInfo.colliding_roles(webhooks))
-    |> assign(:route_toggle, !is_nil(notification) and notification.route_alerts_enabled?)
-    |> assign(:dirty, %{kills: false, route: false})
+    |> assign(:route_toggle, current_route_alerts?(notification))
+    |> assign(:dirty, false)
     |> assign(:excluded_systems, excluded_system_labels(notification))
     |> assign(:focus_corps, focus_corp_labels(notification))
     |> assign(:home_system_options, home_system_options(notification))
-    |> assign(:form, kills_form(notification))
-    |> assign(:route_form, route_form(notification))
+    |> assign(:kills_form, kills_form(notification))
+    |> assign(:settings_form, route_form(notification))
     |> assign(:webhook_forms, webhook_forms(webhooks))
     |> assign(:excluded_form, to_form(%{"excluded_system" => nil}, as: :excluded))
     |> assign(:focus_corp_form, to_form(%{"focus_corp" => nil}, as: :focus_corp))
@@ -902,16 +895,23 @@ defmodule WandererAppWeb.MapNotificationsComponent do
 
   defp mention_picker_available?(_assigns), do: true
 
+  # Every one of these is read by an operator who is mid-task and wants to know
+  # whether they can proceed. So each says what still works (typing ids always
+  # does), and the one with an actionable cause names it: searching by name
+  # needs a bot token, `DISCORD_BOT_TOKEN`, set on the server — which is a
+  # deployment change, not something this screen can offer a button for.
   defp mention_unavailable_reason(%{guild_roles: {:error, :no_bot_token}}),
-    do: "This instance has no Discord bot configured, so names cannot be searched."
+    do:
+      "Searching Discord names needs a bot token (DISCORD_BOT_TOKEN) on the server, and this " <>
+        "one has none. Mentions still work — paste the user or role id instead."
 
   defp mention_unavailable_reason(%{guild_roles: {:error, :no_guild}}),
     do:
-      "The guild for this channel is not known yet. It resolves once the bot can see the " <>
-        "channel; until then, add ids manually."
+      "The Discord server behind this channel is not known yet. It resolves once the bot can " <>
+        "see the channel; until then, paste ids instead."
 
   defp mention_unavailable_reason(%{guild_roles: {:error, _reason}}),
-    do: "Add the bot to this guild to search names."
+    do: "The bot cannot read this Discord server, so names cannot be searched. Paste ids instead."
 
   defp mention_unavailable_reason(_assigns), do: nil
 
@@ -970,7 +970,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
     case socket.assigns.webhooks[:route] do
       nil ->
         {:noreply,
-         put_message(socket, :route, :error, "Add a route alert channel before setting mentions.")}
+         put_message(socket, :error, "Add a route alert channel before setting mentions.")}
 
       webhook ->
         targets =
@@ -984,7 +984,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
              |> assign(:mention_error, nil)}
 
           {:error, error} ->
-            {:noreply, put_message(socket, :route, :error, humanize_error(error))}
+            {:noreply, put_message(socket, :error, humanize_error(error))}
         end
     end
   end
@@ -1017,16 +1017,14 @@ defmodule WandererAppWeb.MapNotificationsComponent do
     end
   end
 
-  # A destination with no stored URL is always in "replace" (i.e. entry) mode;
-  # one with a URL starts masked. Recomputed on every record change so that
-  # saving a URL collapses the field back to the masked hint.
-  defp assign_replacing(socket, webhooks) do
-    replacing =
-      Map.new(@roles, fn role ->
-        {role, is_nil(Map.get(webhooks, role))}
-      end)
-
-    assign(socket, :replacing_url?, replacing)
+  # A destination is in entry mode only when the operator asked for it, via
+  # "Add" (no webhook yet) or "Edit" (replacing a stored URL). It used to open
+  # automatically for every unconfigured role, which was invisible while the
+  # character and route rows were themselves hidden behind a link and a
+  # disclosure. Now that all three rows always render, auto-opening would put
+  # three credential fields on screen before the operator has asked for one.
+  defp assign_replacing(socket, _webhooks) do
+    assign(socket, :replacing_url?, Map.new(@roles, &{&1, false}))
   end
 
   defp load_webhooks(nil), do: %{system: nil, character: nil, route: nil}
@@ -1064,15 +1062,17 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   defp rebuild_form(params, base) do
     base
     |> Map.merge(params)
-    |> Map.put("webhook_url", "")
     |> to_form(as: :notification)
   end
 
   defp kills_form(notification), do: to_form(kills_form_values(notification), as: :notification)
 
+  # No `webhook_url` here any more. It existed for the old "no record yet"
+  # create form, which asked for a kill webhook before the tab would show
+  # anything else. Destinations are now added through their own rows, at any
+  # time, in any order.
   defp kills_form_values(notification) do
     %{
-      "webhook_url" => "",
       "enabled" => is_nil(notification) or notification.enabled?,
       "wh_only" => is_nil(notification) or notification.wh_only
     }
@@ -1085,18 +1085,15 @@ defmodule WandererAppWeb.MapNotificationsComponent do
       # Unlike wh_only/enabled, this one defaults OFF (Task 3: `default:
       # false`) — `is_nil(notification) or ...` would default it ON, which
       # is backwards for this field.
-      "route_alerts_enabled" => !is_nil(notification) and notification.route_alerts_enabled?,
+      "route_alerts_enabled" => current_route_alerts?(notification),
       "home_system_id" => home_system_id_value(notification),
-      "route_max_jumps" => route_max_jumps_value(notification)
+      "route_max_jumps" => current_route_max_jumps(notification)
     }
   end
 
   defp home_system_id_value(nil), do: ""
   defp home_system_id_value(%{home_system_id: nil}), do: ""
   defp home_system_id_value(%{home_system_id: id}), do: to_string(id)
-
-  defp route_max_jumps_value(nil), do: @default_route_max_jumps
-  defp route_max_jumps_value(%{route_max_jumps: n}), do: n
 
   # Blank or non-numeric input clears the home system rather than raising —
   # the Ash "required when enabled" validation is what reports that, not this
@@ -1106,20 +1103,6 @@ defmodule WandererAppWeb.MapNotificationsComponent do
     case Integer.parse(to_string(raw || "")) do
       {id, ""} -> id
       _ -> nil
-    end
-  end
-
-  defp save_route(socket, rec, params) do
-    case MapDiscordNotification.update(rec, notification_attrs(params)) do
-      {:ok, updated} ->
-        {:noreply,
-         socket
-         |> assign_notification(updated)
-         |> assign(:home_system_error, nil)
-         |> put_message(:route, :info, "Saved.")}
-
-      {:error, error} ->
-        {:noreply, put_message(socket, :route, :error, humanize_error(error))}
     end
   end
 
@@ -1477,43 +1460,14 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   # the channel's own "#name", and the fallback is a truncated non-reversible
   # digest that is never derived from the token.
   #
-  # D4: the label alone cannot say what it IS. `#kills` read off the channel and
-  # `#kills` typed as a webhook's nickname are the same string, and only
-  # `source` separates them — labelling the second one "Channel:" is the bug
-  # this rework exists partly to fix. So the two prefixes are only ever spoken
-  # when the source earns them, and `:unknown` (a row written before the source
-  # column existed) and `:masked` make no claim at all.
-  #
-  # Returns `{sentence_case_prefix, lowercase_word, label}` — the two forms the
-  # label appears in, "Channel: #kills" in the row and "Posting to channel
-  # #kills" in the status line, resolved once so they cannot drift apart.
-  defp identity_parts(%{label: label, source: :channel}) when is_binary(label),
-    do: {"Channel", "channel", label}
-
-  defp identity_parts(%{label: label, source: :webhook_name}) when is_binary(label),
-    do: {"Webhook", "webhook", label}
-
-  defp identity_parts(%{label: label}) when is_binary(label), do: {nil, nil, label}
-  defp identity_parts(_no_info), do: nil
-
-  defp channel_identity(info) do
-    case identity_parts(info) do
-      {nil, _word, label} -> label
-      {prefix, _word, label} -> "#{prefix}: #{label}"
-      nil -> nil
-    end
-  end
-
-  defp posting_to(info) do
-    case identity_parts(info) do
-      {_prefix, nil, label} -> label
-      {_prefix, word, label} -> "#{word} #{label}"
-      nil -> nil
-    end
-  end
-
-  defp webhook_named?(%{source: :webhook_name}), do: true
-  defp webhook_named?(_info), do: false
+  # The label is spoken plainly, with no "Channel:" / "Webhook:" prefix. Whether
+  # Discord answered from the channel or from the webhook's own nickname is a
+  # distinction about how the name was *fetched*, not about where the messages
+  # land — and the operator has nothing to do differently either way. `source`
+  # is still persisted (`channel_label_source`) because it separates a masked
+  # fingerprint from a known name, which is what `masked?` below turns on.
+  defp channel_label(%{label: label}) when is_binary(label), do: label
+  defp channel_label(_no_info), do: nil
 
   # Roles whose destination resolves to the same Discord channel as `role`.
   # `ChannelInfo.colliding_roles/1` groups on the resolved `channel_id` where it
@@ -1581,7 +1535,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   # channel was deleted, a refresh still in flight) for that to be the common
   # first impression rather than an edge case.
   defp status_line(webhook, channel_info) do
-    case posting_to(channel_info) do
+    case channel_label(channel_info) do
       nil -> last_kill_text(webhook)
       destination -> "Posting to #{destination} · #{last_kill_text(webhook)}"
     end
@@ -1642,35 +1596,26 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   defp focus_corp_count_label(1), do: "1 corporation"
   defp focus_corp_count_label(n), do: "#{n} corporations"
 
-  # Never collapse a problem (D5). Under D2 that is enforced by *placement*
-  # rather than by an initial-state computation: every save/test result renders
-  # in its card's message region, which is never inside a disclosure, and the
-  # one remaining disclosure badges its own trouble. The `filters_expanded?/7`
-  # and `route_expanded?/3` predicates this used to need are gone with it.
-  defp route_badge(nil, _route_webhook), do: "Off"
-
-  defp route_badge(%{route_alerts_enabled?: true}, route_webhook) do
-    if route_destination_ready?(route_webhook), do: "On", else: "On — no channel ready"
-  end
-
-  defp route_badge(%{route_alerts_enabled?: false}, route_webhook) do
-    if route_destination_ready?(route_webhook), do: "Off — channel configured", else: "Off"
-  end
-
   # --- Function components ---------------------------------------------
 
-  # D5's disclosure mechanism: client-side only (`JS.toggle_class`), following
-  # the one existing precedent in the app
-  # (characters_live.html.heex:92) rather than inventing a parallel pattern or
-  # round-tripping open/closed state through the server.
+  # Open/closed lives in `@open_sections` on the server, not in a
+  # `JS.toggle_class` on the client. The client-only version was the pattern
+  # copied from characters_live.html.heex, and it is wrong for this panel: every
+  # save, every background channel-identity refresh and every PubSub-driven
+  # re-render re-sends this markup with its literal `hidden` and its literal
+  # `aria-expanded="false"`, slamming an open section shut mid-edit and leaving
+  # the toggled attribute claiming the opposite of what is on screen. Round-trip
+  # cost is one small diff; the alternative is state that silently desyncs.
   #
-  # Always starts collapsed (D2). It used to start open whenever its body held
-  # a problem, which made the initial state depend on transient message state;
-  # the cause is gone instead — results render in a card-level message region
-  # that is never collapsed, and `@badge` reports trouble inside the body.
+  # Sections start collapsed. They used to start open whenever the body held a
+  # problem, which made the initial state depend on transient message state; the
+  # cause is gone instead — results render in a card-level message region that
+  # is never collapsed, and `@badge` reports trouble inside the body.
   attr :id, :string, required: true
   attr :title, :string, required: true
   attr :badge, :string, default: nil
+  attr :open?, :boolean, default: false
+  attr :myself, :any, required: true
   slot :inner_block, required: true
 
   defp disclosure(assigns) do
@@ -1678,17 +1623,18 @@ defmodule WandererAppWeb.MapNotificationsComponent do
     <div class="rounded border border-white/10">
       <button
         type="button"
-        aria-expanded="false"
+        aria-expanded={to_string(@open?)}
         aria-controls={"#{@id}-body"}
-        phx-click={
-          JS.toggle_class("hidden", to: "##{@id}-body")
-          |> JS.toggle_class("rotate-90", to: "##{@id}-caret")
-          |> JS.toggle_attribute({"aria-expanded", "true", "false"})
-        }
+        phx-click="toggle-section"
+        phx-value-section={@id}
+        phx-target={@myself}
         class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left"
       >
         <span class="flex items-center gap-2 text-sm font-semibold">
-          <span id={"#{@id}-caret"} aria-hidden="true" class="inline-block transition-transform">
+          <span
+            aria-hidden="true"
+            class={["inline-block transition-transform", @open? && "rotate-90"]}
+          >
             ▸
           </span>
           {@title}
@@ -1696,31 +1642,35 @@ defmodule WandererAppWeb.MapNotificationsComponent do
         <span :if={@badge} class="text-xs opacity-70">{@badge}</span>
       </button>
 
-      <div id={"#{@id}-body"} class="hidden flex-col gap-3 border-t border-white/10 p-3">
+      <%!-- Toggled by class, not by `:if`: `aria-controls` above must resolve
+            to a real element even while collapsed, and the LiveSelect hooks
+            inside these bodies would be destroyed and re-mounted if the markup
+            left the DOM. The `hidden` class rather than the HTML attribute,
+            because a utility-layer `flex` would win over preflight's
+            `[hidden] { display: none }`. --%>
+      <div
+        id={"#{@id}-body"}
+        class={[
+          "flex-col gap-3 border-t border-white/10 p-3",
+          if(@open?, do: "flex", else: "hidden")
+        ]}
+      >
         {render_slot(@inner_block)}
       </div>
     </div>
     """
   end
 
-  # D2's per-panel flash: one `@message` assign shaped
-  # `%{scope:, kind:, text:}`, rendered once per panel via `scope`. Only the
-  # panel that matches `@message.scope` ever shows anything, so a save on one
-  # channel cannot be mistaken for a save on another.
+  # One message region for the whole tab, at its foot. It used to be two, keyed
+  # by a `scope` on the message — which only made sense while the tab had a Save
+  # per section and those sections were far enough apart that a result had to
+  # land next to the control that produced it. Every control now acts where it
+  # stands, so there is one place a result belongs, in view from all of them.
   attr :message, :any, default: nil
-  attr :scope, :atom, required: true
 
-  # The id is load-bearing for the tests: with the filters body permanently
-  # collapsed (D2), "the message rendered" and "the message rendered somewhere
-  # the map owner can see it" are different claims, and only a selector rooted
-  # at the card level can tell them apart.
   defp panel_message(assigns) do
     ~H"""
-    <p
-      :if={@message && @message.scope == @scope}
-      id={"panel-message-#{@scope}"}
-      class={message_class(@message.kind)}
-    >
+    <p :if={@message} id="panel-message" class={message_class(@message.kind)}>
       {@message.text}
     </p>
     """
@@ -1772,16 +1722,20 @@ defmodule WandererAppWeb.MapNotificationsComponent do
 
   attr :role, :atom, required: true
   attr :title, :string, required: true
-  attr :help, :string, required: true
+  # Why an operator would want this destination, in one line. Shown whenever
+  # the row is not configured — the state in which that question is actually
+  # being asked — and while editing, where it explains what is being replaced.
+  # Suppressed on a configured, closed row, where the channel name on the same
+  # line already answers it.
+  attr :help, :string, default: nil
   attr :webhook, :any, required: true
   attr :form, :any, required: true
   attr :replacing?, :boolean, required: true
   attr :removable?, :boolean, required: true
-  # The system row's own delivery status is promoted to the card level (P1
+  # The kill row's delivery status is promoted to the card level (P1
   # hierarchy) — the status line and failure line live just above this
-  # component in L1, so repeating them here would be the exact "identical to
-  # the help text above it" problem being fixed. Character/route rows have no
-  # card-level equivalent and keep their own status block.
+  # component, so repeating them here would be the exact "identical to the help
+  # text above it" problem being fixed. The other rows keep their own status.
   attr :show_status?, :boolean, default: true
   # What the status block says when nothing has ever been delivered. The
   # default is the kill wording because two of the three rows are kill
@@ -1796,112 +1750,128 @@ defmodule WandererAppWeb.MapNotificationsComponent do
 
   defp webhook_row(assigns) do
     ~H"""
-    <div id={"webhook-row-#{@role}"} class="flex flex-col gap-2">
-      <h4 class="text-sm font-semibold">{@title}</h4>
-      <p class="text-xs opacity-70">{@help}</p>
+    <div id={"webhook-row-#{@role}"} class="flex flex-col gap-1">
+      <%!-- Closed — configured or not. One line of truth: what this row is,
+            where it posts (or that it does not), whether that is working, and
+            the one control that opens everything else. The URL field, the
+            enabled toggle, Save, test and remove all live behind Edit/Add,
+            because none of them describe the current state and all of them
+            cost vertical space on every render of a tab that already does not
+            fit.
+
+            An unconfigured row renders here too, rather than opening its form
+            on sight. All three destinations are always listed now, and three
+            credential fields on arrival is not an introduction to a feature —
+            it is a form nobody asked for.
+
+            A degraded or disabled destination still says so here rather than
+            auto-expanding: expanding would put a credential field on screen
+            unasked, and the operator needs to read the fault before deciding
+            to touch the URL. --%>
+      <div :if={!@replacing?} class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+        <h4 class="text-sm font-semibold">{@title}</h4>
+
+        <span :if={@webhook && channel_label(@channel_info)} class="text-sm opacity-70">
+          {channel_label(@channel_info)}
+        </span>
+        <span :if={is_nil(@webhook)} class="text-sm opacity-50">Not set</span>
+
+        <span
+          :if={@webhook && @show_status?}
+          class={["text-xs font-semibold", status_class(status_state(@webhook))]}
+        >
+          ● {status_label(status_state(@webhook))}
+        </span>
+
+        <.button
+          type="button"
+          variant={:ghost}
+          phx-click="replace-url"
+          phx-value-role={@role}
+          phx-target={@myself}
+        >
+          {if @webhook, do: "Edit", else: "Add"}
+        </.button>
+      </div>
+
+      <p
+        :if={@webhook && !@replacing? && @show_status? && @webhook.last_error}
+        class="text-sm text-amber-400"
+      >
+        Last error: {@webhook.last_error}
+        <span :if={@webhook.consecutive_failures > 0}>
+          ({@webhook.consecutive_failures} consecutive failures)
+        </span>
+      </p>
+
+      <p :if={@help && (is_nil(@webhook) || @replacing?)} class="text-xs opacity-70">{@help}</p>
 
       <.form
         :let={wf}
+        :if={@replacing?}
         for={@form}
         id={"webhook-form-#{@role}"}
         phx-submit="save-webhook"
         phx-value-role={@role}
         phx-target={@myself}
-        class="flex flex-col gap-2"
+        class="flex flex-col gap-2 pt-1"
       >
         <.input
-          :if={@replacing?}
           field={wf[:webhook_url]}
           type="password"
           label="Discord webhook URL"
-          placeholder="https://discord.com/api/webhooks/..."
+          placeholder={
+            if @webhook,
+              do: "Leave blank to keep the current URL",
+              else: "https://discord.com/api/webhooks/..."
+          }
           autocomplete="off"
         />
 
-        <div :if={!@replacing? && @webhook} class="flex flex-col gap-1">
-          <div class="flex items-center gap-2">
-            <span class="text-sm opacity-70">{channel_identity(@channel_info)}</span>
-            <.button
-              type="button"
-              variant={:ghost}
-              phx-click="replace-url"
-              phx-value-role={@role}
-              phx-target={@myself}
-            >
-              Edit
-            </.button>
-          </div>
-
-          <%!-- Why this destination is named after a webhook rather than a
-                channel. Without it, "Webhook: Zoo Killfeed" looks like a
-                different kind of destination instead of the same one with a
-                weaker answer. --%>
-          <p :if={webhook_named?(@channel_info)} class="text-xs opacity-70">
-            This is the webhook's own name. Discord only tells us the channel name when
-            this instance's bot is in that server.
-          </p>
-        </div>
-
-        <.button
-          :if={@replacing? && @webhook}
-          type="button"
-          variant={:ghost}
-          class="self-start"
-          phx-click="cancel-replace"
-          phx-value-role={@role}
-          phx-target={@myself}
-        >
-          Cancel
-        </.button>
-
         <.input :if={@webhook} field={wf[:enabled]} type="checkbox" label="Enabled" />
 
-        <.button type="submit" variant={:primary} class="self-start">
-          {if @webhook, do: "Save", else: "Add"}
-        </.button>
-      </.form>
-
-      <div :if={@webhook} class="flex items-center gap-2">
-        <.button
-          type="button"
-          phx-click="send-test"
-          phx-value-webhook_id={@webhook.id}
-          phx-target={@myself}
-        >
-          Send test message
-        </.button>
-        <.button
-          :if={@removable?}
-          type="button"
-          variant={:danger}
-          class="self-start"
-          phx-click="remove-webhook"
-          phx-value-role={@role}
-          phx-target={@myself}
-          data-confirm="Remove this Discord destination?"
-        >
-          Remove
-        </.button>
-      </div>
-
-      <div :if={@webhook && @show_status?} class="flex flex-col gap-1 text-sm">
-        <span :if={@webhook.last_delivery_at} class="opacity-70">
-          Last delivered: {Calendar.strftime(@webhook.last_delivery_at, "%Y-%m-%d %H:%M UTC")}
-        </span>
-        <span :if={is_nil(@webhook.last_delivery_at)} class="opacity-70">
-          {@empty_status_text}
-        </span>
-
-        <span :if={@webhook.last_error} class="text-amber-400">
-          Last error: {@webhook.last_error}
-          <span :if={@webhook.consecutive_failures > 0}>
-            ({@webhook.consecutive_failures} consecutive failures)
+        <div :if={@webhook} class="text-sm opacity-70">
+          <span :if={@webhook.last_delivery_at}>
+            Last delivered: {Calendar.strftime(@webhook.last_delivery_at, "%Y-%m-%d %H:%M UTC")}
           </span>
-        </span>
-        <span :if={!@webhook.enabled?} class="text-amber-400">
-          This destination is disabled and is not delivering.
-        </span>
-      </div>
+          <span :if={is_nil(@webhook.last_delivery_at)}>{@empty_status_text}</span>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-2">
+          <.button type="submit" variant={:primary}>
+            {if @webhook, do: "Save", else: "Add"}
+          </.button>
+          <.button
+            type="button"
+            variant={:ghost}
+            phx-click="cancel-replace"
+            phx-value-role={@role}
+            phx-target={@myself}
+          >
+            Cancel
+          </.button>
+          <.button
+            :if={@webhook}
+            type="button"
+            phx-click="send-test"
+            phx-value-webhook_id={@webhook.id}
+            phx-target={@myself}
+          >
+            Send test message
+          </.button>
+          <.button
+            :if={@webhook && @removable?}
+            type="button"
+            variant={:danger}
+            phx-click="remove-webhook"
+            phx-value-role={@role}
+            phx-target={@myself}
+            data-confirm="Remove this Discord destination?"
+          >
+            Remove
+          </.button>
+        </div>
+      </.form>
     </div>
     """
   end
@@ -1926,13 +1896,12 @@ defmodule WandererAppWeb.MapNotificationsComponent do
 
   defp mentions_section(assigns) do
     ~H"""
-    <div id="route-mentions" class="flex flex-col gap-3 rounded border border-white/10 p-3">
-      <div>
-        <h4 class="text-sm font-semibold">Mentions</h4>
-        <p class="text-xs opacity-70">
-          Who to ping when a route opens. Leave both empty to post with no ping.
-        </p>
-      </div>
+    <div id="route-mentions" class="flex flex-col gap-3">
+      <%!-- No heading or border of its own: this now renders inside the
+            "Mentions" disclosure, which supplies both. --%>
+      <p class="text-xs opacity-70">
+        Who to ping when a route opens. Leave both empty to post with no ping.
+      </p>
 
       <.mention_group
         kind={:role}
@@ -2078,34 +2047,27 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   attr :notification, :any, required: true
   attr :webhooks, :any, required: true
   attr :route_toggle, :boolean, required: true
-  attr :myself, :any, required: true
 
-  # D4's reachable warning, rendered at card level OUTSIDE either disclosure so
-  # a configured-but-inert route destination is visible without opening
-  # anything. Both halves of the "disable, don't hide" fix live here: the
-  # alerts-on-but-no-channel case is the pre-existing guard made reachable at
-  # all times, and the alerts-off-but-configured case is the P0 this rework
-  # was written for.
+  # D4's reachable warning: both halves of "disable, don't hide". The
+  # alerts-on-but-no-channel case is the pre-existing guard; the
+  # alerts-off-but-configured case is the P0 this rework was written for.
+  #
+  # Neither carries an action button any more. "Enable route alerts" was a
+  # second, differently-shaped control for a checkbox that is now three lines
+  # away and always visible — two places to do one thing, one of which
+  # committed immediately while the other waited for Save.
   defp route_alert_banner(assigns) do
     ~H"""
     <p
       :if={route_alert_on_no_channel?(@notification, @webhooks[:route], @route_toggle)}
       class="text-sm text-amber-400"
     >
-      Route alerts are on, but no Route alert channel is ready — nothing is being sent.
+      Route alerts are on, but no route alert channel is ready — nothing is being sent.
     </p>
 
-    <div
-      :if={route_inert?(@notification, @webhooks[:route])}
-      class="flex items-center gap-2 text-sm text-amber-400"
-    >
-      <span>
-        Route alerts are switched off, but this channel is configured — nothing is being sent to it.
-      </span>
-      <.button type="button" phx-click="enable-route-alerts" phx-target={@myself}>
-        Enable route alerts
-      </.button>
-    </div>
+    <p :if={route_inert?(@notification, @webhooks[:route])} class="text-sm text-amber-400">
+      Route alerts are switched off, but this channel is configured — nothing is being sent to it.
+    </p>
     """
   end
 
@@ -2113,292 +2075,258 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   def render(assigns) do
     ~H"""
     <div id={@id} class="flex max-w-3xl flex-col gap-4">
-      <p class="text-sm opacity-70">
-        Posts kills to Discord, and optionally alerts when a highsec route to Jita
-        opens. The kill filters below are separate from the Kills widget's own
-        filters, which are per-user and only affect what you see in the map UI —
-        and they do not apply to route alerts.
-      </p>
-
-      <div :if={is_nil(@notification)} class="flex flex-col gap-3 rounded border border-white/10 p-3">
-        <h3 class="text-base font-semibold">Kill notifications</h3>
-
-        <.panel_message message={@message} scope={:kills} />
-
-        <.form
-          :let={f}
-          for={@form}
-          id="discord-notification-form"
-          phx-submit="save"
-          phx-target={@myself}
-          class="flex flex-col gap-3"
-        >
-          <.input
-            field={f[:webhook_url]}
-            type="password"
-            label="Discord webhook URL"
-            placeholder="https://discord.com/api/webhooks/..."
-            autocomplete="off"
-          />
-
-          <.button type="submit" variant={:primary} class="self-start">Connect</.button>
-        </.form>
-      </div>
-
-      <div :if={@notification} class="flex flex-col gap-3 rounded border border-white/10 p-3">
-        <div class="flex items-center justify-between gap-2">
+      <%!-- One card, two subsections, no global controls. There is no longer a
+            separate "no record yet" screen asking for a kill webhook before
+            anything else appears: kills and route alerts are independent
+            features that happen to share a policy row, and gating the second
+            on the first made an implementation detail into a setup step. The
+            row is created lazily by whichever control is touched first (see
+            `upsert/2`). --%>
+      <div class="flex flex-col gap-4 rounded border border-white/10 p-3">
+        <div class="flex flex-col gap-3">
           <h3 class="text-base font-semibold">Kill notifications</h3>
-          <span class={["text-xs font-semibold", status_class(status_state(@webhooks[:system]))]}>
-            ● {status_label(status_state(@webhooks[:system]))}
-          </span>
-        </div>
 
-        <p class="text-sm opacity-70">{status_line(@webhooks[:system], @channel_hints[:system])}</p>
-        <p :if={@webhooks[:system] && @webhooks[:system].last_error} class="text-sm text-amber-400">
-          Last error: {@webhooks[:system].last_error}
-          <span :if={@webhooks[:system].consecutive_failures > 0}>
-            ({@webhooks[:system].consecutive_failures} consecutive failures)
-          </span>
-        </p>
-        <.collision_warning role={:system} collisions={@collisions} />
+          <%!-- The two switches sit ABOVE both destination rows, because they
+                govern both. Underneath the character row — where they used to
+                be — they read as that row's settings, which is exactly
+                backwards for "Send kill notifications": it is the map-level
+                master switch.
 
-        <.webhook_row
-          role={:system}
-          title="System channel"
-          help="Receives kills that happen in systems on this map."
-          webhook={@webhooks[:system]}
-          channel_info={@channel_hints[:system]}
-          form={@webhook_forms[:system]}
-          replacing?={@replacing_url?[:system]}
-          removable?={false}
-          show_status?={false}
-          myself={@myself}
-        />
-
-        <%!-- Promoted out of the filters disclosure (D1): a delivery
-              destination is a peer of the system channel, not a filter. It
-              still collapses behind one link when absent, because the minimum
-              viable config is a single pasted URL. CSS-only toggle, so the row
-              stays in the DOM and `#webhook-form-character` keeps existing. --%>
-        <button
-          type="button"
-          id="character-channel-toggle"
-          class={[
-            "text-left text-sm underline opacity-80 hover:opacity-100",
-            @webhooks[:character] && "hidden"
-          ]}
-          phx-click={
-            JS.toggle_class("hidden", to: "#character-channel-toggle")
-            |> JS.toggle_class("hidden", to: "#character-channel-body")
-          }
-        >
-          + Add a separate channel
-        </button>
-
-        <div
-          id="character-channel-body"
-          class={["flex flex-col gap-2", is_nil(@webhooks[:character]) && "hidden"]}
-        >
-          <.webhook_row
-            role={:character}
-            title="Character channel"
-            help={
-              "Receives kills involving characters tracked on this map, wherever they happen. " <>
-                "Leave it unset and those kills go to the system channel instead."
-            }
-            webhook={@webhooks[:character]}
-            channel_info={@channel_hints[:character]}
-            form={@webhook_forms[:character]}
-            replacing?={@replacing_url?[:character]}
-            removable?={true}
-            myself={@myself}
-          />
-
-          <.collision_warning role={:character} collisions={@collisions} />
-        </div>
-
-        <.panel_message message={@message} scope={:kills} />
-
-        <.form
-          :let={f}
-          for={@form}
-          id="discord-notification-form"
-          phx-submit="save"
-          phx-change="kills-form-change"
-          phx-target={@myself}
-          class="flex flex-col gap-2"
-        >
-          <%!-- The record-level master switch. It is deliberately still here
-                at L1 and not folded into the per-destination `enabled?` on the
-                webhook rows: this one stops kill notifications for the whole
-                map in one tick, and without it the only way to stop delivery
-                would be "Remove all Discord notifications", which also throws
-                away every filter and channel the user has configured. --%>
-          <.input field={f[:enabled]} type="checkbox" label="Send kill notifications" />
-          <.input field={f[:wh_only]} type="checkbox" label="Only wormhole kills" />
-
-          <.button type="submit" variant={:primary} class="self-start" disabled={not @dirty.kills}>
-            Save
-          </.button>
-        </.form>
-
-        <.disclosure
-          id="filters-disclosure"
-          title="Kill filters"
-          badge={
-            filters_badge(@excluded_systems, @focus_corps, @system_search_error, @corp_search_error)
-          }
-        >
-          <div class="flex flex-col gap-2">
-            <h4 class="text-sm font-semibold">Excluded systems</h4>
-
-            <ul class="flex flex-wrap gap-2">
-              <li :for={{system_id, label} <- @excluded_systems}>
-                <.chip
-                  label={label}
-                  phx-click="remove-excluded"
-                  phx-value-system_id={system_id}
-                  phx-target={@myself}
-                />
-              </li>
-            </ul>
-
-            <%!-- Height matching, without predicting either box: `compact` makes the
-                  field wrapper exactly as tall as its input, `!py-0` drops the
-                  button's vertical padding so its intrinsic height (one line of
-                  text) is always shorter than the input's, and the grid row is
-                  therefore sized by the field. `items-stretch` then gives the
-                  button that exact height. Nothing here depends on the button and
-                  the input agreeing on font size, padding or line-height, which
-                  they do not. --%>
-            <.form
-              :let={ef}
-              for={@excluded_form}
-              id="excluded-system-form"
-              phx-submit="add-excluded"
-              phx-target={@myself}
-              class="grid items-stretch gap-2"
-              style="grid-template-columns: 1fr auto"
-            >
-              <.live_select
-                field={ef[:excluded_system]}
-                id={@excluded_select_id}
-                phx-target={@myself}
-                dropdown_extra_class="!h-24"
-                compact={true}
-                debounce={250}
-                update_min_len={@min_search_length}
-                mode={:single}
-                options={@system_options}
-                placeholder="Search a system by name"
-              />
-              <.button type="submit" class="!py-0 inline-flex items-center justify-center">
-                Add
-              </.button>
-            </.form>
-
-            <p :if={@system_search_error} class="text-sm text-amber-400">{@system_search_error}</p>
-          </div>
-
-          <div class="flex flex-col gap-2">
-            <h4 class="text-sm font-semibold">Corporation filter</h4>
-            <%!-- Two sentences, by D10. The full routing rules — that a
-                  corporation match replaces the tracked-character test rather
-                  than widening it, and bypasses the excluded-system and
-                  wormhole-only filters — are in docs/ZOO-FORK.md under
-                  "Kill filter semantics". A four-sentence paragraph next to an
-                  input is not read; it is scrolled past. --%>
-            <p class="text-xs opacity-70">
-              When set, the character channel follows these corporations instead of this
-              map's tracked characters. Leave it empty to use the tracked characters.
-            </p>
-
-            <ul class="flex flex-wrap gap-2">
-              <li :for={{corp_id, label} <- @focus_corps}>
-                <.chip
-                  label={label}
-                  phx-click="remove-focus-corp"
-                  phx-value-corp_id={corp_id}
-                  phx-target={@myself}
-                />
-              </li>
-            </ul>
-
-            <p :if={@current_user.characters in [nil, []]} class="text-sm text-amber-400">
-              Add a character to this account to search corporations.
-            </p>
-
-            <.form
-              :let={cf}
-              :if={@current_user.characters not in [nil, []]}
-              for={@focus_corp_form}
-              id="focus-corp-form"
-              phx-submit="add-focus-corp"
-              phx-target={@myself}
-              class="grid items-stretch gap-2"
-              style="grid-template-columns: 1fr auto"
-            >
-              <.live_select
-                field={cf[:focus_corp]}
-                id={@focus_corp_select_id}
-                phx-target={@myself}
-                dropdown_extra_class="!h-24"
-                compact={true}
-                debounce={250}
-                update_min_len={@corp_min_search_length}
-                mode={:single}
-                options={@corp_options}
-                placeholder="Search a corporation by name"
-              />
-              <.button type="submit" class="!py-0 inline-flex items-center justify-center">
-                Add
-              </.button>
-            </.form>
-
-            <p :if={@corp_search_error} class="text-sm text-amber-400">{@corp_search_error}</p>
-          </div>
-        </.disclosure>
-      </div>
-
-      <div :if={@notification} class="flex flex-col gap-3 rounded border border-white/10 p-3">
-        <div class="flex items-center justify-between gap-2">
-          <h3 class="text-base font-semibold">Route alerts</h3>
-          <span class="text-xs opacity-70">{route_badge(@notification, @webhooks[:route])}</span>
-        </div>
-
-        <.panel_message message={@message} scope={:route} />
-
-        <.route_alert_banner
-          notification={@notification}
-          webhooks={@webhooks}
-          route_toggle={@route_toggle}
-          myself={@myself}
-        />
-
-        <.form
-          :let={rf}
-          for={@route_form}
-          id="route-alerts-form"
-          phx-submit="save-route"
-          phx-change="route-form-change"
-          phx-target={@myself}
-          class="flex flex-col gap-2"
-        >
-          <%!-- The same `phx-change` as the enclosing form, declared on the
-                  checkbox itself as well. An input-level `phx-change` still
-                  serialises the whole form, so the handler receives exactly
-                  the same params either way — but it makes the toggle
-                  independently addressable, which is how both the tests and
-                  the #130 regression drive it. --%>
-          <.input
-            field={rf[:route_alerts_enabled]}
-            type="checkbox"
-            label="Route alerts (highsec route to Jita)"
-            phx-change="route-form-change"
+                They apply on change, with no Save of their own. A checkbox
+                whose effect is deferred to a button somewhere below the fold
+                is a checkbox that lies about its own state, and these two are
+                the controls an operator reaches for in a hurry. The route
+                fields cannot do this — they are validated against each other
+                — which is what the one Save at the bottom is for. --%>
+          <.form
+            :let={f}
+            for={@kills_form}
+            id="kill-toggles-form"
+            phx-change="toggle-setting"
             phx-target={@myself}
+            class="flex flex-col gap-2"
+          >
+            <.input field={f[:enabled]} type="checkbox" label="Send kill notifications" />
+            <.input field={f[:wh_only]} type="checkbox" label="Only wormhole kills" />
+          </.form>
+
+          <p :if={@webhooks[:system]} class="text-sm opacity-70">
+            {status_line(@webhooks[:system], @channel_hints[:system])}
+          </p>
+          <p :if={@webhooks[:system] && @webhooks[:system].last_error} class="text-sm text-amber-400">
+            Last error: {@webhooks[:system].last_error}
+            <span :if={@webhooks[:system].consecutive_failures > 0}>
+              ({@webhooks[:system].consecutive_failures} consecutive failures)
+            </span>
+          </p>
+
+          <div class="flex flex-col gap-3">
+            <.webhook_row
+              role={:system}
+              title="Kill channel"
+              help="Where kills on this map are posted."
+              webhook={@webhooks[:system]}
+              channel_info={@channel_hints[:system]}
+              form={@webhook_forms[:system]}
+              replacing?={@replacing_url?[:system]}
+              removable?={true}
+              show_status?={false}
+              myself={@myself}
+            />
+            <.collision_warning role={:system} collisions={@collisions} />
+
+            <%!-- Always listed, rather than hidden behind "+ Add a separate
+                  channel". That link asked the operator to commit before it
+                  would say what they were committing to, and the row it
+                  revealed was titled differently from the link that revealed
+                  it. A named row with "Not set" beside it answers the
+                  question — is there one, and what would it do — without
+                  costing anything but a line. --%>
+            <.webhook_row
+              role={:character}
+              title="Character kill channel"
+              help="Optional second channel for kills involving characters tracked on this map, wherever they happen. Leave it unset and those kills go to the kill channel with the rest."
+              webhook={@webhooks[:character]}
+              channel_info={@channel_hints[:character]}
+              form={@webhook_forms[:character]}
+              replacing?={@replacing_url?[:character]}
+              removable?={true}
+              myself={@myself}
+            />
+            <.collision_warning role={:character} collisions={@collisions} />
+          </div>
+
+          <.disclosure
+            id="filters-disclosure"
+            title="Kill filters"
+            open?={MapSet.member?(@open_sections, "filters-disclosure")}
+            myself={@myself}
+            badge={
+              filters_badge(@excluded_systems, @focus_corps, @system_search_error, @corp_search_error)
+            }
+          >
+            <%!-- The one sentence kept from the tab's old intro paragraph. It
+                  sits here rather than at the top because it disambiguates these
+                  filters specifically, and at the top it was answering a question
+                  nobody had yet asked about a section that was collapsed. --%>
+            <p class="text-xs opacity-70">
+              Separate from the Kills widget's own filters, which are per-user and only
+              change what you see on the map. Neither applies to route alerts.
+            </p>
+
+            <div class="flex flex-col gap-2">
+              <h4 class="text-sm font-semibold">Excluded systems</h4>
+
+              <ul class="flex flex-wrap gap-2">
+                <li :for={{system_id, label} <- @excluded_systems}>
+                  <.chip
+                    label={label}
+                    phx-click="remove-excluded"
+                    phx-value-system_id={system_id}
+                    phx-target={@myself}
+                  />
+                </li>
+              </ul>
+
+              <%!-- Height matching, without predicting either box: `compact` makes the
+                    field wrapper exactly as tall as its input, `!py-0` drops the
+                    button's vertical padding so its intrinsic height (one line of
+                    text) is always shorter than the input's, and the grid row is
+                    therefore sized by the field. `items-stretch` then gives the
+                    button that exact height. Nothing here depends on the button and
+                    the input agreeing on font size, padding or line-height, which
+                    they do not. --%>
+              <.form
+                :let={ef}
+                for={@excluded_form}
+                id="excluded-system-form"
+                phx-submit="add-excluded"
+                phx-target={@myself}
+                class="grid items-stretch gap-2"
+                style="grid-template-columns: 1fr auto"
+              >
+                <.live_select
+                  field={ef[:excluded_system]}
+                  id={@excluded_select_id}
+                  phx-target={@myself}
+                  label="Exclude a system"
+                  dropdown_extra_class="!h-24"
+                  compact={true}
+                  debounce={250}
+                  update_min_len={@min_search_length}
+                  mode={:single}
+                  options={@system_options}
+                  placeholder="Search a system by name"
+                />
+                <.button type="submit" class="!py-0 inline-flex items-center justify-center">
+                  Add
+                </.button>
+              </.form>
+
+              <p :if={@system_search_error} class="text-sm text-amber-400">{@system_search_error}</p>
+            </div>
+
+            <div class="flex flex-col gap-2">
+              <h4 class="text-sm font-semibold">Corporation filter</h4>
+              <%!-- Two sentences, by D10. The full routing rules — that a
+                    corporation match replaces the tracked-character test rather
+                    than widening it, and bypasses the excluded-system and
+                    wormhole-only filters — are in docs/ZOO-FORK.md under
+                    "Kill filter semantics". A four-sentence paragraph next to an
+                    input is not read; it is scrolled past. --%>
+              <p class="text-xs opacity-70">
+                When set, the character kill channel follows these corporations instead of
+                this map's tracked characters. Leave it empty to use the tracked characters.
+              </p>
+
+              <ul class="flex flex-wrap gap-2">
+                <li :for={{corp_id, label} <- @focus_corps}>
+                  <.chip
+                    label={label}
+                    phx-click="remove-focus-corp"
+                    phx-value-corp_id={corp_id}
+                    phx-target={@myself}
+                  />
+                </li>
+              </ul>
+
+              <p :if={@current_user.characters in [nil, []]} class="text-sm text-amber-400">
+                Add a character to this account to search corporations.
+              </p>
+
+              <.form
+                :let={cf}
+                :if={@current_user.characters not in [nil, []]}
+                for={@focus_corp_form}
+                id="focus-corp-form"
+                phx-submit="add-focus-corp"
+                phx-target={@myself}
+                class="grid items-stretch gap-2"
+                style="grid-template-columns: 1fr auto"
+              >
+                <.live_select
+                  field={cf[:focus_corp]}
+                  id={@focus_corp_select_id}
+                  phx-target={@myself}
+                  label="Add a corporation"
+                  dropdown_extra_class="!h-24"
+                  compact={true}
+                  debounce={250}
+                  update_min_len={@corp_min_search_length}
+                  mode={:single}
+                  options={@corp_options}
+                  placeholder="Search a corporation by name"
+                />
+                <.button type="submit" class="!py-0 inline-flex items-center justify-center">
+                  Add
+                </.button>
+              </.form>
+
+              <p :if={@corp_search_error} class="text-sm text-amber-400">{@corp_search_error}</p>
+            </div>
+          </.disclosure>
+        </div>
+
+        <div class="flex flex-col gap-3 border-t border-white/10 pt-4">
+          <h3 class="text-base font-semibold">Route alerts</h3>
+
+          <.route_alert_banner
+            notification={@notification}
+            webhooks={@webhooks}
+            route_toggle={@route_toggle}
           />
 
-          <%!-- Disabled rather than hidden (upstream checklist §5), and disabled
+          <%!-- The three route fields are one form because they are validated
+                against each other: enabling alerts without a home system is
+                rejected by the resource, so the toggle cannot commit on change
+                the way the kill switches do. This is the form the Save button
+                at the bottom of the pane submits, via `form=` — it is a submit
+                button, so no hidden-companion or event-bubbling caveat
+                applies, and a nested <form> would have been dropped by the
+                browser outright. --%>
+          <.form
+            :let={rf}
+            for={@settings_form}
+            id="notification-settings-form"
+            phx-submit="save-settings"
+            phx-change="settings-change"
+            phx-target={@myself}
+            class="flex flex-col gap-2"
+          >
+            <%!-- A checkbox, not a button. "Enable route alerts" was a button
+                  because the fields below it needed a home system before they
+                  could be saved — but that is what the disabled fieldset and
+                  the validation are for, and the operator was left with two
+                  differently-shaped controls for one boolean. --%>
+            <.input
+              field={rf[:route_alerts_enabled]}
+              type="checkbox"
+              label="Send route alerts"
+              phx-change="settings-change"
+              phx-target={@myself}
+            />
+
+            <%!-- Disabled rather than hidden (upstream checklist §5), and disabled
                   through a <fieldset> rather than per-input for two reasons. It
                   natively disables every descendant control including
                   LiveSelect's own text and hidden inputs — `live_select/1`
@@ -2411,98 +2339,122 @@ defmodule WandererAppWeb.MapNotificationsComponent do
                   because `notification_attrs/1` treats an absent key as "leave
                   this field alone" — otherwise pressing Save with alerts off
                   would clear a saved home system. --%>
-          <fieldset disabled={not @route_toggle} class="flex flex-col gap-2 border-0 p-0">
-            <div class="flex flex-col gap-1">
-              <span class="text-sm">Home system</span>
-              <.live_select
-                field={rf[:home_system_id]}
-                id={@home_system_select_id}
-                phx-target={@myself}
-                dropdown_extra_class="!h-24"
-                compact={true}
-                debounce={250}
-                update_min_len={@min_search_length}
-                mode={:single}
-                options={@home_system_options}
-                placeholder="Search a system by name, or enter its solar system ID"
+            <fieldset disabled={not @route_toggle} class="flex flex-col gap-2 border-0 p-0">
+              <div class="flex flex-col gap-1">
+                <%!-- The visible text; the associated label on the combobox
+                    itself is screen-reader-only (see `live_select/1`), so this
+                    is hidden from AT to avoid announcing the name twice. --%>
+                <span class="text-sm" aria-hidden="true">Home system</span>
+                <.live_select
+                  field={rf[:home_system_id]}
+                  id={@home_system_select_id}
+                  phx-target={@myself}
+                  label="Home system"
+                  dropdown_extra_class="!h-24"
+                  compact={true}
+                  debounce={250}
+                  update_min_len={@min_search_length}
+                  mode={:single}
+                  options={@home_system_options}
+                  placeholder="Search a system by name, or enter its solar system ID"
+                />
+                <p :if={@home_system_error} class="text-sm text-red-400">{@home_system_error}</p>
+                <p :if={@home_system_search_error} class="text-sm text-amber-400">
+                  {@home_system_search_error}
+                </p>
+              </div>
+
+              <.input
+                field={rf[:route_max_jumps]}
+                type="number"
+                min={@min_route_max_jumps}
+                max={@max_route_max_jumps}
+                label="Max jumps to Jita (inclusive)"
               />
-              <p :if={@home_system_error} class="text-sm text-red-400">{@home_system_error}</p>
-              <p :if={@home_system_search_error} class="text-sm text-amber-400">
-                {@home_system_search_error}
-              </p>
+            </fieldset>
+
+            <p class="text-xs opacity-70">
+              Posts when a highsec-only route this length or shorter opens from the home
+              system to Jita. Wormhole hops on the way don't count against "highsec" —
+              only k-space systems on the path do.
+            </p>
+
+            <%!-- Inside the form it commits, not in a pane-level action bar. The
+                  three fields above are the only ones on this tab that cannot
+                  apply on change: `route_max_jumps` is typed, so a per-keystroke
+                  save would submit "" mid-edit against an `allow_nil? false`
+                  attribute, and the toggle and home system are interdependent —
+                  `validate_home_system_required/2` rejects "enabled with no home
+                  system", so committing the tick on its own is exactly how an
+                  operator gets told off for a field they have not reached yet.
+                  Everything else on the tab acts where it stands. --%>
+            <div>
+              <.button type="submit" variant={:primary} disabled={not @dirty}>
+                Save route alerts
+              </.button>
             </div>
+          </.form>
 
-            <.input
-              field={rf[:route_max_jumps]}
-              type="number"
-              min={@min_route_max_jumps}
-              max={@max_route_max_jumps}
-              label="Max jumps to Jita (inclusive)"
+          <.webhook_row
+            role={:route}
+            title="Route alert channel"
+            help="Where route alerts are posted. Alerts name every system on the route, unredacted — treat this channel as trusted."
+            webhook={@webhooks[:route]}
+            channel_info={@channel_hints[:route]}
+            form={@webhook_forms[:route]}
+            replacing?={@replacing_url?[:route]}
+            removable?={true}
+            empty_status_text="No route alerts delivered yet."
+            myself={@myself}
+          />
+          <.collision_warning role={:route} collisions={@collisions} />
+
+          <.disclosure
+            :if={@webhooks[:route]}
+            id="mentions-disclosure"
+            title="Mentions"
+            open?={MapSet.member?(@open_sections, "mentions-disclosure")}
+            myself={@myself}
+            badge={mentions_badge(@mention_users, @mention_roles)}
+          >
+            <.mentions_section
+              users={@mention_users}
+              roles={@mention_roles}
+              labels={@mention_labels}
+              guild_roles={@guild_roles}
+              picker_available?={mention_picker_available?(assigns)}
+              unavailable_reason={mention_unavailable_reason(assigns)}
+              user_select_id={@mention_user_select_id}
+              role_select_id={@mention_role_select_id}
+              user_options={@mention_user_options}
+              role_options={@mention_role_options}
+              search_error={@mention_search_error}
+              error={@mention_error}
+              myself={@myself}
             />
-          </fieldset>
-
-          <p class="text-xs opacity-70">
-            Posts when a highsec-only route this length or shorter opens from the home
-            system to Jita. Wormhole hops on the way don't count against "highsec" —
-            only k-space systems on the path do.
-          </p>
-
-          <.button type="submit" variant={:primary} class="self-start" disabled={not @dirty.route}>
-            Save
-          </.button>
-        </.form>
-
-        <.webhook_row
-          role={:route}
-          title="Route alert channel"
-          help={
-              "Receives an alert when a highsec-only route opens from the home system to Jita. " <>
-                "This message names every system on the route in order. Treat this channel as " <>
-                "trusted; there is no redacted version of it. Route alerts are sent here and " <>
-                "nowhere else — leave it unset and no route alerts are sent at all."
-            }
-          webhook={@webhooks[:route]}
-          channel_info={@channel_hints[:route]}
-          form={@webhook_forms[:route]}
-          replacing?={@replacing_url?[:route]}
-          removable?={true}
-          empty_status_text="No route alerts delivered yet."
-          myself={@myself}
-        />
-
-        <.mentions_section
-          :if={@webhooks[:route]}
-          users={@mention_users}
-          roles={@mention_roles}
-          labels={@mention_labels}
-          guild_roles={@guild_roles}
-          picker_available?={mention_picker_available?(assigns)}
-          unavailable_reason={mention_unavailable_reason(assigns)}
-          user_select_id={@mention_user_select_id}
-          role_select_id={@mention_role_select_id}
-          user_options={@mention_user_options}
-          role_options={@mention_role_options}
-          search_error={@mention_search_error}
-          error={@mention_error}
-          myself={@myself}
-        />
-
-        <.collision_warning role={:route} collisions={@collisions} />
+          </.disclosure>
+        </div>
       </div>
 
-      <div :if={@notification} class="flex items-center gap-2">
-        <.button
-          type="button"
-          variant={:danger}
-          class="self-start"
-          phx-click="delete"
-          phx-target={@myself}
-          data-confirm="Remove Discord notifications for this map?"
-        >
-          Remove all Discord notifications
-        </.button>
+      <%!-- The message region is shared: every control on this tab reports here,
+            not just the one Save. It sits at the foot because that is the one
+            place in view from any of them. --%>
+      <div class="flex flex-wrap items-center gap-3">
+        <.panel_message message={@message} />
       </div>
     </div>
     """
   end
+
+  defp mentions_badge([], []), do: "None"
+
+  defp mentions_badge(users, roles) do
+    [count_label(length(roles), "role"), count_label(length(users), "user")]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(", ")
+  end
+
+  defp count_label(0, _noun), do: nil
+  defp count_label(1, noun), do: "1 #{noun}"
+  defp count_label(n, noun), do: "#{n} #{noun}s"
 end

--- a/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
+++ b/lib/wanderer_app_web/live/maps/components/map_notifications_component.ex
@@ -323,13 +323,33 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   def handle_event("save-webhook", %{"role" => role, "webhook" => params}, socket) do
     role = parse_role(role)
 
-    with {:ok, rec} <- ensure_notification(socket),
-         {:ok, _} <- save_webhook(rec, socket.assigns.webhooks[role], role, params) do
-      {:noreply,
-       socket
-       |> assign_notification(reload_notification(socket.assigns.map_id))
-       |> put_message(:info, "Saved.")}
-    else
+    case ensure_notification(socket) do
+      {:ok, rec} ->
+        case save_webhook(rec, socket.assigns.webhooks[role], role, params) do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> assign_notification(reload_notification(socket.assigns.map_id))
+             |> put_message(:info, "Saved.")}
+
+          {:error, error} ->
+            # `:notification` is assigned even though the save failed, because
+            # by this point the policy row is committed regardless. Leaving it
+            # nil made `ensure_notification/1` try to create it a SECOND time
+            # when the operator corrected the URL and resubmitted, and the
+            # `unique_map_id` identity rejects that — so a rejected URL used to
+            # poison every retry with "has already been taken".
+            #
+            # Only that one key, not `assign_notification/2`: the full cascade
+            # rebuilds `webhook_forms` and `replacing_url?`, which would close
+            # the row and discard the URL the operator is in the middle of
+            # fixing.
+            {:noreply,
+             socket
+             |> assign(:notification, rec)
+             |> put_message(:error, humanize_error(error))}
+        end
+
       {:error, error} ->
         {:noreply, put_message(socket, :error, humanize_error(error))}
     end
@@ -357,7 +377,7 @@ defmodule WandererAppWeb.MapNotificationsComponent do
             {:noreply,
              socket
              |> assign_notification(reload_notification(socket.assigns.map_id))
-             |> put_message(:info, "#{role_label(role)} destination removed.")}
+             |> put_message(:info, "#{role_label(role)} removed.")}
 
           {:error, error} ->
             {:noreply, put_message(socket, :error, humanize_error(error))}
@@ -704,8 +724,18 @@ defmodule WandererAppWeb.MapNotificationsComponent do
   defp parse_role(:route), do: :route
   defp parse_role(_), do: :system
 
-  defp role_label(:character), do: "Character"
-  defp role_label(:route), do: "Route"
+  # One clause per role, and every role has one. `:system` was missing while
+  # `remove-webhook` still refused that role; widening the handler without
+  # widening this made removing the kill channel raise FunctionClauseError —
+  # after the destroy had already committed, so the row was gone and the tab
+  # was down.
+  #
+  # The strings are the row titles verbatim, so the confirmation names the
+  # thing the operator just clicked ("Kill channel removed.") rather than a
+  # role name that appears nowhere on screen ("System destination removed.").
+  defp role_label(:system), do: "Kill channel"
+  defp role_label(:character), do: "Character kill channel"
+  defp role_label(:route), do: "Route alert channel"
 
   defp reload_notification(map_id) do
     case MapDiscordNotification.by_map(map_id) do

--- a/lib/wanderer_app_web/live/maps/maps_live.ex
+++ b/lib/wanderer_app_web/live/maps/maps_live.ex
@@ -883,6 +883,49 @@ defmodule WandererAppWeb.MapsLive do
     |> Map.put(:acls, acls |> Enum.map(&map_acl/1))
   end
 
+  # Single source of truth for the Map Settings tab strip. The markup was
+  # originally copied out of a rendered PrimeReact TabView, which left seven
+  # near-identical `<li>` blocks carrying hand-written `aria-selected` and
+  # `aria-controls` values that never matched the real state or the real panel.
+  # Rendering from this list keeps the ARIA computed instead of transcribed.
+  defp settings_tabs(map_subscriptions_enabled?) do
+    [
+      %{id: "general", label: "General", icon: "hero-wrench-screwdriver-solid", show?: true},
+      %{
+        id: "balance",
+        label: "Balance",
+        icon: "hero-banknotes-solid",
+        show?: map_subscriptions_enabled?
+      },
+      %{
+        id: "subscription",
+        label: "Subscription",
+        icon: "hero-check-badge-solid",
+        show?: map_subscriptions_enabled?
+      },
+      %{
+        id: "import",
+        label: "Import/Export",
+        icon: "hero-document-arrow-down-solid",
+        show?: true
+      },
+      %{
+        id: "public_api",
+        label: "Public Api",
+        icon: "hero-globe-alt-solid",
+        show?: not WandererApp.Env.public_api_disabled?()
+      },
+      %{
+        id: "bot",
+        label: "Bots",
+        icon: "hero-puzzle-piece-solid",
+        show?: map_subscriptions_enabled?
+      },
+      %{id: "notifications", label: "Notifications", icon: "hero-bell-alert-solid", show?: true}
+    ]
+    |> Enum.filter(& &1.show?)
+  end
+
   defp available_scopes do
     [
       %{value: "wormholes", label: "Wormholes", description: "J-space systems"},

--- a/lib/wanderer_app_web/live/maps/maps_live.html.heex
+++ b/lib/wanderer_app_web/live/maps/maps_live.html.heex
@@ -244,10 +244,14 @@
   </.form>
 </.modal>
 
+<%!-- Width: `min()` rather than a `w-full md:` pair. `w-full` made the dialog
+      fill the mask on every viewport, and CSS resolves min-width AFTER
+      max-width, so a bare `!min-w-[700px]` would overflow a phone instead of
+      shrinking. This keeps the 700px working width and collapses below it. --%>
 <.modal
   :if={@live_action in [:settings] && not is_nil(assigns[:map])}
   title="Map Settings"
-  class="!min-w-[700px]"
+  class="!min-w-[min(700px,100%)]"
   id="map-settings-modal"
   show
   on_cancel={JS.patch(~p"/maps")}
@@ -260,202 +264,48 @@
             <div class="p-tabview-nav-content" data-pc-section="navcontent">
               <ul class="p-tabview-nav" role="tablist" data-pc-section="nav">
                 <li
+                  :for={tab <- settings_tabs(@map_subscriptions_enabled?)}
                   class={[
                     "p-unselectable-text",
-                    classes("p-tabview-selected p-highlight": @active_settings_tab == "general")
+                    classes("p-tabview-selected p-highlight": @active_settings_tab == tab.id)
                   ]}
                   role="presentation"
                   data-pc-name=""
                   data-pc-section="header"
                 >
-                  <a
+                  <%!-- A real <button>, not the <a role="tab"> this markup was
+                        copied with: that anchor had no href, so Enter never
+                        activated it and every tab but General was also
+                        tabindex="-1" — leaving Notifications unreachable by
+                        keyboard entirely. Every tab is tabindex-reachable
+                        rather than roving, because roving tabindex is only
+                        operable with an arrow-key handler and there is no hook
+                        here to host one. --%>
+                  <button
+                    type="button"
+                    id={"map-settings-tab-#{tab.id}"}
                     role="tab"
-                    class="p-tabview-nav-link flex p-[10px]"
-                    tabindex="0"
-                    aria-controls="pr_id_330_content"
-                    aria-selected="true"
-                    aria-disabled="false"
-                    data-pc-section="headeraction"
+                    class="p-tabview-nav-link flex w-full p-[10px]"
+                    aria-controls="map-settings-tabpanel"
+                    aria-selected={to_string(@active_settings_tab == tab.id)}
                     phx-click="change_settings_tab"
-                    phx-value-tab="general"
+                    phx-value-tab={tab.id}
+                    data-pc-section="headeraction"
                   >
                     <span class="p-tabview-title" data-pc-section="headertitle">
-                      <.icon name="hero-wrench-screwdriver-solid" class="w-4 h-4" />&nbsp;General
+                      <.icon name={tab.icon} class="w-4 h-4" />&nbsp;{tab.label}
                     </span>
-                  </a>
-                </li>
-
-                <li
-                  :if={@map_subscriptions_enabled?}
-                  class={[
-                    "p-unselectable-text",
-                    classes("p-tabview-selected p-highlight": @active_settings_tab == "balance")
-                  ]}
-                  role="presentation"
-                  data-pc-name=""
-                  data-pc-section="header"
-                >
-                  <a
-                    role="tab"
-                    class="p-tabview-nav-link flex p-[10px]"
-                    tabindex="-1"
-                    aria-controls="pr_id_332_content"
-                    aria-selected="false"
-                    aria-disabled="false"
-                    data-pc-section="headeraction"
-                    phx-click="change_settings_tab"
-                    phx-value-tab="balance"
-                  >
-                    <span class="p-tabview-title" data-pc-section="headertitle">
-                      <.icon name="hero-banknotes-solid" class="w-4 h-4" />&nbsp;Balance
-                    </span>
-                  </a>
-                </li>
-
-                <li
-                  :if={@map_subscriptions_enabled?}
-                  class={[
-                    "p-unselectable-text",
-                    classes(
-                      "p-tabview-selected p-highlight": @active_settings_tab == "subscription"
-                    )
-                  ]}
-                  role="presentation"
-                  data-pc-name=""
-                  data-pc-section="header"
-                >
-                  <a
-                    role="tab"
-                    class="p-tabview-nav-link flex p-[10px]"
-                    tabindex="-1"
-                    aria-controls="pr_id_334_content"
-                    aria-selected="false"
-                    aria-disabled="false"
-                    data-pc-section="headeraction"
-                    phx-click="change_settings_tab"
-                    phx-value-tab="subscription"
-                  >
-                    <span class="p-tabview-title" data-pc-section="headertitle">
-                      <.icon name="hero-check-badge-solid" class="w-4 h-4" />&nbsp;Subscription
-                    </span>
-                  </a>
-                </li>
-
-                <li
-                  class={[
-                    "p-unselectable-text",
-                    classes("p-tabview-selected p-highlight": @active_settings_tab == "import")
-                  ]}
-                  role="presentation"
-                  data-pc-name=""
-                  data-pc-section="header"
-                >
-                  <a
-                    role="tab"
-                    class="p-tabview-nav-link flex p-[10px]"
-                    tabindex="-1"
-                    aria-controls="pr_id_331_content"
-                    aria-selected="false"
-                    aria-disabled="false"
-                    data-pc-section="headeraction"
-                    phx-click="change_settings_tab"
-                    phx-value-tab="import"
-                  >
-                    <span class="p-tabview-title" data-pc-section="headertitle">
-                      <.icon name="hero-document-arrow-down-solid" class="w-4 h-4" />&nbsp;Import/Export
-                    </span>
-                  </a>
-                </li>
-                <li
-                  :if={not WandererApp.Env.public_api_disabled?()}
-                  class={[
-                    "p-unselectable-text",
-                    classes(
-                      "p-tabview-selected p-highlight": @active_settings_tab == "public_api"
-                    )
-                  ]}
-                  role="presentation"
-                  data-pc-name=""
-                  data-pc-section="header"
-                >
-                  <a
-                    role="tab"
-                    class="p-tabview-nav-link flex p-[10px]"
-                    tabindex="-1"
-                    aria-controls="pr_id_335_content"
-                    aria-selected="false"
-                    aria-disabled="false"
-                    data-pc-section="headeraction"
-                    phx-click="change_settings_tab"
-                    phx-value-tab="public_api"
-                  >
-                    <span class="p-tabview-title" data-pc-section="headertitle">
-                      <.icon name="hero-globe-alt-solid" class="w-4 h-4" />&nbsp;Public Api
-                    </span>
-                  </a>
-                </li>
-                <li
-                  :if={@map_subscriptions_enabled?}
-                  class={[
-                    "p-unselectable-text",
-                    classes("p-tabview-selected p-highlight": @active_settings_tab == "bot")
-                  ]}
-                  role="presentation"
-                  data-pc-name=""
-                  data-pc-section="header"
-                >
-                  <a
-                    role="tab"
-                    class="p-tabview-nav-link flex p-[10px]"
-                    tabindex="-1"
-                    aria-controls="pr_id_335_content"
-                    aria-selected="false"
-                    aria-disabled="false"
-                    data-pc-section="headeraction"
-                    phx-click="change_settings_tab"
-                    phx-value-tab="bot"
-                  >
-                    <span class="p-tabview-title" data-pc-section="headertitle">
-                      <.icon name="hero-puzzle-piece-solid" class="w-4 h-4" />&nbsp;Bots
-                    </span>
-                  </a>
-                </li>
-                <li
-                  class={[
-                    "p-unselectable-text",
-                    classes(
-                      "p-tabview-selected p-highlight": @active_settings_tab == "notifications"
-                    )
-                  ]}
-                  role="presentation"
-                  data-pc-name=""
-                  data-pc-section="header"
-                >
-                  <a
-                    role="tab"
-                    class="p-tabview-nav-link flex p-[10px]"
-                    tabindex="-1"
-                    aria-controls="pr_id_335_content"
-                    aria-selected="false"
-                    aria-disabled="false"
-                    data-pc-section="headeraction"
-                    phx-click="change_settings_tab"
-                    phx-value-tab="notifications"
-                  >
-                    <span class="p-tabview-title" data-pc-section="headertitle">
-                      <.icon name="hero-bell-alert-solid" class="w-4 h-4" />&nbsp;Notifications
-                    </span>
-                  </a>
+                  </button>
                 </li>
               </ul>
             </div>
           </div>
           <div class="p-tabview-panels" data-pc-section="panelcontainer">
             <div
-              id="pr_id_330_content"
+              id="map-settings-tabpanel"
               class="p-tabview-panel"
               role="tabpanel"
-              aria-labelledby="pr_id_33_header_0"
+              aria-labelledby={"map-settings-tab-#{@active_settings_tab}"}
               data-pc-name=""
               data-pc-section="content"
             >

--- a/test/unit/components/live_select_compact_test.exs
+++ b/test/unit/components/live_select_compact_test.exs
@@ -43,12 +43,45 @@ defmodule WandererAppWeb.CoreComponents.LiveSelectCompactTest do
     refute compact_tags =~ ~s(class="hidden")
   end
 
-  test "the default rendering is byte-identical to before the compact attr existed" do
+  test "an unlabelled default still renders the spacer rows it always did" do
     # Every other call site in the app omits `compact`, so this is the
-    # regression guard for them.
+    # regression guard for them. What it no longer asserts is the literal
+    # `for="form_description"`: that was a `for` attribute on a <div>, pointing
+    # at an id that exists nowhere in the app. It contributed nothing but a
+    # copy-paste artifact, and keeping it pinned here would have blocked giving
+    # these comboboxes a real label.
     default = render_field([])
 
-    assert default =~ ~s(<div for="form_description" class="label">)
+    assert default =~ ~s(<div class="label">)
     assert default =~ ~s(<span class="label-text">)
+    refute default =~ "form_description"
+  end
+
+  # The bug: `:label` was accepted, stripped from the opts forwarded to
+  # LiveSelect, and then never rendered — so every combobox in the app was
+  # announced as "combobox, blank". `for` has to target LiveSelect's own text
+  # input, whose id it derives as `<field>_text_input`, NOT the `id` we pass
+  # (that lands on the LiveComponent wrapper).
+  test "a label is rendered and associated with the text input LiveSelect actually creates" do
+    labelled = render_field(label: "Home system")
+
+    assert labelled =~ ~s(<label for="f_pick_text_input")
+    assert labelled =~ "Home system"
+    # …and that id is a real element in the same render.
+    assert labelled =~ ~s(id="f_pick_text_input")
+    # The empty spacer row is not rendered on top of a real label.
+    refute labelled =~ ~s(<span class="label-text"></span>)
+  end
+
+  # `compact` exists to make the wrapper exactly as tall as its input, so a
+  # neighbouring Add button lines up with the field. A visible label row would
+  # undo that, but a missing accessible name is not an acceptable price for it.
+  test "a compact label is present for assistive tech but takes no vertical space" do
+    compact = render_field(compact: true, label: "Exclude a system")
+
+    assert compact =~ ~s(<label for="f_pick_text_input")
+    assert compact =~ ~s(class="sr-only")
+    assert compact =~ "Exclude a system"
+    refute compact =~ ~s(class="label")
   end
 end

--- a/test/wanderer_app_web/live/map_notifications_test.exs
+++ b/test/wanderer_app_web/live/map_notifications_test.exs
@@ -70,9 +70,9 @@ defmodule WandererAppWeb.MapNotificationsTest do
     view
   end
 
-  # Task 2's `create` takes `webhook_url` as a required argument and seeds the
-  # `:system` child in the same transaction, so `roles` here only controls
-  # whether a `:character` row is added on top. Passing `:system` in `roles`
+  # `create`'s `webhook_url` is optional but still seeds the `:system` child in
+  # the same transaction when given, so `roles` here only controls whether a
+  # `:character`/`:route` row is added on top. Passing `:system` in `roles`
   # would violate the (notification_id, role) identity from Task 1.
   defp notification_with_webhooks(map, roles) do
     {:ok, rec} =
@@ -105,67 +105,77 @@ defmodule WandererAppWeb.MapNotificationsTest do
     assert has_element?(view, "[phx-value-tab='notifications']")
   end
 
-  test "saving a valid webhook url creates the record", %{conn: conn, map: map} do
+  test "adding the first kill webhook creates the record", %{conn: conn, map: map} do
     view = open_notifications(conn, map)
 
-    # L0 is one URL field and one button — no checkboxes at all. The absent
-    # params are the point: `notification_attrs/1` omits a key it was not
-    # given rather than parsing `nil` into `false`, so the resource defaults
-    # apply.
+    # There is no create form any more. The kill channel is a destination row
+    # like the other two, listed as "Not set" with an Add button, and adding it
+    # is what brings the policy row into existence (`ensure_notification/1`).
+    edit_row(view, :system)
+
     view
-    |> form("#discord-notification-form", %{
-      "notification" => %{"webhook_url" => "https://discord.com/api/webhooks/123/tok"}
+    |> form("#webhook-form-system", %{
+      "webhook" => %{"webhook_url" => "https://discord.com/api/webhooks/123/tok"}
     })
     |> render_submit()
 
     assert {:ok, rec} = MapDiscordNotification.by_map(map.id)
+
+    # The lazily-created parent takes the resource defaults. Nothing in the add
+    # flow submits `enabled`/`wh_only`, and that is the point: a key that was
+    # never submitted must not be read as `false`.
+    assert rec.enabled? == true
     assert rec.wh_only == true
 
-    # Regression guard, now guarding a different mechanism. Previously the
-    # Enabled checkbox was hidden behind `:if={@notification}`, so its param
-    # was absent, `params["enabled"] == "true"` was false, and every new
-    # config was born disabled — invisibly, because no checkbox contradicted
-    # it. The checkbox is deliberately absent at L0 again, so what keeps this
-    # true is `put_param/5` treating "key not submitted" as "leave it alone".
-    assert rec.enabled? == true
-
-    # The create action seeds the required `:system` destination in the same
-    # transaction; a parent with no destination would deliver nothing.
     assert {:ok, [webhook]} = MapDiscordWebhook.by_notification(rec.id)
     assert webhook.role == :system
   end
 
-  test "a new configuration is enabled when the box is left checked", %{conn: conn, map: map} do
+  test "route alerts can be configured with no kill webhook at all", %{conn: conn, map: map} do
     view = open_notifications(conn, map)
 
-    # Submit exactly what the browser sends for a checked box rendered with a
-    # preceding hidden "false": both keys, last one winning.
+    # The regression this guards: `create` used to require `webhook_url`, and
+    # the tab used to render nothing but that one field until it was supplied.
+    # Route alerts are a separate feature and must not be gated behind a kill
+    # channel the operator may not want.
+    assert has_element?(view, "#notification-settings-form")
+    assert has_element?(view, "#webhook-row-route button[phx-click='replace-url']")
+
+    edit_row(view, :route)
+
     view
-    |> form("#discord-notification-form", %{
-      "notification" => %{"webhook_url" => "https://discord.com/api/webhooks/123/tok"}
+    |> form("#webhook-form-route", %{
+      "webhook" => %{"webhook_url" => "https://discord.com/api/webhooks/456/tok"}
     })
     |> render_submit()
 
     assert {:ok, rec} = MapDiscordNotification.by_map(map.id)
-    assert rec.enabled? == true
+    assert {:ok, [webhook]} = MapDiscordWebhook.by_notification(rec.id)
+    assert webhook.role == :route
   end
 
   test "an invalid url is rejected with a message", %{conn: conn, map: map} do
     view = open_notifications(conn, map)
 
+    edit_row(view, :system)
+
     html =
       view
-      |> form("#discord-notification-form", %{
-        "notification" => %{"webhook_url" => "https://evil.example.com/x"}
+      |> form("#webhook-form-system", %{
+        "webhook" => %{"webhook_url" => "https://evil.example.com/x"}
       })
       |> render_submit()
 
-    # Assert the resource's actual validation message, NOT the string
-    # "Discord webhook URL" — that is the create form's own <label>, which
-    # renders whenever there is no record, i.e. in this scenario always.
-    # Asserting on it would pass even if the error were discarded entirely.
+    # The resource's own validation message, not the form's <label> — asserting
+    # on the label would pass even if the error were discarded entirely.
     assert html =~ "must be a Discord webhook URL"
-    assert {:error, _} = MapDiscordNotification.by_map(map.id)
+
+    # The parent row is created before the destination is validated, so a
+    # rejected URL can leave an empty policy behind. That is harmless — a
+    # policy with no destinations delivers nothing (`Router.route/3` drops a
+    # nil destination in `usable/1`) — but no webhook may survive it.
+    assert {:ok, rec} = MapDiscordNotification.by_map(map.id)
+    assert {:ok, []} = MapDiscordWebhook.by_notification(rec.id)
   end
 
   test "unchecking 'enabled' actually disables", %{conn: conn, map: map} do
@@ -173,14 +183,15 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
     view = open_notifications(conn, map)
 
-    # An unchecked checkbox submits NO value at all. The hidden companion input
-    # is what makes "off" distinguishable from "field absent"; without it the
-    # record would silently re-enable itself on every save.
+    # The two kill switches apply on change, in their own small form — they are
+    # not part of the bottom Save. An unchecked checkbox submits NO value at
+    # all; the hidden companion input is what makes "off" distinguishable from
+    # "field absent", without which the record would silently re-enable itself.
     view
-    |> form("#discord-notification-form", %{
+    |> form("#kill-toggles-form", %{
       "notification" => %{"enabled" => "false", "wh_only" => "false"}
     })
-    |> render_submit()
+    |> render_change()
 
     assert {:ok, rec} = MapDiscordNotification.by_map(map.id)
     assert rec.enabled? == false
@@ -197,10 +208,10 @@ defmodule WandererAppWeb.MapNotificationsTest do
     # A checked box wins: the browser sends both hidden "false" and "true",
     # and Phoenix keeps the last value.
     view
-    |> form("#discord-notification-form", %{
+    |> form("#kill-toggles-form", %{
       "notification" => %{"enabled" => "true", "wh_only" => "true"}
     })
-    |> render_submit()
+    |> render_change()
 
     assert {:ok, updated} = MapDiscordNotification.by_map(map.id)
     assert updated.enabled? == true
@@ -215,33 +226,37 @@ defmodule WandererAppWeb.MapNotificationsTest do
     # test that drives the REAL save action with the key present catches a
     # handler that still forwards it: Ash raises `NoSuchInput` and takes the
     # LiveView process down. Pushed at the component rather than through
-    # `form/3` because the create-only URL field is not rendered once a record
-    # exists — but a handler must not depend on the template to stay correct.
+    # `form/3` because no rendered form carries that key — but a handler must
+    # not depend on the template to stay correct.
     notification_with_webhooks(map, [:system])
 
     view = open_notifications(conn, map)
 
-    html =
-      view
-      |> with_target("#map-notifications")
-      |> render_submit("save", %{
-        "notification" => %{
-          "webhook_url" => "https://discord.com/api/webhooks/999/NEWTOKEN",
-          "enabled" => "true",
-          "wh_only" => "true"
-        }
-      })
+    view
+    |> with_target("#map-notifications")
+    |> render_change("toggle-setting", %{
+      "notification" => %{
+        "webhook_url" => "https://discord.com/api/webhooks/999/NEWTOKEN",
+        "enabled" => "true",
+        "wh_only" => "true"
+      }
+    })
 
-    assert html =~ "Saved."
     assert {:ok, rec} = MapDiscordNotification.by_map(map.id)
     assert rec.wh_only == true
   end
 
-  test "with no configuration at all, only the create form renders", %{conn: conn, map: map} do
+  test "with no configuration at all, all three rows render unset", %{conn: conn, map: map} do
     view = open_notifications(conn, map)
 
-    assert has_element?(view, "#discord-notification-form")
-    refute has_element?(view, "#webhook-form-character")
+    # Every destination is listed from the start, closed, so the tab states what
+    # is possible without putting three credential fields on screen unasked.
+    for role <- [:system, :character, :route] do
+      assert has_element?(view, "#webhook-row-#{role} button[phx-click='replace-url']")
+      refute has_element?(view, "#webhook-form-#{role}")
+    end
+
+    assert render(view) =~ "Not set"
   end
 
   test "with only a system webhook, the character row offers to add one", %{
@@ -252,16 +267,36 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
     view = open_notifications(conn, map)
 
-    assert has_element?(view, "#webhook-form-system")
-    assert has_element?(view, "#webhook-form-character")
-    # The character destination is unset, so its form must be in add mode: a
-    # URL field, and no test/remove buttons for a webhook that does not exist.
-    # Both refutes are scoped to `#webhook-row-character`, not to the form:
-    # those buttons live in a sibling <div> of the <form>, so a form-descendant
-    # selector never matches them and the refute would pass unconditionally.
-    assert has_element?(view, "#webhook-form-character input[type='password']")
+    # The configured system row is a truth line at rest — no form until Edit.
+    refute has_element?(view, "#webhook-form-system")
+    assert has_element?(view, "#webhook-row-system button[phx-click='replace-url']")
+
+    # The character destination is unset, so it renders closed too, and offers
+    # nothing destructive: no test or remove control for a webhook that does not
+    # exist. Both refutes are scoped to `#webhook-row-character` rather than to
+    # its form, because those buttons live in a sibling <div> of the <form> and a
+    # form-descendant selector would make the refute pass unconditionally.
+    refute has_element?(view, "#webhook-form-character")
     refute has_element?(view, "#webhook-row-character button[phx-click='remove-webhook']")
     refute has_element?(view, "#webhook-row-character button[phx-click='send-test']")
+
+    # …and it says so, rather than being silently absent.
+    assert has_element?(view, "#webhook-row-character button[phx-click='replace-url']")
+
+    edit_row(view, :character)
+    assert has_element?(view, "#webhook-form-character input[type='password']")
+  end
+
+  # A configured destination now renders as a truth line — its name, its status,
+  # and an Edit button. The URL field and the destructive/test controls live in
+  # the form behind that button, so anything asserting on them has to open the
+  # row first, exactly as a user does.
+  defp edit_row(view, role) do
+    view
+    |> element("#webhook-row-#{role} button[phx-click='replace-url']")
+    |> render_click()
+
+    view
   end
 
   test "with both webhooks, each row has its own test and status controls", %{
@@ -272,8 +307,24 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
     view = open_notifications(conn, map)
 
-    assert has_element?(view, "#webhook-row-system button[phx-click='send-test']")
-    assert has_element?(view, "#webhook-row-character button[phx-click='send-test']")
+    # At rest, each configured row shows its identity and an Edit affordance —
+    # and nothing else. This is the change the whole rework turns on: five
+    # simultaneously-expanded destinations is what made the tab taller than the
+    # dialog could ever show.
+    assert has_element?(view, "#webhook-row-system button[phx-click='replace-url']")
+    assert has_element?(view, "#webhook-row-character button[phx-click='replace-url']")
+    refute has_element?(view, "#webhook-row-system button[phx-click='send-test']")
+
+    assert has_element?(
+             edit_row(view, :system),
+             "#webhook-row-system button[phx-click='send-test']"
+           )
+
+    assert has_element?(
+             edit_row(view, :character),
+             "#webhook-row-character button[phx-click='send-test']"
+           )
+
     # Distinct webhook ids, so the two buttons target different destinations.
     assert has_element?(view, "#webhook-row-character button[phx-click='remove-webhook']")
   end
@@ -307,13 +358,12 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
     view = open_notifications(conn, map)
 
-    # A saved destination renders masked, so the URL field only appears after
-    # asking to replace it — the same two-step a user goes through.
+    # A saved destination renders as a truth line, so the URL field only appears
+    # after asking to edit it — the same two-step a user goes through. The Edit
+    # button sits in the row rather than the form: the form is what it reveals.
     refute has_element?(view, "#webhook-form-system input[type='password']")
 
-    view
-    |> element("#webhook-form-system button[phx-click='replace-url']")
-    |> render_click()
+    edit_row(view, :system)
 
     html =
       view
@@ -338,6 +388,8 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
     view = open_notifications(conn, map)
 
+    edit_row(view, :character)
+
     view
     |> form("#webhook-form-character", %{
       "webhook" => %{"webhook_url" => "https://discord.com/api/webhooks/888/chartok"}
@@ -346,7 +398,14 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
     {:ok, webhooks} = MapDiscordWebhook.by_notification(rec.id)
     assert %{role: :character} = Enum.find(webhooks, &(&1.role == :character))
-    assert has_element?(view, "#webhook-row-character button[phx-click='remove-webhook']")
+    # A row that has become configured collapses to its truth line, so the
+    # on-screen proof is the Edit affordance, not the remove button behind it.
+    assert has_element?(view, "#webhook-row-character button[phx-click='replace-url']")
+
+    assert has_element?(
+             edit_row(view, :character),
+             "#webhook-row-character button[phx-click='remove-webhook']"
+           )
   end
 
   test "removing the character destination leaves the system one alone", %{conn: conn, map: map} do
@@ -355,12 +414,18 @@ defmodule WandererAppWeb.MapNotificationsTest do
     view = open_notifications(conn, map)
 
     view
+    |> edit_row(:character)
     |> element("#webhook-row-character button[phx-click='remove-webhook']")
     |> render_click()
 
     {:ok, webhooks} = MapDiscordWebhook.by_notification(rec.id)
     assert Enum.map(webhooks, & &1.role) == [:system]
     refute has_element?(view, "#webhook-row-character button[phx-click='remove-webhook']")
+    # …and it is genuinely back to unconfigured, not merely collapsed: the row
+    # is still listed, but as "Not set" with nothing behind it.
+    refute has_element?(view, "#webhook-form-character")
+    assert has_element?(view, "#webhook-row-character button[phx-click='replace-url']")
+    assert has_element?(view, "#webhook-row-system button[phx-click='replace-url']")
   end
 
   test "a plain-string error renders as a sentence, not an inspected term", %{
@@ -370,6 +435,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
     notification_with_webhooks(map, [:system])
 
     view = open_notifications(conn, map)
+    edit_row(view, :character)
 
     # The component's own guard returns a bare binary. Passing that through
     # `inspect/1` would show the user literal quote marks around the sentence.
@@ -389,6 +455,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
     notification_with_webhooks(map, [:system])
 
     view = open_notifications(conn, map)
+    edit_row(view, :character)
 
     # Well-formed enough to clear the Discord-host validation, long enough to
     # trip `max_length: 2000` on the attribute.
@@ -414,14 +481,13 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
     view = open_notifications(conn, map)
 
-    html = view |> element("button[phx-click='send-test']") |> render_click()
+    html = view |> edit_row(:system) |> element("button[phx-click='send-test']") |> render_click()
 
     # What this proves: a saved-but-disabled destination gets the remedy that
     # matches its actual state. The assert is the whole test — assert the
     # specific remedy sentence, not the word "disabled", because the row's own
-    # status line already says "This destination is disabled and is not
-    # delivering." and a looser match would pass without the error copy
-    # changing at all.
+    # truth line already reads "● Disabled" and a looser match would pass
+    # without the error copy changing at all.
     #
     # The refute below is a belt-and-braces guard against the production
     # wording bug it names, but it does NOT demonstrate coverage of it here:
@@ -454,6 +520,9 @@ defmodule WandererAppWeb.MapNotificationsTest do
     webhook = system_webhook(rec)
 
     view = open_notifications(conn, map)
+    # Send test lives behind the row's Edit affordance now; open it while the
+    # webhook still exists, so the rendered button carries the real id.
+    edit_row(view, :system)
 
     # Destroyed AFTER render, so the button still carries the now-dead id —
     # the stale-page case `:webhook_not_found` exists for.
@@ -743,38 +812,64 @@ defmodule WandererAppWeb.MapNotificationsTest do
     # must return an error rather than crash the LiveView.
     view = open_notifications(conn, map)
 
-    # The fixture is `[:system]` only, so exactly one Send test button exists.
-    html = view |> element("button[phx-click='send-test']") |> render_click()
+    # The fixture is `[:system]` only, so exactly one Send test button exists
+    # once that row is opened for editing.
+    html = view |> edit_row(:system) |> element("button[phx-click='send-test']") |> render_click()
 
     assert html =~ "disabled on this server"
   end
 
-  test "removing the configuration deletes the record", %{conn: conn, map: map} do
-    notification_with_webhooks(map, [:system])
+  test "the tab offers no wholesale remove", %{conn: conn, map: map} do
+    notification_with_webhooks(map, [:system, :character, :route])
 
     view = open_notifications(conn, map)
 
-    html = view |> element("button[phx-click='delete']") |> render_click()
+    # Deliberate: each destination has its own Remove behind its Edit, and a
+    # policy row with no destinations delivers nothing. A pane-level destroy
+    # only added the ability to discard invisible filter and mention state, and
+    # put the tab's most destructive control permanently on screen to do it.
+    refute has_element?(view, "button[phx-click='delete']")
 
-    assert html =~ "Removed."
-    assert {:error, _} = MapDiscordNotification.by_map(map.id)
-    # Back to the create form, so the tab is usable again without a reload.
-    assert has_element?(view, "#discord-notification-form")
+    for role <- ~w(system character route) do
+      assert has_element?(
+               edit_row(view, role),
+               "#webhook-row-#{role} button[phx-click='remove-webhook']"
+             )
+    end
+  end
+
+  # Both of the tests below drive `humanize_error/1` and `fallback_message/1`
+  # through an error that carries no message of its own. They used to go through
+  # the pane-level destroy; with that gone, the trigger is a destination removed
+  # out from under the mounted view, so the row's Remove destroys a stale record.
+  #
+  # NOT the route Save, which was the obvious substitute and is wrong: `upsert/2`
+  # creates when the parent is missing, so destroying the policy row and saving
+  # re-creates it and reports "Saved." — a self-healing trigger that would have
+  # left the test asserting nothing. There is no such recreate path for a
+  # specific webhook id.
+  defp stale_remove(view, map, role) do
+    # Edit BEFORE the row is destroyed: opening the row is what renders its
+    # Remove button, and the component keeps the (about to be stale) struct in
+    # its own assigns until something re-reads the map's notification.
+    view = edit_row(view, role)
+
+    {:ok, rec} = MapDiscordNotification.by_map(map.id)
+    {:ok, webhooks} = MapDiscordWebhook.by_notification(rec.id)
+    :ok = webhooks |> Enum.find(&(&1.role == role)) |> Ash.destroy()
+
+    view
+    |> element("#webhook-row-#{role} button[phx-click='remove-webhook']")
+    |> render_click()
   end
 
   test "a failed removal is reported instead of raising", %{conn: conn, map: map} do
-    rec = notification_with_webhooks(map, [:system])
+    notification_with_webhooks(map, [:system, :character])
 
     view = open_notifications(conn, map)
+    html = stale_remove(view, map, :character)
 
-    # Delete the row out from under the mounted view. The destroy then fails on
-    # a stale record — with `Ash.destroy!` this raised and took the LiveView
-    # down; it must surface as a message instead.
-    :ok = Ash.destroy(rec)
-
-    html = view |> element("button[phx-click='delete']") |> render_click()
-
-    refute html =~ "Removed."
+    refute html =~ "destination removed."
     assert render(view) =~ "class=\"text-sm text-red-400\""
     # `StaleRecord` carries no message, so it reaches `humanize_error/1`'s
     # catch-all. That branch must not render the term: an unanticipated error
@@ -808,6 +903,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
     html =
       view
+      |> edit_row(:system)
       |> element("button[phx-click='send-test']")
       |> render_click(%{"webhook_id" => other_webhook.id})
 
@@ -826,18 +922,17 @@ defmodule WandererAppWeb.MapNotificationsTest do
     conn: conn,
     map: map
   } do
-    rec = notification_with_webhooks(map, [:system])
+    notification_with_webhooks(map, [:system, :character])
 
     view = open_notifications(conn, map)
 
-    # Same trigger as "a failed removal is reported instead of raising": the
-    # row is deleted under the mounted view, so the destroy fails with a
-    # `StaleRecord`, which carries no message and reaches `fallback_message/1`.
-    :ok = Ash.destroy(rec)
-
     log =
       capture_log(fn ->
-        html = view |> element("button[phx-click='delete']") |> render_click()
+        # Same trigger as "a failed removal is reported instead of raising": the
+        # destination is deleted under the mounted view, so the destroy fails
+        # with a `StaleRecord`, which carries no message of its own and reaches
+        # `fallback_message/1`.
+        html = stale_remove(view, map, :character)
         assert html =~ "Something went wrong. Please try again."
       end)
 
@@ -913,7 +1008,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
       html =
         view
         |> with_target("#map-notifications")
-        |> render_submit("save-route", %{
+        |> render_submit("save-settings", %{
           "notification" => %{
             "route_alerts_enabled" => "true",
             "home_system_id" => "",
@@ -921,11 +1016,11 @@ defmodule WandererAppWeb.MapNotificationsTest do
           }
         })
 
-      # Exact wording is Task 3's to define; this asserts on it because a
-      # substring match loose enough to survive any wording would also survive
-      # the validation being silently removed. If Task 3 ships different
-      # copy, update this one line to match it — do not weaken the match.
-      assert html =~ "is required when route alerts are enabled"
+      # The message has to NAME the field. A field-scoped Ash error alone
+      # surfaced in the panel's message region as the orphan sentence "is
+      # required when route alerts are enabled", with no indication which of
+      # the three route fields it meant.
+      assert html =~ "Home system is required when route alerts are enabled"
 
       assert {:ok, rec} = MapDiscordNotification.by_map(map.id)
       refute rec.route_alerts_enabled?
@@ -950,7 +1045,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
       # DOM — LiveSelect's hidden input, holding the id behind the name the
       # user picked — which is the whole point of the picker.
       view
-      |> form("#route-alerts-form", %{
+      |> form("#notification-settings-form", %{
         "notification" => %{
           "route_alerts_enabled" => "true",
           "route_max_jumps" => "3"
@@ -964,7 +1059,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
       assert rec.route_max_jumps == 3
     end
 
-    test "the route Save writes only route fields, and the kills Save only kill fields", %{
+    test "the kill switches and the Save each write only their own fields", %{
       conn: conn,
       map: map
     } do
@@ -980,15 +1075,16 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
       view = open_notifications(conn, map)
 
-      # P0 (four saves, one flash, no scope): pressing one panel's Save must
-      # not touch another panel's fields. Before the split, ticking a box in
-      # one section and pressing the wrong Save reported "Saved." and silently
-      # reverted the tick, because every Save submitted the whole tab.
+      # P0 (four saves, one flash, no scope): one control must not touch
+      # another's fields. Before the split, ticking a box in one section and
+      # pressing the wrong Save reported "Saved." and silently reverted the
+      # tick, because every Save submitted the whole tab. The kill switches now
+      # apply on change and carry only their own two keys.
       view
-      |> form("#discord-notification-form", %{
+      |> form("#kill-toggles-form", %{
         "notification" => %{"enabled" => "true", "wh_only" => "false"}
       })
-      |> render_submit()
+      |> render_change()
 
       assert {:ok, after_kills} = MapDiscordNotification.by_map(map.id)
       assert after_kills.wh_only == false
@@ -999,7 +1095,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
       view
       |> with_target("#map-notifications")
-      |> render_submit("save-route", %{
+      |> render_submit("save-settings", %{
         "notification" => %{
           "route_alerts_enabled" => "true",
           "home_system_id" => "30000144",
@@ -1034,7 +1130,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
       # disabled by an ancestor fieldset.
       assert has_element?(
                view,
-               "#route-alerts-form fieldset[disabled] input[name='notification[home_system_id]']"
+               "#notification-settings-form fieldset[disabled] input[name='notification[home_system_id]']"
              )
 
       view
@@ -1043,11 +1139,14 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
       refute has_element?(
                view,
-               "#route-alerts-form fieldset[disabled] input[name='notification[home_system_id]']"
+               "#notification-settings-form fieldset[disabled] input[name='notification[home_system_id]']"
              )
 
       # Still in the DOM either way — never `:if`-ed out.
-      assert has_element?(view, "#route-alerts-form input[name='notification[home_system_id]']")
+      assert has_element?(
+               view,
+               "#notification-settings-form input[name='notification[home_system_id]']"
+             )
     end
 
     test "a disabled route field does not wipe the saved value on the next save", %{
@@ -1071,7 +1170,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
       # absent value as nil and clear a home system the user never touched.
       view
       |> with_target("#map-notifications")
-      |> render_submit("save-route", %{"notification" => %{"route_alerts_enabled" => "false"}})
+      |> render_submit("save-settings", %{"notification" => %{"route_alerts_enabled" => "false"}})
 
       assert {:ok, saved} = MapDiscordNotification.by_map(map.id)
       assert saved.route_alerts_enabled? == false
@@ -1162,7 +1261,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
       # No params at all — the checkbox and the picked home system both come
       # from the rendered DOM, which is the whole point: this is what the
       # browser actually posts.
-      view |> form("#route-alerts-form") |> render_submit()
+      view |> form("#notification-settings-form") |> render_submit()
 
       assert {:ok, rec} = MapDiscordNotification.by_map(map.id)
       assert rec.route_alerts_enabled? == true
@@ -1200,7 +1299,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
       |> render_change("option_click", %{"idx" => "0"})
 
       view
-      |> form("#route-alerts-form", %{
+      |> form("#notification-settings-form", %{
         "notification" => %{"route_alerts_enabled" => "true"}
       })
       |> render_submit()
@@ -1237,7 +1336,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
       # says nothing about the name that was actually typed.
       html =
         view
-        |> form("#route-alerts-form", %{
+        |> form("#notification-settings-form", %{
           "notification" => %{
             "route_alerts_enabled" => "true",
             "home_system_id_text_input" => "Jitaaa"
@@ -1264,7 +1363,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
       |> render_change(%{"notification" => %{"route_alerts_enabled" => "true"}})
 
       view
-      |> form("#route-alerts-form", %{
+      |> form("#notification-settings-form", %{
         "notification" => %{
           "route_alerts_enabled" => "true",
           "home_system_id_text_input" => "jita"
@@ -1299,7 +1398,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
       html =
         view
-        |> form("#route-alerts-form", %{
+        |> form("#notification-settings-form", %{
           "notification" => %{
             "route_alerts_enabled" => "true",
             "home_system_id_text_input" => "Jit"
@@ -1334,7 +1433,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
       pick_home_system(view, "Jita")
 
       # What the browser does on selection: post the form as the DOM now has it.
-      view |> form("#route-alerts-form") |> render_change()
+      view |> form("#notification-settings-form") |> render_change()
 
       # An unrelated widget re-renders the component.
       view
@@ -1347,7 +1446,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
       assert has_element?(view, "input[name='notification[home_system_id]'][value='30000142']")
 
-      view |> form("#route-alerts-form") |> render_submit()
+      view |> form("#notification-settings-form") |> render_submit()
 
       assert {:ok, rec} = MapDiscordNotification.by_map(map.id)
       assert rec.home_system_id == 30_000_142
@@ -1361,29 +1460,27 @@ defmodule WandererAppWeb.MapNotificationsTest do
       # change, because the route toggle and the create-path URL field shared
       # one form and the generic `.input` writes `value=` for password inputs
       # too. The IA split removes the shared form entirely: the credential now
-      # lives only on the L0 create form and the per-row webhook forms, none of
-      # which carry a `phx-change`. This asserts the structural property rather
-      # than the old symptom, so it fails if a change handler is ever added
-      # back to a form holding a URL.
-      view = open_notifications(conn, map)
-      html = render(view)
-
-      # The L0 create form is the one that holds the URL field...
-      assert has_element?(
-               view,
-               "#discord-notification-form input[name='notification[webhook_url]']"
-             )
-
-      # ...and its form tag must carry no phx-change.
-      [create_form] = Regex.run(~r/<form[^>]*id="discord-notification-form"[^>]*>/, html)
-      refute create_form =~ "phx-change"
-
+      # lives ONLY on the per-row webhook forms, none of which carry a
+      # `phx-change`. This asserts the structural property rather than the old
+      # symptom, so it fails if a change handler is ever added back to a form
+      # holding a URL — or if a URL field is ever added to one of the two forms
+      # that DO have a change handler.
       notification_with_webhooks(map, [:system, :character, :route])
 
-      html = render(open_notifications(conn, map))
+      view = open_notifications(conn, map)
+
+      for form_id <- ~w(kill-toggles-form notification-settings-form) do
+        refute has_element?(view, "##{form_id} input[name='notification[webhook_url]']")
+      end
+
+      # Configured rows are truth lines until opened, so each form has to be
+      # revealed before there is a `<form>` tag to inspect at all.
+      for role <- ~w(system character route), do: edit_row(view, role)
+      html = render(view)
 
       for role <- ~w(system character route) do
         [form_tag] = Regex.run(~r/<form[^>]*id="webhook-form-#{role}"[^>]*>/, html)
+        assert has_element?(view, "#webhook-form-#{role} input[name='webhook[webhook_url]']")
         refute form_tag =~ "phx-change"
       end
     end
@@ -1391,6 +1488,8 @@ defmodule WandererAppWeb.MapNotificationsTest do
     test "the route webhook url can be added", %{conn: conn, map: map} do
       rec = notification_with_webhooks(map, [:system])
       view = open_notifications(conn, map)
+
+      edit_row(view, :route)
 
       view
       |> form("#webhook-form-route", %{
@@ -1400,7 +1499,13 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
       {:ok, webhooks} = MapDiscordWebhook.by_notification(rec.id)
       assert %{role: :route, enabled?: true} = Enum.find(webhooks, &(&1.role == :route))
-      assert has_element?(view, "#webhook-row-route button[phx-click='remove-webhook']")
+      # Saved, so the row has collapsed to its truth line.
+      assert has_element?(view, "#webhook-row-route button[phx-click='replace-url']")
+
+      assert has_element?(
+               edit_row(view, :route),
+               "#webhook-row-route button[phx-click='remove-webhook']"
+             )
     end
 
     # Mentions left the webhook form in this rework: they are chip state saved
@@ -1472,7 +1577,7 @@ defmodule WandererAppWeb.MapNotificationsTest do
     # form lets an owner enable route alerts, set a home system and max jumps,
     # and save successfully while every alert is silently dropped for want of a
     # destination. The hint is the only feedback in that state.
-    @hint "Route alerts are on, but no Route alert channel is ready"
+    @hint "Route alerts are on, but no route alert channel is ready"
 
     test "enabling route alerts with no route channel warns that nothing will be sent", %{
       conn: conn,
@@ -1527,18 +1632,16 @@ defmodule WandererAppWeb.MapNotificationsTest do
   # inside the filters disclosure. That disclosure now starts collapsed
   # unconditionally and no longer auto-expands on a problem (D2), so a message
   # left in the old place would be invisible: the owner sees their click do
-  # nothing. `#panel-message-kills` is at card level, above the disclosure —
-  # the assertions check the LOCATION, which is the actual regression risk,
-  # not merely that the text exists somewhere in the document.
+  # nothing. There is now ONE `#panel-message`, in the action bar at the foot of
+  # the tab beside the single Save — the assertions check the LOCATION, which is
+  # the actual regression risk, not merely that the text exists somewhere in the
+  # document.
   describe "kill-filter messages render on the card, not inside the collapsed body" do
     defp assert_in_kills_card(view, text) do
-      assert has_element?(view, "#panel-message-kills", text)
+      assert has_element?(view, "#panel-message", text)
 
-      # Not swallowed by the collapsed body...
-      refute has_element?(view, "#filters-disclosure-body #panel-message-kills")
-      # ...and not misfiled onto the peer card, where it would describe the
-      # wrong feature entirely.
-      refute has_element?(view, "#panel-message-route")
+      # Not swallowed by the collapsed body.
+      refute has_element?(view, "#filters-disclosure-body #panel-message")
     end
 
     setup %{conn: conn, map: map} do
@@ -1618,19 +1721,21 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
       html = conn |> open_notifications(map) |> render()
 
-      assert html =~ "Channel: #kill-feed"
+      assert html =~ "#kill-feed"
       # The card-level status line is built from the same identity.
-      assert html =~ "Posting to channel #kill-feed"
+      assert html =~ "Posting to #kill-feed"
       # Neither snowflake is a label.
       refute html =~ "987650001234500777"
       refute html =~ "112233445566778899"
     end
 
-    # The bug this rework exists partly to fix: Discord's webhook object carries
-    # the webhook's own NICKNAME, which an operator can set to anything and
-    # which has nothing to do with the channel. The old UI stamped "Channel:"
-    # on it regardless, so the two were indistinguishable on screen.
-    test "a webhook nickname is labelled as one, not asserted to be the channel", %{
+    # `channel_label_source` still records whether Discord answered from the
+    # channel itself or from the webhook's own nickname, and `ChannelInfo` still
+    # uses it to separate a known name from a masked fingerprint. The UI no
+    # longer *speaks* the difference: it is a fact about how the name was
+    # fetched, not about where messages land, and the operator has nothing to do
+    # differently either way.
+    test "a webhook nickname is shown plainly, with no source prefix", %{
       conn: conn,
       map: map
     } do
@@ -1645,13 +1750,18 @@ defmodule WandererAppWeb.MapNotificationsTest do
 
       html = conn |> open_notifications(map) |> render()
 
-      assert html =~ "Webhook: Kill bot"
-      assert html =~ "Posting to webhook Kill bot"
+      assert html =~ "Kill bot"
+      refute html =~ "Webhook: Kill bot"
       refute html =~ "Channel: Kill bot"
-      # And it says why it could not do better than the nickname.
+
+      # The sentence that used to explain the prefix is gone, and must stay
+      # gone. It was also wrong more often than not: `bot_channel/1` returns
+      # nil for a missing token, a 403, a 404, a rate limit and a plain cache
+      # miss alike, and `persist/2` freezes that result for an hour — so
+      # instances whose bot *is* in the server routinely read that it was not.
       # HEEx escapes the apostrophe, so match the half either side of it.
-      assert html =~ "This is the webhook"
-      assert html =~ "s own name."
+      refute html =~ "This is the webhook"
+      refute html =~ "s bot is in that server"
     end
 
     # A row written before `channel_label_source` existed. The label is still
@@ -1695,6 +1805,8 @@ defmodule WandererAppWeb.MapNotificationsTest do
       # A masked hint makes no claim about being a channel or a webhook name.
       refute html =~ "Channel: ••••"
       refute html =~ "Webhook: ••••"
+      refute html =~ "Posting to channel"
+      refute html =~ "Posting to webhook"
       # A blank label would render as the separator with nothing before it.
       refute html =~ "Posting to  "
     end
@@ -1705,9 +1817,93 @@ defmodule WandererAppWeb.MapNotificationsTest do
     } do
       notification_with_webhooks(map, [:system, :route])
 
-      html = conn |> open_notifications(map) |> render()
+      view = open_notifications(conn, map)
+
+      # At rest the truth line uses the role-neutral state word, which is
+      # correct for every row: "Never delivered" is a fact about deliveries, not
+      # about what kind of thing was never delivered.
+      assert render(view) =~ "Never delivered"
+      refute render(view) =~ "No kills delivered yet."
+
+      # The role-specific wording lives in the open form, where "No kills
+      # delivered yet." under a channel that only ever carries route alerts
+      # would read as a fault rather than an empty state.
+      html = view |> edit_row(:route) |> render()
 
       assert html =~ "No route alerts delivered yet."
+      refute html =~ "No kills delivered yet."
+    end
+  end
+
+  describe "disclosure state" do
+    # The reason `@open_sections` lives on the server rather than in
+    # `JS.toggle_class`. This component re-renders on saves, on PubSub ticks and
+    # on background channel-identity refreshes; a client-only toggle means every
+    # one of those re-sends the literal collapsed markup and slams an open
+    # section shut under the operator's hands. `edit_row/2` here is just a cheap
+    # way to force a real re-render — any of the three would do.
+    test "an opened section stays open across a re-render", %{conn: conn, map: map} do
+      notification_with_webhooks(map, [:system])
+
+      view = open_notifications(conn, map)
+
+      assert has_element?(view, "#filters-disclosure-body.hidden")
+
+      view
+      |> element("button[phx-value-section='filters-disclosure']")
+      |> render_click()
+
+      assert has_element?(view, "#filters-disclosure-body.flex")
+
+      assert has_element?(
+               view,
+               "button[phx-value-section='filters-disclosure'][aria-expanded='true']"
+             )
+
+      # Re-render the whole component.
+      edit_row(view, :system)
+
+      assert has_element?(view, "#filters-disclosure-body.flex")
+    end
+
+    # The body is toggled by class rather than by `:if` so that `aria-controls`
+    # resolves to a real element while collapsed, and so the LiveSelect hooks
+    # inside it are not destroyed and re-mounted on every toggle.
+    test "a collapsed section is still in the document, and still addressed", %{
+      conn: conn,
+      map: map
+    } do
+      notification_with_webhooks(map, [:system])
+
+      view = open_notifications(conn, map)
+
+      assert has_element?(
+               view,
+               "button[phx-value-section='filters-disclosure'][aria-controls='filters-disclosure-body'][aria-expanded='false']"
+             )
+
+      assert has_element?(view, "#filters-disclosure-body")
+    end
+
+    # D4's whole point: a configured-but-inert route destination is a warning,
+    # and a warning inside a collapsed body has not been shown to anyone. Route
+    # alerts are no longer a disclosure at all — they are the tab's second
+    # section, always expanded — but the banner still has to sit outside the one
+    # disclosure that section does have.
+    test "the route warning renders outside any collapsed disclosure", %{
+      conn: conn,
+      map: map
+    } do
+      # `route_alerts_enabled?` defaults to false, so a route channel added
+      # without turning alerts on is inert the moment it is saved — which is
+      # precisely the trap this banner exists to name.
+      notification_with_webhooks(map, [:system, :route])
+
+      view = open_notifications(conn, map)
+
+      assert has_element?(view, "#mentions-disclosure-body.hidden")
+      refute has_element?(view, "#mentions-disclosure-body p", "Route alerts are switched off")
+      assert render(view) =~ "Route alerts are switched off, but this channel is configured"
     end
   end
 

--- a/test/wanderer_app_web/live/map_notifications_test.exs
+++ b/test/wanderer_app_web/live/map_notifications_test.exs
@@ -838,6 +838,72 @@ defmodule WandererAppWeb.MapNotificationsTest do
     end
   end
 
+  # Asserting the button EXISTS is not the same as asserting it works, and the
+  # difference was a crash: `role_label/1` had no `:system` clause while
+  # `remove-webhook` refused that role, and widening the handler without
+  # widening the label raised FunctionClauseError — after the destroy had
+  # committed, so the destination was gone and the tab was down with it. Every
+  # role is clicked here, not just listed.
+  test "every destination can actually be removed", %{conn: conn, map: map} do
+    rec = notification_with_webhooks(map, [:system, :character, :route])
+
+    view = open_notifications(conn, map)
+
+    for {role, label} <- [
+          {"system", "Kill channel"},
+          {"character", "Character kill channel"},
+          {"route", "Route alert channel"}
+        ] do
+      html =
+        view
+        |> edit_row(role)
+        |> element("#webhook-row-#{role} button[phx-click='remove-webhook']")
+        |> render_click()
+
+      # The confirmation names the row the operator clicked, not an internal
+      # role name that appears nowhere on screen.
+      assert html =~ "#{label} removed."
+    end
+
+    # The policy row outlives its destinations — nothing here deletes it, and a
+    # row with no destinations simply delivers nothing.
+    assert {:ok, []} = MapDiscordWebhook.by_notification(rec.id)
+    assert {:ok, _} = MapDiscordNotification.by_map(map.id)
+  end
+
+  test "a rejected URL does not poison the retry", %{conn: conn, map: map} do
+    view = open_notifications(conn, map)
+
+    # First save on a map with no policy row yet: `ensure_notification/1`
+    # commits the row, then the webhook write is rejected. The row is now real
+    # even though the operator saw only an error.
+    edit_row(view, :route)
+
+    bad =
+      view
+      |> form("#webhook-form-route", %{"webhook" => %{"webhook_url" => "not-a-url"}})
+      |> render_submit()
+
+    refute bad =~ "Saved."
+
+    # The correction must succeed. It used to fail with the identity error from
+    # a second `create` for the same map, because the failed attempt left
+    # `@notification` nil.
+    good =
+      view
+      |> form("#webhook-form-route", %{
+        "webhook" => %{"webhook_url" => "https://discord.com/api/webhooks/456/tok"}
+      })
+      |> render_submit()
+
+    assert good =~ "Saved."
+    refute good =~ "already been taken"
+
+    {:ok, rec} = MapDiscordNotification.by_map(map.id)
+    assert {:ok, [webhook]} = MapDiscordWebhook.by_notification(rec.id)
+    assert webhook.role == :route
+  end
+
   # Both of the tests below drive `humanize_error/1` and `fallback_message/1`
   # through an error that carries no message of its own. They used to go through
   # the pane-level destroy; with that gone, the trigger is a destination removed

--- a/test/wanderer_app_web/live/maps_settings_tabs_test.exs
+++ b/test/wanderer_app_web/live/maps_settings_tabs_test.exs
@@ -42,7 +42,7 @@ defmodule WandererAppWeb.MapsSettingsTabsTest do
 
   defp selected_tab_count(view, tab) do
     view
-    |> element("li.p-tabview-selected a[phx-value-tab='#{tab}']")
+    |> element("li.p-tabview-selected button[phx-value-tab='#{tab}']")
     |> has_element?()
   end
 
@@ -60,6 +60,61 @@ defmodule WandererAppWeb.MapsSettingsTabsTest do
       view = open_settings(conn, map)
 
       assert selected_tab_count(view, "general")
+    end
+
+    # The tab strip was transcribed out of a rendered PrimeReact TabView, which
+    # left `aria-selected` as a hardcoded literal on all seven tabs: General
+    # permanently claimed to be the selected tab and every other tab
+    # permanently denied it, whatever was actually on screen. It is computed
+    # now, and this is the test that keeps it computed.
+    test "aria-selected follows the active tab", %{conn: conn, map: map} do
+      view = open_settings(conn, map)
+
+      assert has_element?(view, "button[phx-value-tab='general'][aria-selected='true']")
+      assert has_element?(view, "button[phx-value-tab='notifications'][aria-selected='false']")
+
+      push_tab(view, "notifications")
+
+      assert has_element?(view, "button[phx-value-tab='notifications'][aria-selected='true']")
+      assert has_element?(view, "button[phx-value-tab='general'][aria-selected='false']")
+    end
+
+    # `aria-controls` pointed at four ids, three of which did not exist in the
+    # document, and one of which was shared by three different tabs. There is
+    # exactly one panel element; every tab must name it, and the panel must
+    # name whichever tab is showing.
+    test "every tab points at the one real panel, which points back", %{conn: conn, map: map} do
+      view = open_settings(conn, map)
+
+      for tab <- ~w(general import public_api notifications) do
+        assert has_element?(
+                 view,
+                 "button[phx-value-tab='#{tab}'][aria-controls='map-settings-tabpanel']"
+               )
+      end
+
+      assert has_element?(
+               view,
+               "#map-settings-tabpanel[aria-labelledby='map-settings-tab-general']"
+             )
+
+      push_tab(view, "notifications")
+
+      assert has_element?(
+               view,
+               "#map-settings-tabpanel[aria-labelledby='map-settings-tab-notifications']"
+             )
+    end
+
+    # Every tab but General used to be `tabindex="-1"` on an `<a>` with no
+    # `href`: not focusable, and not activatable by Enter even if focused, so
+    # Notifications could not be reached from the keyboard at all.
+    test "tabs are real buttons, not inert anchors", %{conn: conn, map: map} do
+      view = open_settings(conn, map)
+
+      refute has_element?(view, "a[phx-value-tab='notifications']")
+      assert has_element?(view, "button[type='button'][phx-value-tab='notifications']")
+      refute has_element?(view, "[phx-value-tab='notifications'][tabindex='-1']")
     end
   end
 
@@ -98,7 +153,7 @@ defmodule WandererAppWeb.MapsSettingsTabsTest do
       view = open_settings(conn, map)
 
       # The <li> is not rendered ...
-      refute has_element?(view, "a[phx-value-tab='bot']")
+      refute has_element?(view, "button[phx-value-tab='bot']")
 
       # ... and pushing the event directly must not render the panel either.
       push_tab(view, "bot")


### PR DESCRIPTION
The Map Settings → Notifications tab did not fit on a laptop, and an earlier
pass had not moved the needle. This is the rebuild.

## The problem

Every section rendered expanded, inside a dialog that has no height of its own,
so the lower half of the tab was simply unreachable — you could see it existed
and could not scroll to it. On top of that the tab carried **five** separate
Save buttons, each committing a different subset of the same record, and the
kill webhook gated everything: route alerts were a distinct feature that you
could not configure at all until you had first set up a Discord channel for
killmails you may not have wanted.

## What changed

**Organised around the two features the schema actually models** — kill
notifications and route alerts — rather than three peer destinations.

**Show what is true now; everything that changes it goes behind an edit.** At
rest the tab is a short list of statements: which destinations exist, where
they post, whether they are delivering. The controls that would change any of
that are one click away. This is what makes the tab fit; it is a constraint,
not a preference.

**The five Saves are gone.** The two kill switches apply on change, like the
chip lists beside them always have. Route alerts keep one Save, labelled *Save
route alerts* and sitting inside the section it commits, because those three
fields genuinely cannot apply on change: `route_max_jumps` is typed, so a
per-keystroke save submits `""` mid-edit against an `allow_nil? false`
attribute, and the toggle is validated against the home system, so committing
the tick alone reports a missing field the operator has not reached yet.

**No global controls at all.** *Remove all Discord notifications* is gone too —
each destination has its own Remove, and a policy row with no destinations
delivers nothing, so the only thing a wholesale destroy added was discarding
invisible filter and mention state, at the cost of parking the tab's most
destructive control permanently on screen.

**Neither feature gates the other.** `MapDiscordNotification`'s `create` now
takes an optional `webhook_url`, and the policy row is created lazily by
whichever control the operator touches first. Routing already tolerated the
absence: `Router.route/3` resolves `:system` through `usable/1`, which drops on
`nil`, so a row with no kill destination posts no kills. Someone who wants
route alerts and nothing else now configures route alerts and nothing else.

**All three destinations are removable.** `:system` used to be exempt, on the
reasoning that "removing notifications entirely means deleting the parent
record" — true while a pane-level destroy existed, false once it didn't.
Leaving it exempt would have made the kill channel the one destination that
could be added and never taken away.

Copy fixes along the way: the "this instance has no Discord bot" subtext now
names `DISCORD_BOT_TOKEN` instead of leaving the reader to guess; the character
channel is listed as *Not set* with an *Add* rather than an unexplained "add a
separate channel"; and the route validation error now reads "Home system is
required when route alerts are enabled" instead of the orphan fragment "is
required when route alerts are enabled", which named none of the three route
fields it meant.

## Three things this surfaced, fixed here

**The settings dialog could not be scrolled.** `core_components.ex`'s modal put
`overflow: visible` on the dialog (correct — LiveSelect dropdowns must not be
clipped) and made nothing else a scroll container, so any panel taller than the
viewport was unreachable. The mask is now the scroll container. It uses
`m-auto` rather than `items-center`: a centred flex item taller than a
scrollable container overflows past its *start* edge, and that region cannot be
scrolled to. Auto margins centre only the slack, so a tall dialog pins to the
top and stays reachable.

**The tab strip's ARIA was hand-transcribed and wrong.** The markup had been
copied out of a rendered PrimeReact TabView, leaving seven near-identical `<li>`
blocks with literal `aria-selected` and `aria-controls` values that matched
neither the real state nor the real panel ids. Rendered from one list now, so
the ARIA is computed.

**`live_select`'s `:label` was accepted and never rendered.** It was stripped
from the forwarded opts and dropped, so every combobox in the app announced as
"combobox, blank" — five identical ones on this tab alone. `for` has to target
LiveSelect's own text input (`<field>_text_input`), not the `id` we pass, which
lands on the LiveComponent wrapper. In `compact` mode the label is
screen-reader-only, since `compact` exists to keep the wrapper exactly as tall
as its input so a neighbouring button lines up. Nothing loses a visible label
it had before — the element did not render at all until now.

Error text also moved from `rose-600` to `rose-400`: on this app's near-black
panels `rose-600` measures ~3.8:1 and fails WCAG AA, and error text is the
worst place to miss contrast.

## Security invariants preserved

Webhook URLs are credentials. They remain encrypted at rest and are only ever
rendered as a masked hint behind a replace flow. `humanize_error/1` and
`fallback_message/1` still never `inspect/1` an error — an unanticipated error
shape can carry the submitted URL verbatim, and `sensitive? true` does **not**
redact it (confirmed empirically). `send_test/2` keeps its map-scoping check, so
a hand-crafted `phx-value-webhook_id` cannot reach another map's Discord
channel. All three are pinned by tests.

## Deliberately not done

Moving map settings from a modal to its own route. It is the right shape for a
seven-tab settings surface and would remove the height problem at the root, but
it is a larger change than this PR and needs upstream agreement first.

## Verification

- `mix test test/wanderer_app_web/live/map_notifications_test.exs` — 71 tests, 0 failures
- `mix test` — 1727 tests, 0 failures, 64 excluded, 22 skipped
- `mix format --check-formatted` — clean
- `mix credo --strict` — no findings in any touched file
- Re-ran the three touched suites after rebasing onto `guarzo/zoo` — 87 tests, 0 failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map notification settings now support independent kill alerts, route alerts, and webhook destinations.
  * Webhooks can be added, edited, tested, or removed individually.
  * Map Settings tabs now adapt to available features and support keyboard navigation.
  * Notification policies can be saved without a webhook destination.
* **UI Improvements**
  * Updated modal scrolling, responsive sizing, disclosure behavior, and validation messaging.
  * LiveSelect fields now provide improved accessibility, labels, compact layouts, and spacing.
* **Bug Fixes**
  * Improved validation details and handling for notification searches, channels, mentions, and stale records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->